### PR TITLE
Updated local testing instructions to be more easily reproducible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 develop-eggs/
 dist/
 front-end/dist/
+front-end/node_modules/
 downloads/
 eggs/
 .eggs/

--- a/README.md
+++ b/README.md
@@ -117,23 +117,13 @@ Please join our [Matrix chat
 server](https://matrix.to/#/#mwmbl:matrix.org) or email the main
 author (email address is in the git commit history).
 
+
 Development
 ===========
 
 ### Local Testing
 
-This will run against a local test database without running background
-tasks to update batches etc.
-
-This is the simplest way to configure postgres, but you can set it up
-how you like as long as the `DATABASE_URL` you give is correct for
-your configuration.
-
-1. Install postgres and create a user for your current username
-2. Install [poetry](https://python-poetry.org/docs/#installation)
-3. Run `poetry install` to install dependencies
-4. Run `poetry shell` in the root directory to enter the virtual environment
-5. Run `$ DATABASE_URL="postgres://username@" python -m mwmbl.main` replacing "username" with your username.
+For trying out the service locally see [Local Setup](docs/development.md)
 
 ### Using Dokku
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,29 @@
+### Local Testing
+
+This will run against a local test database without running background
+tasks to update batches etc.
+
+You will need a PostgreSQL database.
+If you also want to use the crawler you additionally will need to install redis.
+
+Check that you are running Python 3.10
+If not then either install it from your distro or from [python.org](https://python.org/downloads)
+
+1. Install [poetry](https://python-poetry.org/docs/#installation)
+2. Run `poetry install` to install dependencies
+3. Run `poetry shell` in the root directory to enter the virtual environment
+
+Now to build the Vitejs/htmx frontend install [node](https://nodejs.org)
+Specifically you will need Nodejs 16 later
+1. In the front-end directory run `npm install` then `npm run build`
+
+Set some environment variables:
+1. First set the config `$ export DJANGO_SETTINGS_MODULE=mwmbl.settings_dev`
+2. For the database set `$ export DATABASE_URL="postgres://yourusername:yourpassword@localhost/yourdbname"`
+Where you replace username, password and database name respectivley with your own credentials.
+
+Note that you can also directly edit the config in `mwmbl/setttings*.py` instead of the environment variables.
+
+Finally:
+1. Run the migrations `python3 manage.py migrate`
+2. To start the service run `python3 manage.py runserver`


### PR DESCRIPTION
I did not completely understand how the front-end is supposed to be set up. There is a npm run dev http server command which however is not very convenient to run because it listens on a different port than the main service.
Also the docs now advise to run via manage.py rather than main.py.
Otherwise there are again some problems with the frontend and a STATIC_ROOT variable need to be manually set so this seems more convenient for now until the main entrypoint adds more logic.
Also note that I did have to manually export REDIS_URL which could be fixed with #146