### PR TITLE
Fix stats page crash when API returns empty daily dicts

### DIFF
--- a/front-end/src/stats/index.html
+++ b/front-end/src/stats/index.html
@@ -79,20 +79,6 @@
     </div>
   </section>
   <section>
-    <div class="info">
-      <h1>Number of unique URLs in the index: <span id="num-index-urls"></span></h1>
-      <div class="wrap">
-        <canvas id="num-index-urls-by-day"></canvas>
-      </div>
-    </div>
-    <div class="info">
-      <h1>Number of results in the index: <span id="num-index-results"></span></h1>
-      <div class="wrap">
-        <canvas id="num-index-results-by-day"></canvas>
-      </div>
-    </div>
-  </section>
-  <section>
     <div class="info tall">
       <div class="wrap tall">
         <canvas id="urls-by-domain"></canvas>

--- a/front-end/src/stats/stats.js
+++ b/front-end/src/stats/stats.js
@@ -29,8 +29,6 @@ import {Chart} from "chart.js/auto";
   const urlsCrawledDailyChart = createChart('urls-by-day', null, "URLs crawled by day");
   const urlsCrawledHourlyChart = createChart('urls-by-hour', [...Array(24).keys()], "URLs crawled today by hour");
   const usersCrawledDailyChart = createChart('users-by-day', null, "Number of users crawling by day");
-  const numUrlsInIndexDailyChart = createChart('num-index-urls-by-day', null, "Number of URLs in index by day");
-  const numResultsInIndexDailyChart = createChart('num-index-results-by-day', null, "Number of results in index by day");
   const datasetQueriesDailyChart = createChart('dataset-queries-by-day', null, "Dataset queries by day");
   const datasetResultsDailyChart = createChart('dataset-results-by-day', null, "Dataset results by day");
 
@@ -93,14 +91,6 @@ function numberWithCommas(x) {
         const userCountSpan = document.getElementById("num-users");
         userCountSpan.innerText = numberWithCommas(numUsers);
 
-        const numUrlsInIndex = Object.values(stats.urls_in_index_daily)[Object.keys(stats.urls_in_index_daily).length - 1];
-        const numUrlsInIndexSpan = document.getElementById("num-index-urls");
-        numUrlsInIndexSpan.innerText = numberWithCommas(numUrlsInIndex);
-
-        const numResultsInIndex = Object.values(stats.results_in_index_daily)[Object.keys(stats.results_in_index_daily).length - 1];
-        const numResultsInIndexSpan = document.getElementById("num-index-results");
-        numResultsInIndexSpan.innerText = numberWithCommas(numResultsInIndex);
-
         const numDatasetQueries = Object.values(stats.dataset_queries_daily)[Object.keys(stats.dataset_queries_daily).length - 1];
         const numDatasetQueriesSpan = document.getElementById("num-dataset-queries");
         numDatasetQueriesSpan.innerText = numberWithCommas(numDatasetQueries);
@@ -132,14 +122,6 @@ function numberWithCommas(x) {
         byDomainChart.data.labels = stats.top_domains.map(d => d[0]);
         byDomainChart.data.datasets[0].data = stats.top_domains.map(d => d[1]);
         byDomainChart.update();
-
-        numUrlsInIndexDailyChart.data.labels = Object.keys(stats.urls_in_index_daily);
-        numUrlsInIndexDailyChart.data.datasets[0].data = Object.values(stats.urls_in_index_daily);
-        numUrlsInIndexDailyChart.update();
-
-        numResultsInIndexDailyChart.data.labels = Object.keys(stats.results_in_index_daily);
-        numResultsInIndexDailyChart.data.datasets[0].data = Object.values(stats.results_in_index_daily);
-        numResultsInIndexDailyChart.update();
 
         datasetQueriesDailyChart.data.labels = Object.keys(stats.dataset_queries_daily);
         datasetQueriesDailyChart.data.datasets[0].data = Object.values(stats.dataset_queries_daily);

--- a/front-end/src/stats/stats.js
+++ b/front-end/src/stats/stats.js
@@ -77,6 +77,7 @@ import {Chart} from "chart.js/auto";
 
 function numberWithCommas(x) {
   // From https://stackoverflow.com/a/2901298/660902
+  if (x == null) return "0";
   return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
 }
 


### PR DESCRIPTION
numberWithCommas now returns "0" for undefined/null values, preventing a TypeError when urls_in_index_daily or similar fields are empty objects.