### PR TITLE
Apply MMR diversity re-ranking to Super Search

### DIFF
--- a/mwmbl/tinysearchengine/super_search.py
+++ b/mwmbl/tinysearchengine/super_search.py
@@ -42,6 +42,7 @@ from mwmbl.search_auth import authenticate_user
 from mwmbl.search_setup import index_path, ltr_model
 from mwmbl.tinysearchengine.indexer import Document
 from mwmbl.tinysearchengine.ltr_rank import score_documents
+from mwmbl.tinysearchengine.mmr_rank import mmr_rerank
 from mwmbl.tinysearchengine.rank import score_result_whole
 from mwmbl.tinysearchengine.super_search_sources import SOURCES
 from mwmbl.tokenizer import tokenize
@@ -434,6 +435,11 @@ async def _emit_final_results(
 
         final_scores = await asyncio.to_thread(score_documents, ltr_model, query, unique)
         ranked = sorted(zip(unique, final_scores), key=lambda x: -x[1])[:final_limit]
+        # Diversify with MMR (demotes, never drops, same-domain / near-duplicate
+        # results) to match standard search — see MMRRanker in search_setup.py.
+        score_by_url = {doc.url: score for doc, score in ranked}
+        diversified = mmr_rerank([doc for doc, _ in ranked])
+        ranked = [(doc, score_by_url[doc.url]) for doc in diversified]
         key = tuple(doc.url for doc, _ in ranked)
         if key == last_results_key[0]:
             return

--- a/test/test_super_search.py
+++ b/test/test_super_search.py
@@ -304,6 +304,50 @@ def test_final_results_event_emitted(client, api_key, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_final_results_are_mmr_diversified(client, api_key, monkeypatch):
+    """The final ranking applies MMR diversity (as standard search does): a second
+    same-domain result is demoted below a lower-scored fresh-domain result, while
+    all results are retained (MMR demotes, never drops)."""
+    cache.delete(_super_search_monthly_key(api_key.user.id))
+    # Relevance order a > b > c. a and b share a domain (and text); c is a fresh
+    # domain. MMR should lift c above the second same-domain result b.
+    _stub_sources(monkeypatch, {
+        "hn": [
+            Document(title="Python alpha repo", url="https://github.com/x/alpha",
+                     extract="python alpha project"),
+            Document(title="Python beta repo", url="https://github.com/x/beta",
+                     extract="python beta project"),
+            Document(title="Python gamma site", url="https://example.org/gamma",
+                     extract="python gamma guide"),
+        ],
+    })
+    # Promotion scores, then descending final-ranking scores (consumed once per
+    # _emit_final_results call) all in the same a > b > c order.
+    _stub_scoring(monkeypatch, [0.9, 0.8, 0.7] * 4 + [0.0] * 30)
+
+    def fake_crawl(url, redis):
+        return {"url": url, "status": 200, "content": None}
+
+    monkeypatch.setattr("mwmbl.tinysearchengine.super_search.crawl_url", fake_crawl)
+
+    response = client.get("/api/v2/super-search/?q=python", HTTP_X_API_KEY=api_key.raw_key)
+    assert response.status_code == 200
+    events = _parse_sse(_read_stream(response))
+    final = [d for t, d in events if t == "results"][-1]["results"]
+    urls = [r["url"] for r in final]
+
+    # All retained (demoted, not dropped).
+    assert set(urls) == {
+        "https://github.com/x/alpha",
+        "https://github.com/x/beta",
+        "https://example.org/gamma",
+    }
+    # Most relevant stays first; fresh domain lifted above the 2nd same-domain result.
+    assert urls[0] == "https://github.com/x/alpha"
+    assert urls.index("https://example.org/gamma") < urls.index("https://github.com/x/beta")
+
+
+@pytest.mark.django_db
 def test_done_reports_pages_indexed(client, api_key, monkeypatch):
     """Results are indexed at the end and the count is reported in 'done'."""
     import mwmbl.tinysearchengine.super_search as ss


### PR DESCRIPTION
## Context

MMR (Maximal Marginal Relevance) diversity re-ranking demotes (never drops) near-duplicate / same-domain results so a single domain can't dominate the list. It lives in `mwmbl/tinysearchengine/mmr_rank.py` as the standalone `mmr_rerank` function plus an `MMRRanker` decorator, and standard search applies it via `MMRRanker` wrapping the `LTRRanker` (`search_setup.py`).

**Super Search never applied it.** Its final ranking in `_emit_final_results` scored candidate docs with the LTR model (`score_documents`) and sorted purely by descending relevance, so it lacked the domain diversity standard search has.

## Change

- Reuse the standalone `mmr_rerank` (the exact function `MMRRanker.search()` calls) to diversify the relevance-sorted final list in `_emit_final_results`.
- Map each doc's LTR score back by URL (URLs are already deduped) so the SSE `ResultItem` payload keeps real scores. The downstream dedup `key`, `last_results_key` check, and emit are unchanged.

Super Search now shares both the **same LTR model** (`ltr_model` via `score_documents`) and the **same diversity algorithm** (`mmr_rerank`) as standard search — without re-querying the index or Wikipedia. MMR cost stays bounded by `MMR_WINDOW` (50).

## Tests

Added `test_final_results_are_mmr_diversified`: two same-domain results plus a lower-scored fresh-domain result; asserts the fresh domain is lifted above the second same-domain result while all results are retained (MMR demotes, never drops). Existing `test/test_mmr_rank.py` already covers `mmr_rerank` correctness.

All 26 tests in `test/test_super_search.py` + `test/test_mmr_rank.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)