### PR TITLE
Optimize Dockerfile by cleaning up apt cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN /venv/bin/pip install pip wheel --upgrade && \
 
 FROM base as final
 
-RUN apt-get update && apt-get install -y postgresql-client
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
 
 # Copy only the required /venv directory from the builder image that contains mwmbl and its dependencies
 COPY --from=builder /venv /venv


### PR DESCRIPTION
In the Dockerfile, after installing the `postgresql-client` package using `apt-get`, the apt cache is now cleaned up.

This reduces the size of the Docker image, adhering to Docker best practices.