### PR TITLE
Add Discord link and remove YouTube link from homepage

### DIFF
--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -161,9 +161,9 @@ FOOTER_LINKS = [
         "href": "https://github.com/mwmbl/mwmbl",
     },
     {
-        "name": "YouTube",
-        "icon": "ph-youtube-logo-bold",
-        "href": "https://www.youtube.com/channel/UCFLbqrH63-icAHxQ1eFfAvA",
+        "name": "Discord",
+        "icon": "ph-discord-logo-bold",
+        "href": "https://discord.gg/2BGSUYFdkD",
     },
 
 

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -161,6 +161,11 @@ FOOTER_LINKS = [
         "href": "https://github.com/mwmbl/mwmbl",
     },
     {
+        "name": "YouTube",
+        "icon": "ph-youtube-logo-bold",
+        "href": "https://www.youtube.com/@mwmbl",
+    },
+    {
         "name": "Discord",
         "icon": "ph-discord-logo-bold",
         "href": "https://discord.gg/2BGSUYFdkD",


### PR DESCRIPTION
Of course one could also just add Discord alongside YouTube.
I think I also saw a Reddit Twitter ?!? and even an Instagram. So Discord replaces Reddit anyway but the accounts are not very active either from staff or in terms of followers compared to the Matrix space.
So until someone is found who wants to create contents for these platforms I would say it's better to link this elsewhere.