### PR TITLE
Add links to the /stats page and to the Firefox extension

### DIFF
--- a/mwmbl/templates/home.html
+++ b/mwmbl/templates/home.html
@@ -2,6 +2,8 @@
 {%  include "title.html" %}
 <p>Welcome to Mwmbl! Feel free to <a href="{% url "submit_domain" %}">submit</a> a site to crawl.
   Please read the <a href="https://book.mwmbl.org/page/curating/">guidelines</a> before editing results.</p>
+<p>To contribute to the index you can get our Firefox Extension <a href="https://addons.mozilla.org/en-GB/firefox/addon/mwmbl-web-crawler/">here</a>.
+For recent crawling activity see <a href="/stats">stats</a>.</p>
 <br>
 <div is="mwmbl-add-result" style="display: none">
   <form class="modal-content"


### PR DESCRIPTION
Add links in templates/home.html for the extension and stats page to increase visibility.