### PR TITLE
Make page responsive for mobile devices

### DIFF
--- a/tinysearchengine/static/index.css
+++ b/tinysearchengine/static/index.css
@@ -3,8 +3,11 @@ html {
     background: #dcdced;
 }
 
+body {
+  font-size: 1.2rem;
+}
+
 p {
-    font-size: 25px;
     width: 100%;
     white-space: nowrap;
     overflow: hidden;
@@ -19,11 +22,11 @@ div {
 
 .url {
    margin-top: 0px;
-   font-size: 20px;
 }
 
-#container {
-  width: 1024px;
+.container {
+  width: 100%;
+  max-width: 1024px;
   margin: 0 auto;
 }
 
@@ -34,7 +37,7 @@ div {
 
     outline: none;
 
-    font-size: 50px;
+    font-size: inherit;
 
     border: 2px solid #ccc;
     border-width: 4px;

--- a/tinysearchengine/static/index.css
+++ b/tinysearchengine/static/index.css
@@ -22,6 +22,7 @@ div {
 
 .url {
    margin-top: 0px;
+   font-size: 1rem;
 }
 
 .container {

--- a/tinysearchengine/static/index.html
+++ b/tinysearchengine/static/index.html
@@ -1,7 +1,8 @@
 <html>
 <head>
 <meta name="referrer" content="no-referrer">
-<title>Stoatally Different</title>
+  <title>Stoatally Different</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="/index.css" rel="stylesheet">
   <link rel="search"
       type="application/opensearchdescription+xml"
@@ -10,7 +11,7 @@
   <script src="/index.js"></script>
 </head>
 <body>
-<div id="container">
+<div class="container">
   <form autocomplete="off" id="search-form">
     <input type="search" id="search" name="s" value="" autofocus/>
   </form>


### PR DESCRIPTION
Closes #10 

- Adds [viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) to page head
- Makes container width 100% on mobile, and max 1024px on desktop
- Uses rem for font-sizes 
- Makes default font-size 1.2rem to keep the spirit of a big font-size, but a bit more reasonable on mobile devices
- Makes all elements inherit the font-size of the body

Preview:
<img width=300 src="https://user-images.githubusercontent.com/1388162/147468155-424aabe2-28a2-4881-9941-df24a8920e00.png" />

![image](https://user-images.githubusercontent.com/1388162/147468191-f442ebcb-c078-4ace-94b7-2c8859ab88dc.png)