### PR TITLE
Set default redis url to localhost

### DIFF
--- a/mwmbl/crawler/app.py
+++ b/mwmbl/crawler/app.py
@@ -32,7 +32,7 @@ from mwmbl.settings import (
     FILE_NAME_SUFFIX,
     DATE_REGEX)
 
-stats_manager = StatsManager(Redis.from_url(os.environ.get("REDIS_URL")))
+stats_manager = StatsManager(Redis.from_url(os.environ.get("REDIS_URL", "redis://127.0.0.1:6379")))
 
 
 def get_bucket(name):


### PR DESCRIPTION
Set a default variable for the redis environment variable to avoid having to set it in development manually because it is rarely used and there currently exists no documentation for setting up a crawler anyway. Also I assume the same db is used for stats and the crawler here. Again you can still manually specify for production.