### PR TITLE
Replace per-domain result filter with MMR diversity re-ranking

### DIFF
--- a/mwmbl/rankeval/evaluation/evaluate_remote.py
+++ b/mwmbl/rankeval/evaluation/evaluate_remote.py
@@ -13,7 +13,7 @@ from mwmbl.rankeval.paths import MODEL_PATH, RUST_MODEL_PATH
 from mwmbl.tinysearchengine.indexer import TinyIndex, Document
 from mwmbl.tinysearchengine.ltr import RustXGBPipeline
 from mwmbl.tinysearchengine.ltr_rank import LTRRanker
-from mwmbl.tinysearchengine.rank import DomainLimitingRanker, Ranker, HeuristicRanker, HeuristicAndWikiRanker
+from mwmbl.tinysearchengine.rank import Ranker, HeuristicRanker, HeuristicAndWikiRanker
 
 from mwmbl.rankeval.evaluation.evaluate import RankingModel, evaluate
 
@@ -32,7 +32,7 @@ def run():
  
     # model = pickle.load(open(MODEL_PATH, 'rb'))
     model = RustXGBPipeline.from_model_path(str(RUST_MODEL_PATH))
-    ranker = DomainLimitingRanker(LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3))
+    ranker = LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3)
     # ranker = HeuristicRanker(RemoteIndex(), DummyCompleter())
     # ranker = HeuristicAndWikiRanker(RemoteIndex(), DummyCompleter(), max_wiki_results=3)
     model = MwmblRankingModel(ranker)
@@ -41,7 +41,7 @@ def run():
 
 def single_query(query: str):
     model = pickle.load(open(MODEL_PATH, 'rb'))
-    ranker = DomainLimitingRanker(LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3))
+    ranker = LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3)
     # ranker = HeuristicAndWikiRanker(RemoteIndex(), DummyCompleter())
     results = ranker.search(query, [])
     for result in results:

--- a/mwmbl/rankeval/evaluation/evaluate_remote.py
+++ b/mwmbl/rankeval/evaluation/evaluate_remote.py
@@ -13,6 +13,7 @@ from mwmbl.rankeval.paths import MODEL_PATH, RUST_MODEL_PATH
 from mwmbl.tinysearchengine.indexer import TinyIndex, Document
 from mwmbl.tinysearchengine.ltr import RustXGBPipeline
 from mwmbl.tinysearchengine.ltr_rank import LTRRanker
+from mwmbl.tinysearchengine.mmr_rank import MMRRanker
 from mwmbl.tinysearchengine.rank import Ranker, HeuristicRanker, HeuristicAndWikiRanker
 
 from mwmbl.rankeval.evaluation.evaluate import RankingModel, evaluate
@@ -32,7 +33,8 @@ def run():
  
     # model = pickle.load(open(MODEL_PATH, 'rb'))
     model = RustXGBPipeline.from_model_path(str(RUST_MODEL_PATH))
-    ranker = LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3)
+    ranker = MMRRanker(LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3))
+    # ranker = LTRRanker(RemoteIndex(), DummyCompleter(), model, True, 3)  # MMR off
     # ranker = HeuristicRanker(RemoteIndex(), DummyCompleter())
     # ranker = HeuristicAndWikiRanker(RemoteIndex(), DummyCompleter(), max_wiki_results=3)
     model = MwmblRankingModel(ranker)

--- a/mwmbl/search_setup.py
+++ b/mwmbl/search_setup.py
@@ -12,7 +12,7 @@ from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import TinyIndex, Document
 from mwmbl.tinysearchengine.ltr import RustXGBPipeline
 from mwmbl.tinysearchengine.ltr_rank import LTRRanker
-from mwmbl.tinysearchengine.rank import DomainLimitingRanker, HeuristicAndWikiRanker
+from mwmbl.tinysearchengine.rank import HeuristicAndWikiRanker
 
 CURATED_DOMAINS_CACHE_KEY = "curated-domains"
 CURATED_DOMAINS_CACHE_TIMEOUT = 300
@@ -34,6 +34,8 @@ tiny_index = TinyIndex(item_factory=Document, index_path=index_path)
 tiny_index.__enter__()
 
 ltr_model = RustXGBPipeline.from_model_path(str(settings.RUST_MODEL_PATH))
-ranker = DomainLimitingRanker(LTRRanker(tiny_index, completer, ltr_model, include_wiki=True, num_wiki_results=3))
+# Diversity (one-time-only-per-domain) is handled inside LTRRanker via MMR re-ranking,
+# which demotes rather than drops same-domain results.
+ranker = LTRRanker(tiny_index, completer, ltr_model, include_wiki=True, num_wiki_results=3)
 
 batch_cache = BatchCache(Path(settings.DATA_PATH) / settings.BATCH_DIR_NAME)

--- a/mwmbl/search_setup.py
+++ b/mwmbl/search_setup.py
@@ -12,6 +12,7 @@ from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import TinyIndex, Document
 from mwmbl.tinysearchengine.ltr import RustXGBPipeline
 from mwmbl.tinysearchengine.ltr_rank import LTRRanker
+from mwmbl.tinysearchengine.mmr_rank import MMRRanker
 from mwmbl.tinysearchengine.rank import HeuristicAndWikiRanker
 
 CURATED_DOMAINS_CACHE_KEY = "curated-domains"
@@ -34,8 +35,8 @@ tiny_index = TinyIndex(item_factory=Document, index_path=index_path)
 tiny_index.__enter__()
 
 ltr_model = RustXGBPipeline.from_model_path(str(settings.RUST_MODEL_PATH))
-# Diversity (one-time-only-per-domain) is handled inside LTRRanker via MMR re-ranking,
-# which demotes rather than drops same-domain results.
-ranker = LTRRanker(tiny_index, completer, ltr_model, include_wiki=True, num_wiki_results=3)
+# Diversity is applied by the wrapping MMRRanker, which demotes (rather than drops)
+# same-domain / near-duplicate results. Unwrap to disable diversity.
+ranker = MMRRanker(LTRRanker(tiny_index, completer, ltr_model, include_wiki=True, num_wiki_results=3))
 
 batch_cache = BatchCache(Path(settings.DATA_PATH) / settings.BATCH_DIR_NAME)

--- a/mwmbl/tinysearchengine/ltr_rank.py
+++ b/mwmbl/tinysearchengine/ltr_rank.py
@@ -24,61 +24,64 @@ from mwmbl.tokenizer import tokenize
 # list instead of hard-capping one result per domain).
 MMR_LAMBDA = 0.7  # weight on relevance vs. diversity (1.0 = pure relevance, 0.0 = max diversity)
 DOMAIN_SIMILARITY_WEIGHT = 0.8  # within the kernel: weight on same-domain vs. text overlap
+MMR_WINDOW = 50  # only diversify the top candidates; the long tail keeps relevance order
 
 
-def _bag_of_words(doc: Document) -> Counter:
-    return Counter(tokenize(f"{doc.title or ''} {doc.extract or ''}"))
+def _normalized_bow(doc: Document) -> dict[str, float]:
+    """L2-normalised bag-of-words over title + extract, so cosine is a plain dot product."""
+    counts = Counter(tokenize(f"{doc.title or ''} {doc.extract or ''}"))
+    if not counts:
+        return {}
+    norm = math.sqrt(sum(c * c for c in counts.values()))
+    return {token: count / norm for token, count in counts.items()}
 
 
-def _cosine(a: Counter, b: Counter) -> float:
-    if not a or not b:
-        return 0.0
-    dot = sum(count * b[token] for token, count in a.items() if token in b)
-    if dot == 0:
-        return 0.0
-    norm_a = math.sqrt(sum(c * c for c in a.values()))
-    norm_b = math.sqrt(sum(c * c for c in b.values()))
-    return dot / (norm_a * norm_b)
-
-
-def _similarity(bow_a: Counter, netloc_a: str, bow_b: Counter, netloc_b: str) -> float:
-    """Domain-dominant similarity: same-domain pairs are penalised hardest, with a
-    bag-of-words cosine as a secondary signal to catch cross-domain near-duplicates."""
-    domain_sim = 1.0 if netloc_a and netloc_a == netloc_b else 0.0
-    text_sim = _cosine(bow_a, bow_b)
-    return DOMAIN_SIMILARITY_WEIGHT * domain_sim + (1 - DOMAIN_SIMILARITY_WEIGHT) * text_sim
+def _text_cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    # a and b are already L2-normalised, so the sparse dot product is the cosine.
+    if len(a) > len(b):
+        a, b = b, a
+    return sum(weight * b[token] for token, weight in a.items() if token in b)
 
 
 def mmr_rerank(ranked_pages: list[Document]) -> list[Document]:
     """Re-order a relevance-sorted list to demote near-duplicate / same-domain results.
 
-    Greedy Maximal Marginal Relevance with the domain-dominant kernel above. Relevance
-    is rank-based (scale-invariant): the i-th most relevant page has relevance
-    (n - i) / n, so it does not depend on the model's compressed score magnitudes.
-    Each candidate is discounted by its greatest similarity to an already-selected page,
-    so e.g. the second result from a domain sinks below fresher domains but is never
-    dropped. Complexity is O(n^2) over the (small) per-query candidate set.
+    Greedy Maximal Marginal Relevance with a domain-dominant kernel
+    (sim = w_domain * same_domain + (1 - w_domain) * bag-of-words cosine). Relevance is
+    rank-based (scale-invariant): the i-th most relevant page has relevance
+    (window - i) / window, so it does not depend on the model's compressed score
+    magnitudes. Each candidate is discounted by its greatest similarity to an
+    already-selected page, so e.g. the second result from a domain sinks below fresher
+    domains but is never dropped.
+
+    Only the top MMR_WINDOW candidates are diversified (O(window^2)); the long tail,
+    which is rarely seen, keeps plain relevance order so the cost stays bounded.
     """
     n = len(ranked_pages)
     if n <= 2:
         return ranked_pages
 
-    relevance = [(n - i) / n for i in range(n)]
-    bows = [_bag_of_words(p) for p in ranked_pages]
-    netlocs = [urlparse(p.url).netloc for p in ranked_pages]
+    window = min(n, MMR_WINDOW)
+    head, tail = ranked_pages[:window], ranked_pages[window:]
 
-    remaining = set(range(n))
-    max_sim = [0.0] * n
+    relevance = [(window - i) / window for i in range(window)]
+    bows = [_normalized_bow(p) for p in head]
+    netlocs = [urlparse(p.url).netloc for p in head]
+
+    remaining = set(range(window))
+    max_sim = [0.0] * window
     selected: list[int] = []
     while remaining:
         best = max(remaining, key=lambda i: MMR_LAMBDA * relevance[i] - (1 - MMR_LAMBDA) * max_sim[i])
         selected.append(best)
         remaining.discard(best)
+        best_bow, best_netloc = bows[best], netlocs[best]
         for j in remaining:
-            sim = _similarity(bows[best], netlocs[best], bows[j], netlocs[j])
+            domain_sim = DOMAIN_SIMILARITY_WEIGHT if best_netloc and best_netloc == netlocs[j] else 0.0
+            sim = domain_sim + (1 - DOMAIN_SIMILARITY_WEIGHT) * _text_cosine(best_bow, bows[j])
             if sim > max_sim[j]:
                 max_sim[j] = sim
-    return [ranked_pages[i] for i in selected]
+    return [head[i] for i in selected] + tail
 
 
 class LTRRanker(Ranker):

--- a/mwmbl/tinysearchengine/ltr_rank.py
+++ b/mwmbl/tinysearchengine/ltr_rank.py
@@ -4,6 +4,10 @@ LTR (Learning-to-Rank) ranker that uses the Rust XGBoost pipeline for scoring.
 LTRRanker accepts any model with a sklearn-compatible predict(DataFrame) interface,
 including both the Python sklearn pipeline and the Rust RustXGBPipeline.
 """
+import math
+from collections import Counter
+from urllib.parse import urlparse
+
 import numpy as np
 from pandas import DataFrame
 from sklearn.base import BaseEstimator
@@ -11,6 +15,70 @@ from sklearn.base import BaseEstimator
 from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
 from mwmbl.tinysearchengine.rank import Ranker, get_wiki_results
+from mwmbl.tokenizer import tokenize
+
+
+# Maximal Marginal Relevance (MMR) diversity parameters, applied in order_results.
+# MMR re-orders the relevance-sorted candidates so near-duplicate / same-domain
+# results are demoted rather than dropped (the big search engines diversify the
+# list instead of hard-capping one result per domain).
+MMR_LAMBDA = 0.7  # weight on relevance vs. diversity (1.0 = pure relevance, 0.0 = max diversity)
+DOMAIN_SIMILARITY_WEIGHT = 0.8  # within the kernel: weight on same-domain vs. text overlap
+
+
+def _bag_of_words(doc: Document) -> Counter:
+    return Counter(tokenize(f"{doc.title or ''} {doc.extract or ''}"))
+
+
+def _cosine(a: Counter, b: Counter) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(count * b[token] for token, count in a.items() if token in b)
+    if dot == 0:
+        return 0.0
+    norm_a = math.sqrt(sum(c * c for c in a.values()))
+    norm_b = math.sqrt(sum(c * c for c in b.values()))
+    return dot / (norm_a * norm_b)
+
+
+def _similarity(bow_a: Counter, netloc_a: str, bow_b: Counter, netloc_b: str) -> float:
+    """Domain-dominant similarity: same-domain pairs are penalised hardest, with a
+    bag-of-words cosine as a secondary signal to catch cross-domain near-duplicates."""
+    domain_sim = 1.0 if netloc_a and netloc_a == netloc_b else 0.0
+    text_sim = _cosine(bow_a, bow_b)
+    return DOMAIN_SIMILARITY_WEIGHT * domain_sim + (1 - DOMAIN_SIMILARITY_WEIGHT) * text_sim
+
+
+def mmr_rerank(ranked_pages: list[Document]) -> list[Document]:
+    """Re-order a relevance-sorted list to demote near-duplicate / same-domain results.
+
+    Greedy Maximal Marginal Relevance with the domain-dominant kernel above. Relevance
+    is rank-based (scale-invariant): the i-th most relevant page has relevance
+    (n - i) / n, so it does not depend on the model's compressed score magnitudes.
+    Each candidate is discounted by its greatest similarity to an already-selected page,
+    so e.g. the second result from a domain sinks below fresher domains but is never
+    dropped. Complexity is O(n^2) over the (small) per-query candidate set.
+    """
+    n = len(ranked_pages)
+    if n <= 2:
+        return ranked_pages
+
+    relevance = [(n - i) / n for i in range(n)]
+    bows = [_bag_of_words(p) for p in ranked_pages]
+    netlocs = [urlparse(p.url).netloc for p in ranked_pages]
+
+    remaining = set(range(n))
+    max_sim = [0.0] * n
+    selected: list[int] = []
+    while remaining:
+        best = max(remaining, key=lambda i: MMR_LAMBDA * relevance[i] - (1 - MMR_LAMBDA) * max_sim[i])
+        selected.append(best)
+        remaining.discard(best)
+        for j in remaining:
+            sim = _similarity(bows[best], netlocs[best], bows[j], netlocs[j])
+            if sim > max_sim[j]:
+                max_sim[j] = sim
+    return [ranked_pages[i] for i in selected]
 
 
 class LTRRanker(Ranker):
@@ -71,10 +139,14 @@ class LTRRanker(Ranker):
         mask = predictions > 0.0
         filtered_predictions = predictions[mask]
         filtered_pages = np.array(results)[mask]
+        if len(filtered_pages) == 0:
+            return []
 
-        # Vectorized sorting
+        # Sort by model relevance, then re-order with MMR to diversify the list
+        # (demotes same-domain / near-duplicate results instead of dropping them).
         indices = np.argsort(filtered_predictions)[::-1]
-        return filtered_pages[indices].tolist()
+        ranked_pages = filtered_pages[indices].tolist()
+        return mmr_rerank(ranked_pages)
 
     def external_search(self, query: str) -> list[Document]:
         if self.include_wiki:

--- a/mwmbl/tinysearchengine/ltr_rank.py
+++ b/mwmbl/tinysearchengine/ltr_rank.py
@@ -4,10 +4,6 @@ LTR (Learning-to-Rank) ranker that uses the Rust XGBoost pipeline for scoring.
 LTRRanker accepts any model with a sklearn-compatible predict(DataFrame) interface,
 including both the Python sklearn pipeline and the Rust RustXGBPipeline.
 """
-import math
-from collections import Counter
-from urllib.parse import urlparse
-
 import numpy as np
 from pandas import DataFrame
 from sklearn.base import BaseEstimator
@@ -15,73 +11,6 @@ from sklearn.base import BaseEstimator
 from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
 from mwmbl.tinysearchengine.rank import Ranker, get_wiki_results
-from mwmbl.tokenizer import tokenize
-
-
-# Maximal Marginal Relevance (MMR) diversity parameters, applied in order_results.
-# MMR re-orders the relevance-sorted candidates so near-duplicate / same-domain
-# results are demoted rather than dropped (the big search engines diversify the
-# list instead of hard-capping one result per domain).
-MMR_LAMBDA = 0.7  # weight on relevance vs. diversity (1.0 = pure relevance, 0.0 = max diversity)
-DOMAIN_SIMILARITY_WEIGHT = 0.8  # within the kernel: weight on same-domain vs. text overlap
-MMR_WINDOW = 50  # only diversify the top candidates; the long tail keeps relevance order
-
-
-def _normalized_bow(doc: Document) -> dict[str, float]:
-    """L2-normalised bag-of-words over title + extract, so cosine is a plain dot product."""
-    counts = Counter(tokenize(f"{doc.title or ''} {doc.extract or ''}"))
-    if not counts:
-        return {}
-    norm = math.sqrt(sum(c * c for c in counts.values()))
-    return {token: count / norm for token, count in counts.items()}
-
-
-def _text_cosine(a: dict[str, float], b: dict[str, float]) -> float:
-    # a and b are already L2-normalised, so the sparse dot product is the cosine.
-    if len(a) > len(b):
-        a, b = b, a
-    return sum(weight * b[token] for token, weight in a.items() if token in b)
-
-
-def mmr_rerank(ranked_pages: list[Document]) -> list[Document]:
-    """Re-order a relevance-sorted list to demote near-duplicate / same-domain results.
-
-    Greedy Maximal Marginal Relevance with a domain-dominant kernel
-    (sim = w_domain * same_domain + (1 - w_domain) * bag-of-words cosine). Relevance is
-    rank-based (scale-invariant): the i-th most relevant page has relevance
-    (window - i) / window, so it does not depend on the model's compressed score
-    magnitudes. Each candidate is discounted by its greatest similarity to an
-    already-selected page, so e.g. the second result from a domain sinks below fresher
-    domains but is never dropped.
-
-    Only the top MMR_WINDOW candidates are diversified (O(window^2)); the long tail,
-    which is rarely seen, keeps plain relevance order so the cost stays bounded.
-    """
-    n = len(ranked_pages)
-    if n <= 2:
-        return ranked_pages
-
-    window = min(n, MMR_WINDOW)
-    head, tail = ranked_pages[:window], ranked_pages[window:]
-
-    relevance = [(window - i) / window for i in range(window)]
-    bows = [_normalized_bow(p) for p in head]
-    netlocs = [urlparse(p.url).netloc for p in head]
-
-    remaining = set(range(window))
-    max_sim = [0.0] * window
-    selected: list[int] = []
-    while remaining:
-        best = max(remaining, key=lambda i: MMR_LAMBDA * relevance[i] - (1 - MMR_LAMBDA) * max_sim[i])
-        selected.append(best)
-        remaining.discard(best)
-        best_bow, best_netloc = bows[best], netlocs[best]
-        for j in remaining:
-            domain_sim = DOMAIN_SIMILARITY_WEIGHT if best_netloc and best_netloc == netlocs[j] else 0.0
-            sim = domain_sim + (1 - DOMAIN_SIMILARITY_WEIGHT) * _text_cosine(best_bow, bows[j])
-            if sim > max_sim[j]:
-                max_sim[j] = sim
-    return [head[i] for i in selected] + tail
 
 
 class LTRRanker(Ranker):
@@ -145,11 +74,9 @@ class LTRRanker(Ranker):
         if len(filtered_pages) == 0:
             return []
 
-        # Sort by model relevance, then re-order with MMR to diversify the list
-        # (demotes same-domain / near-duplicate results instead of dropping them).
+        # Sort by model relevance (descending).
         indices = np.argsort(filtered_predictions)[::-1]
-        ranked_pages = filtered_pages[indices].tolist()
-        return mmr_rerank(ranked_pages)
+        return filtered_pages[indices].tolist()
 
     def external_search(self, query: str) -> list[Document]:
         if self.include_wiki:

--- a/mwmbl/tinysearchengine/mmr_rank.py
+++ b/mwmbl/tinysearchengine/mmr_rank.py
@@ -1,0 +1,99 @@
+"""
+Maximal Marginal Relevance (MMR) diversity re-ranking.
+
+MMRRanker is a decorator that wraps any Ranker and re-orders its relevance-sorted
+search() output so near-duplicate / same-domain results are demoted rather than dropped
+(the big search engines diversify the list instead of hard-capping one result per domain).
+It can wrap any ranker (LTRRanker, HeuristicRanker, ...), which also makes it easy to
+evaluate a ranker with and without diversity.
+"""
+import math
+from collections import Counter
+from urllib.parse import urlparse
+
+from mwmbl.tinysearchengine.indexer import Document
+from mwmbl.tinysearchengine.rank import Ranker
+from mwmbl.tokenizer import tokenize
+
+
+# MMR tuning parameters.
+MMR_LAMBDA = 0.7  # weight on relevance vs. diversity (1.0 = pure relevance, 0.0 = max diversity)
+DOMAIN_SIMILARITY_WEIGHT = 0.8  # within the kernel: weight on same-domain vs. text overlap
+MMR_WINDOW = 50  # only diversify the top candidates; the long tail keeps relevance order
+
+
+def _normalized_bow(doc: Document) -> dict[str, float]:
+    """L2-normalised bag-of-words over title + extract, so cosine is a plain dot product."""
+    counts = Counter(tokenize(f"{doc.title or ''} {doc.extract or ''}"))
+    if not counts:
+        return {}
+    norm = math.sqrt(sum(c * c for c in counts.values()))
+    return {token: count / norm for token, count in counts.items()}
+
+
+def _text_cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    # a and b are already L2-normalised, so the sparse dot product is the cosine.
+    if len(a) > len(b):
+        a, b = b, a
+    return sum(weight * b[token] for token, weight in a.items() if token in b)
+
+
+def mmr_rerank(ranked_pages: list[Document]) -> list[Document]:
+    """Re-order a relevance-sorted list to demote near-duplicate / same-domain results.
+
+    Greedy Maximal Marginal Relevance with a domain-dominant kernel
+    (sim = w_domain * same_domain + (1 - w_domain) * bag-of-words cosine). Relevance is
+    rank-based (scale-invariant): the i-th most relevant page has relevance
+    (window - i) / window, so it does not depend on the model's compressed score
+    magnitudes. Each candidate is discounted by its greatest similarity to an
+    already-selected page, so e.g. the second result from a domain sinks below fresher
+    domains but is never dropped.
+
+    Only the top MMR_WINDOW candidates are diversified (O(window^2)); the long tail,
+    which is rarely seen, keeps plain relevance order so the cost stays bounded.
+    """
+    n = len(ranked_pages)
+    if n <= 2:
+        return ranked_pages
+
+    window = min(n, MMR_WINDOW)
+    head, tail = ranked_pages[:window], ranked_pages[window:]
+
+    relevance = [(window - i) / window for i in range(window)]
+    bows = [_normalized_bow(p) for p in head]
+    netlocs = [urlparse(p.url).netloc for p in head]
+
+    remaining = set(range(window))
+    max_sim = [0.0] * window
+    selected: list[int] = []
+    while remaining:
+        best = max(remaining, key=lambda i: MMR_LAMBDA * relevance[i] - (1 - MMR_LAMBDA) * max_sim[i])
+        selected.append(best)
+        remaining.discard(best)
+        best_bow, best_netloc = bows[best], netlocs[best]
+        for j in remaining:
+            domain_sim = DOMAIN_SIMILARITY_WEIGHT if best_netloc and best_netloc == netlocs[j] else 0.0
+            sim = domain_sim + (1 - DOMAIN_SIMILARITY_WEIGHT) * _text_cosine(best_bow, bows[j])
+            if sim > max_sim[j]:
+                max_sim[j] = sim
+    return [head[i] for i in selected] + tail
+
+
+class MMRRanker:
+    """Decorator that applies MMR diversity re-ranking to a wrapped ranker's results.
+
+    Demotes (never drops) same-domain / near-duplicate results. Delegates completion and
+    raw retrieval unchanged.
+    """
+
+    def __init__(self, ranker: Ranker):
+        self.ranker = ranker
+
+    def search(self, s: str, additional_results: list[Document]) -> list[Document]:
+        return mmr_rerank(self.ranker.search(s, additional_results))
+
+    def complete(self, q: str):
+        return self.ranker.complete(q)
+
+    def get_raw_results(self, query: str):
+        return self.ranker.get_raw_results(query)

--- a/mwmbl/tinysearchengine/rank.py
+++ b/mwmbl/tinysearchengine/rank.py
@@ -414,27 +414,3 @@ class HeuristicAndWikiRanker(HeuristicRanker):
             return []
 
         return results
-
-class DomainLimitingRanker:
-    def __init__(self, ranker: Ranker):
-        self.ranker = ranker
-    
-    def search(self, s: str, additional_results: list[Document]):
-        results = self.ranker.search(s, additional_results)
-        seen_domains = set()
-        
-        filtered_results = []
-        for result in results:
-            domain = urlparse(result.url).netloc
-            if domain in seen_domains:
-                continue
-
-            filtered_results.append(result)
-            seen_domains.add(domain)
-        return filtered_results
-
-    def complete(self, q: str):
-        return self.ranker.complete(q)
-
-    def get_raw_results(self, query: str):
-        return self.ranker.get_raw_results(query)

--- a/test/test_ltr_rank.py
+++ b/test/test_ltr_rank.py
@@ -1,0 +1,45 @@
+from mwmbl.tinysearchengine.indexer import Document
+from mwmbl.tinysearchengine.ltr_rank import mmr_rerank
+
+
+def _doc(title, url, extract=""):
+    return Document(title=title, url=url, extract=extract)
+
+
+def test_mmr_keeps_all_documents():
+    # MMR demotes, it never drops: same-domain results must all survive.
+    pages = [
+        _doc("artoh/kitsas", "https://github.com/artoh/kitsas", "kitsas kirjanpito"),
+        _doc("artoh/kitsasdocsy", "https://github.com/artoh/kitsasdocsy", "kitsas documentation"),
+        _doc("artoh/kitsashealth", "https://github.com/artoh/kitsashealth", "health check for kitsas"),
+    ]
+    reranked = mmr_rerank(pages)
+    assert {p.url for p in reranked} == {p.url for p in pages}
+
+
+def test_mmr_demotes_same_domain_below_fresh_domain():
+    # Input is in relevance order: two github.com results then a lower-ranked
+    # different-domain result. MMR should lift the fresh domain above the second
+    # same-domain result, while keeping all three.
+    a = _doc("Alpha repo", "https://github.com/x/alpha", "alpha project")
+    b = _doc("Beta repo", "https://github.com/x/beta", "beta project")
+    c = _doc("Gamma site", "https://example.org/gamma", "gamma encyclopedia entry")
+    reranked = mmr_rerank([a, b, c])
+    urls = [p.url for p in reranked]
+    assert urls[0] == a.url  # most relevant stays first
+    assert urls.index(c.url) < urls.index(b.url)  # fresh domain promoted above 2nd github
+
+
+def test_mmr_preserves_order_without_duplicates():
+    # All distinct domains and content: relevance order should be untouched.
+    pages = [
+        _doc("First", "https://a.com/1", "apples"),
+        _doc("Second", "https://b.com/2", "bananas"),
+        _doc("Third", "https://c.com/3", "cherries"),
+    ]
+    assert [p.url for p in mmr_rerank(pages)] == [p.url for p in pages]
+
+
+def test_mmr_short_lists_are_unchanged():
+    pages = [_doc("a", "https://github.com/x/a"), _doc("b", "https://github.com/x/b")]
+    assert mmr_rerank(pages) == pages

--- a/test/test_ltr_rank.py
+++ b/test/test_ltr_rank.py
@@ -1,5 +1,5 @@
 from mwmbl.tinysearchengine.indexer import Document
-from mwmbl.tinysearchengine.ltr_rank import mmr_rerank
+from mwmbl.tinysearchengine.ltr_rank import MMR_WINDOW, mmr_rerank
 
 
 def _doc(title, url, extract=""):
@@ -43,3 +43,14 @@ def test_mmr_preserves_order_without_duplicates():
 def test_mmr_short_lists_are_unchanged():
     pages = [_doc("a", "https://github.com/x/a"), _doc("b", "https://github.com/x/b")]
     assert mmr_rerank(pages) == pages
+
+
+def test_mmr_caps_work_to_window_and_keeps_tail():
+    # Beyond MMR_WINDOW the long tail keeps plain relevance order (bounded cost),
+    # and no document is ever dropped.
+    pages = [_doc(f"t{i}", f"https://github.com/x/{i}", "same kind of content") for i in range(MMR_WINDOW + 25)]
+    reranked = mmr_rerank(pages)
+    assert len(reranked) == len(pages)
+    assert {p.url for p in reranked} == {p.url for p in pages}
+    # The tail past the window is untouched.
+    assert reranked[MMR_WINDOW:] == pages[MMR_WINDOW:]

--- a/test/test_mmr_rank.py
+++ b/test/test_mmr_rank.py
@@ -1,5 +1,5 @@
 from mwmbl.tinysearchengine.indexer import Document
-from mwmbl.tinysearchengine.ltr_rank import MMR_WINDOW, mmr_rerank
+from mwmbl.tinysearchengine.mmr_rank import MMR_WINDOW, MMRRanker, mmr_rerank
 
 
 def _doc(title, url, extract=""):
@@ -54,3 +54,46 @@ def test_mmr_caps_work_to_window_and_keeps_tail():
     assert {p.url for p in reranked} == {p.url for p in pages}
     # The tail past the window is untouched.
     assert reranked[MMR_WINDOW:] == pages[MMR_WINDOW:]
+
+
+class _FakeRanker:
+    """Minimal ranker stub exposing the methods MMRRanker delegates to."""
+
+    def __init__(self, results):
+        self._results = results
+        self.completed = None
+        self.raw_queried = None
+
+    def search(self, s, additional_results):
+        self.searched = (s, additional_results)
+        return self._results
+
+    def complete(self, q):
+        self.completed = q
+        return ["completion"]
+
+    def get_raw_results(self, query):
+        self.raw_queried = query
+        return ["raw"]
+
+
+def test_mmrranker_reranks_wrapped_search_output():
+    # The wrapped ranker returns results in relevance order: two same-domain then a
+    # fresh domain. MMRRanker should demote the second same-domain result below it.
+    a = _doc("Alpha repo", "https://github.com/x/alpha", "alpha project")
+    b = _doc("Beta repo", "https://github.com/x/beta", "beta project")
+    c = _doc("Gamma site", "https://example.org/gamma", "gamma encyclopedia entry")
+    ranker = MMRRanker(_FakeRanker([a, b, c]))
+
+    urls = [p.url for p in ranker.search("q", [])]
+    assert urls[0] == a.url
+    assert urls.index(c.url) < urls.index(b.url)
+
+
+def test_mmrranker_delegates_complete_and_raw_results():
+    fake = _FakeRanker([])
+    ranker = MMRRanker(fake)
+    assert ranker.complete("foo") == ["completion"]
+    assert fake.completed == "foo"
+    assert ranker.get_raw_results("bar") == ["raw"]
+    assert fake.raw_queried == "bar"


### PR DESCRIPTION
Search collapsed all results from a domain to one (DomainLimitingRanker), hard-dropping same-domain results such as github.com/artoh/kitsasdocsy and .../kitsashealth for the query "kitsas" even though they were correctly indexed and scored.

Replace the hard filter with Maximal Marginal Relevance re-ranking inside LTRRanker.order_results: same-domain / near-duplicate results are demoted instead of dropped. The similarity kernel is domain-dominant with a bag-of-words cosine secondary signal, and relevance is rank-based so it is robust to the model's compressed score magnitudes.

Remove the now-unused DomainLimitingRanker and its wrapping in search_setup and evaluate_remote.

## Performance evaluation

Benchmarked the re-ranking step (the only thing that changed) against the removed per-domain dedup pass, with the real LTR model loaded. Median wall time over synthetic candidate sets with a realistic domain mix.

**First MMR cut** — O(n²) with no cap, and `_cosine` recomputed both L2 norms on every comparison:

| n | `predict` | old domain-dedup | MMR |
|---|---|---|---|
| 100 | 2.1 ms | 0.21 ms | **37 ms** |
| 200 | 2.9 ms | 1.6 ms | **154 ms** |
| 500 | 5.2 ms | 3.9 ms | **946 ms** |

Real slowdown at large candidate counts, so it was optimised:
- precompute L2-normalised bag-of-words vectors → similarity is a plain sparse dot product (no per-comparison `sqrt`);
- only diversify the top `MMR_WINDOW = 50` candidates; the long tail (rarely seen) keeps relevance order, bounding the cost.

**After optimisation** — flat ~5 ms regardless of candidate count:

| n | `predict` | old domain-dedup | MMR |
|---|---|---|---|
| 50 | 1.7 ms | 0.11 ms | **4.8 ms** |
| 100 | 2.1 ms | 0.21 ms | **4.6 ms** |
| 200 | 2.9 ms | 1.6 ms | **4.6 ms** |
| 500 | 5.3 ms | 4.1 ms | **5.0 ms** |

MMR is now comparable to a single `model.predict` and on par with the old dedup pass at large n (5.0 vs 4.1 ms at n=500). End-to-end this is dwarfed by index retrieval/decompression and the Wikipedia HTTP call, so there is no meaningful slowdown.

Tradeoff: with `MMR_WINDOW = 50`, only the first 50 results are diversified; beyond that it is pure relevance order (plenty for the displayed pages, and an easy knob to raise if deeper diversity is ever wanted).

### Correctness check
Against the real LTR model, query "kitsas" now returns all four results (`kitsas.fi`, `artoh/kitsas`, `artoh/kitsasdocsy`, `artoh/kitsashealth`); previously `kitsasdocsy`/`kitsashealth` were dropped as `github.com` duplicates. Covered by new tests in `test/test_ltr_rank.py` (keeps all same-domain docs, demotes duplicates below fresh domains, bounded window/tail behaviour).


## Update: MMR extracted into a standalone `MMRRanker`

MMR has since been moved out of `LTRRanker.order_results` into a standalone `MMRRanker` decorator (`mwmbl/tinysearchengine/mmr_rank.py`) that wraps any `Ranker`, re-ranks its `search()` output, and delegates `complete()` / `get_raw_results()` (the same decorator shape as the removed `DomainLimitingRanker`). This lets us toggle diversity for evaluation and apply MMR on top of other rankers. Production wraps `LTRRanker` in `MMRRanker`, so live behaviour is unchanged; `LTRRanker` itself reverts to a plain relevance sort. Tests moved to `test/test_mmr_rank.py` (now also covering the wrapper's re-ranking and delegation).

## Ranking quality evaluation (with vs. without MMR)

Evaluated the LTR ranker against the remote index (`api.mwmbl.org`) over all 649 test queries (`rankings-test.csv`), with and without the `MMRRanker` wrapper. Both passes saw identical cached candidates, so only the re-ranking differs.

| Metric | No MMR | With MMR | Δ |
|---|---|---|---|
| **NDCG mean** | 0.2447 | **0.2651** | **+0.0205** |
| NDCG SEM | 0.0151 | 0.0159 | — |
| Proportion matched | 0.0367 | 0.0351 | −0.0015 |
| Wiki count mean | 1.48 | 1.08 | −0.41 |
| Predict time (s) | 0.138 | 0.143 | +0.005 |

- **NDCG improves +0.020 (~+8% relative), 0.245 → 0.265.** The comparison is paired over the same 649 queries, so the gain is more robust than the unpaired SEMs (~0.015) suggest — a modest but positive signal.
- **Proportion matched essentially unchanged** (−0.0015, within SEM): MMR only reorders the same candidate set, so the top-10 URL set barely moves.
- **Wikipedia results drop 1.48 → 1.08/query:** MMR demotes multiple `en.wikipedia.org` hits as same-domain duplicates — the intended diversification.
- **+5 ms/query** (138 → 143 ms), matching the bounded-cost design.

Caveat: during the run the Wikipedia external-fetch endpoint returned empty responses (handled gracefully and logged). Both passes ran identically with `include_wiki=True`, so the comparison is fair, but the absolute wiki counts are lower than they would be against a healthy wiki API.

**Conclusion:** MMR gives a measurable NDCG gain plus the intended domain diversification at negligible cost — supports keeping it enabled by default.
