### PR TITLE
Add launch.json for vscode run/debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "mwmbl",
+            "type": "python",
+            "request": "launch",
+            "module": "mwmbl.main",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "stopOnEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
Baking a `launch.json` into the project so that bootstrapping for first time devs is straightforward.

- Following the instructions added in https://github.com/mwmbl/book/pull/5, a user should have the right version of python installed in `${workspaceFolder}/.venv/bin/python`. 

- Then, with this `launch.json` file, they should have a baked in `mwmbl` run configuration that allows one to run mwmbl via the VSCode run interface, as well as add breakpoints and debug the code.