### PR TITLE
Fix ValueError when Document receives invalid state value

### DIFF
--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -67,7 +67,10 @@ class Document:
         self.extract = extract if extract is not None else ''
         self.score = score
         self.term = term
-        self.state = None if state is None else DocumentState(state)
+        try:
+            self.state = None if state is None else DocumentState(state)
+        except (ValueError, TypeError):
+            self.state = None
         self.user_ids = user_ids
         self.last_crawled = last_crawled
 

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -153,3 +153,19 @@ def test_document_backward_compat_old_six_element_tuple():
     doc = Document(*old_tuple)
     assert doc.user_ids is None
     assert doc.last_crawled is None
+
+
+def test_document_invalid_state_false_resolves_to_none():
+    doc = Document(title='t', url='u', extract='e', state=False)
+    assert doc.state is None
+
+
+def test_document_invalid_state_string_resolves_to_none():
+    doc = Document(title='t', url='u', extract='e', state='invalid')
+    assert doc.state is None
+
+
+def test_document_valid_state_preserved():
+    from mwmbl.tinysearchengine.indexer import DocumentState
+    doc = Document(title='t', url='u', extract='e', state=DocumentState.FROM_USER)
+    assert doc.state == DocumentState.FROM_USER


### PR DESCRIPTION
## Problem

The crawler API endpoint `/api/v1/crawler/results` crashes with `ValueError: False is not a valid DocumentState` when a crawler sends `state=False` (or any other invalid value).

From the production traceback in #298:
```
File "mwmbl/tinysearchengine/indexer.py", line 66, in __init__
    self.state = None if state is None else DocumentState(state)
ValueError: False is not a valid DocumentState
```

## Fix

Wrap the `DocumentState()` conversion in `Document.__init__` with `try/except (ValueError, TypeError)`, falling back to `state=None` for invalid values. This matches the existing defensive pattern in `fix_document_state()` in `rank.py`.

Invalid state values now silently resolve to `None` (organic result) instead of crashing the entire request.

## Testing

Added three tests:
- `state=False` resolves to `None`
- `state='invalid'` resolves to `None`
- Valid `DocumentState` values preserved

Fixes #298