### PR TITLE
Using the app object to start uvicorn, instead of using a reference like "mwmbl.tinysearchengine.app:app"

### DIFF
--- a/mwmbl/tinysearchengine/app.py
+++ b/mwmbl/tinysearchengine/app.py
@@ -1,8 +1,5 @@
 import logging
-import sys
-from typing import Optional
 import argparse
-from fastapi import FastAPI
 import uvicorn
 
 from mwmbl.tinysearchengine import create_app
@@ -10,8 +7,6 @@ from mwmbl.tinysearchengine.indexer import TinyIndex, NUM_PAGES, PAGE_SIZE, Docu
 from mwmbl.tinysearchengine.config import parse_config_file
 
 logging.basicConfig()
-
-app: Optional[FastAPI] = None
 
 
 def setup_args():
@@ -28,7 +23,8 @@ def main():
     * Parses CLI args
     * Parses and validates config
     * Initializes TinyIndex
-    * Populates global app (FastAPI) variable so that uvicorn can run the app server
+    * Initialize a FastAPI app instance
+    * Starts uvicorn server using app instance
     """
     args = setup_args()
     config = parse_config_file(config_filename=args.config)
@@ -39,15 +35,11 @@ def main():
         **config.index_config.dict()
     )
 
-    # Update global app variable
-    global app
+    # Initialize FastApi instance
     app = create_app.create(tiny_index)
 
     # Initialize uvicorn server using global app instance and server config params
-    uvicorn.run(
-        "mwmbl.tinysearchengine.app:app",
-        **config.server_config.dict()
-    )
+    uvicorn.run(app, **config.server_config.dict())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes #30 

When running the server using python -m, uvicorn seems to spawn a new process or interpreter session.
At least it appears that way since already initialized & imported modules and variables appear to be uninitialized when using python -m.