### PR TITLE
Super Search: index title-only results (empty extract)

### DIFF
--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -126,7 +126,7 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     with TinyIndex(Document, index_path, 'r') as indexer:
         existing_keys: dict[int, set[tuple]] = {}
         for doc in documents:
-            if not (doc.url and doc.title and doc.extract):
+            if not (doc.url and doc.title):
                 continue
             doc_tokens = _document_token_set(doc)
             for term, words in query_terms.items():

--- a/test/test_index_batches.py
+++ b/test/test_index_batches.py
@@ -127,6 +127,27 @@ def test_index_results_against_query():
         assert index_results_against_query(docs, "rust async", index_path) == 0
 
 
+def test_index_results_against_query_keeps_title_only_documents():
+    # Title-only results (empty extract) must still be indexed, matching what
+    # Super Search now keeps for display. The term is matched via the URL/title
+    # token set, so an empty extract should not exclude the document.
+    num_pages = 64
+    doc = Document(title="Kitsas dictionary", url="https://en.wiktionary.org/wiki/kitsas", extract="")
+    docs = [doc]
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = str(Path(temp_dir) / 'temp-index.tinysearch')
+        with TinyIndex.create(Document, index_path, num_pages=num_pages, page_size=4096):
+            pass
+
+        new_count = index_results_against_query(docs, "kitsas", index_path)
+        assert new_count == 1
+
+        with TinyIndex(Document, index_path, 'r') as indexer:
+            kitsas_urls = {d.url for d in indexer.retrieve("kitsas")}
+        assert kitsas_urls == {doc.url}
+
+
 # ---------------------------------------------------------------------------
 # _merge_user_ids
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Commit cb08a28 relaxed the extract guards throughout super_search.py so title-only results are kept for display, but missed the matching guard in index_results_against_query, the function that actually persists results to the index. Title-only pages (the bulk of what Super Search finds for queries like "kitsas": Wiktionary, Wikipedia, etc.) were therefore shown but never indexed, so a later standard search couldn't see them (pages_indexed was 0).

Relax the guard to require only URL + title, matching the rest of the pipeline; the term is matched via the document's URL/title token set, so an empty extract should not exclude it.