### PR TITLE
Fix permission denied on crawler data directory

### DIFF
--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -47,7 +47,9 @@ FROM base AS final
 # Copy only the required /venv directory from the builder image that contains mwmbl and its dependencies
 COPY --from=builder /venv /venv
 
-RUN useradd --uid 1000 --create-home mwmbl
+RUN useradd --uid 1000 --create-home mwmbl && \
+    mkdir -p /home/mwmbl/.mwmbl && \
+    chown -R mwmbl:mwmbl /home/mwmbl
 USER mwmbl
 WORKDIR /home/mwmbl
 


### PR DESCRIPTION
Create /home/mwmbl/.mwmbl owned by mwmbl before the USER switch so Docker seeds new named volumes with the correct ownership.