### PR TITLE
Fetch curated domains from API in volunteer crawlers

### DIFF
--- a/mwmbl/crawl.py
+++ b/mwmbl/crawl.py
@@ -33,12 +33,35 @@ print("Mwmbl crawling statistics: https://mwmbl.org/stats")
 django.setup()
 
 from mwmbl.indexer.update_urls import record_urls_in_database
-from mwmbl.crawler.retrieve import crawl_batch, crawl_url, CRAWLER_VERSION
+from mwmbl.crawler.retrieve import crawl_batch, crawl_url, CRAWLER_VERSION, USER_AGENT
 from mwmbl.crawler.batch import HashedBatch, Result, Results
 from mwmbl.indexer.index_batches import index_batches, index_pages
 
 BATCH_QUEUE_KEY = "batch-queue"
 REMOTE_SERVER = "https://api.mwmbl.org"
+
+_curated_domains_cache: set[str] = set()
+_curated_domains_fetched_at: float = 0.0
+CURATED_DOMAINS_CACHE_SECONDS = 300.0
+
+
+def _fetch_curated_domains() -> set[str]:
+    global _curated_domains_cache, _curated_domains_fetched_at
+    now = time.monotonic()
+    if now - _curated_domains_fetched_at < CURATED_DOMAINS_CACHE_SECONDS:
+        return _curated_domains_cache
+    try:
+        response = requests.get(
+            f"{REMOTE_SERVER}/api/v1/crawler/curated-domains",
+            timeout=10,
+            headers={"User-Agent": USER_AGENT},
+        )
+        response.raise_for_status()
+        _curated_domains_cache = set(response.json())
+        _curated_domains_fetched_at = now
+    except Exception:
+        logger.exception("Failed to fetch curated domains, using cached value")
+    return _curated_domains_cache
 
 
 # Validate environment variables when actually needed
@@ -92,7 +115,7 @@ class Crawler:
     def url_queue(self):
         """Lazy initialization of URL queue."""
         if self._url_queue is None:
-            self._url_queue = RedisURLQueue(self.redis, lambda: set())
+            self._url_queue = RedisURLQueue(self.redis, _fetch_curated_domains)
         return self._url_queue
     
     def check_redis(self):

--- a/mwmbl/crawl.py
+++ b/mwmbl/crawl.py
@@ -57,7 +57,8 @@ def _fetch_curated_domains() -> set[str]:
             headers={"User-Agent": USER_AGENT},
         )
         response.raise_for_status()
-        _curated_domains_cache = set(response.json())
+        data = response.json()
+        _curated_domains_cache = {d["name"] for d in data["domains"]}
         _curated_domains_fetched_at = now
     except Exception:
         logger.exception("Failed to fetch curated domains, using cached value")

--- a/mwmbl/crawl.py
+++ b/mwmbl/crawl.py
@@ -60,6 +60,7 @@ def _fetch_curated_domains() -> set[str]:
         data = response.json()
         _curated_domains_cache = {d["name"] for d in data["domains"]}
         _curated_domains_fetched_at = now
+        logger.info(f"Fetched {len(_curated_domains_cache)} curated domains")
     except Exception:
         logger.exception("Failed to fetch curated domains, using cached value")
     return _curated_domains_cache

--- a/mwmbl/crawler/app.py
+++ b/mwmbl/crawler/app.py
@@ -239,6 +239,19 @@ def _register_routes(r: Router | NinjaAPI, batch_cache: BatchCache, queued_batch
             'status': 'ok'
         }
 
+    @r.get(
+        '/curated-domains',
+        summary="Get curated domains for crawling",
+        description=(
+            "Retrieve the list of approved domains curated by mwmbl users. "
+            "Crawlers should prioritize these domains when selecting URLs to crawl. "
+            "Results are cached server-side for 5 minutes."
+        ),
+    )
+    def get_curated_domains_endpoint(request) -> list[str]:
+        from mwmbl.search_setup import get_curated_domains
+        return sorted(get_curated_domains())
+
     @r.post(
         '/results',
         response={200: PostResultsResponse, 400: Error, 401: Error},

--- a/mwmbl/crawler/app.py
+++ b/mwmbl/crawler/app.py
@@ -239,6 +239,12 @@ def _register_routes(r: Router | NinjaAPI, batch_cache: BatchCache, queued_batch
             'status': 'ok'
         }
 
+    class CuratedDomain(Schema):
+        name: str
+
+    class CuratedDomainsResponse(Schema):
+        domains: list[CuratedDomain]
+
     @r.get(
         '/curated-domains',
         summary="Get curated domains for crawling",
@@ -248,9 +254,11 @@ def _register_routes(r: Router | NinjaAPI, batch_cache: BatchCache, queued_batch
             "Results are cached server-side for 5 minutes."
         ),
     )
-    def get_curated_domains_endpoint(request) -> list[str]:
+    def get_curated_domains_endpoint(request) -> CuratedDomainsResponse:
         from mwmbl.search_setup import get_curated_domains
-        return sorted(get_curated_domains())
+        return CuratedDomainsResponse(
+            domains=[CuratedDomain(name=d) for d in sorted(get_curated_domains())]
+        )
 
     @r.post(
         '/results',


### PR DESCRIPTION
Add GET /api/v1/crawler/curated-domains endpoint that returns the list of user-approved domains. Update crawl.py to fetch this list at startup and refresh it every 5 minutes, so volunteer crawlers respect curated domain prioritization set on the main site.