### PR TITLE
Fix Wikipedia overuse and stop logging user queries in wiki fetch path

### DIFF
--- a/mwmbl/tinysearchengine/rank.py
+++ b/mwmbl/tinysearchengine/rank.py
@@ -2,6 +2,8 @@ import html
 import json
 import math
 import re
+import threading
+import time
 import urllib
 from abc import abstractmethod
 from collections import defaultdict
@@ -13,6 +15,7 @@ from urllib.parse import urlparse
 
 import numpy as np
 from requests.adapters import HTTPAdapter, Retry
+from requests.exceptions import RetryError
 
 from mwmbl.format import get_query_regex
 from mwmbl.hn_top_domains_filtered import DOMAINS
@@ -260,7 +263,10 @@ class Ranker:
         return ranked_results
 
     def complete(self, q: str):
-        ordered_results, terms, completions = self.get_results(q, [])
+        # Autocomplete fires on every keystroke, so it must never trigger external_search
+        # (e.g. a live Wikipedia lookup) - that would multiply outbound requests by the
+        # length of every query typed and can get us rate-limited (see fix-wiki-overuse).
+        ordered_results, terms, completions = self.get_results(q, [], use_external_search=False)
         if len(ordered_results) == 0:
             # There are no results so suggest Google searches instead
             completion_queries = [' '.join(terms[:-1] + [t]) for t in completions]
@@ -275,7 +281,7 @@ class Ranker:
             completed = [' '.join(terms[:-1] + [t]) for t in adjusted_completions]
             return [q, urls + completed]
 
-    def get_results(self, q: str, additional_results: list[Document]):
+    def get_results(self, q: str, additional_results: list[Document], use_external_search: bool = True):
         logger.info(f"Get results with {len(additional_results)} additional results")
         terms = tokenize(q)
 
@@ -314,7 +320,7 @@ class Ranker:
             if items is not None:
                 pages += items
 
-        external_search_items = self.external_search(q)
+        external_search_items = self.external_search(q) if use_external_search else []
         ordered_results = self.order_results(terms, pages + additional_results + external_search_items, is_complete)
         deduplicated_results = deduplicate(curated_items + ordered_results, set())
         state_fixed = [fix_document_state(result) for result in deduplicated_results]
@@ -363,6 +369,25 @@ WIKI_URL_FORMAT = "https://en.wikipedia.org/wiki/{title}"
 WIKI_RETRY = Retry(total=4, backoff_factor=0.5, status_forcelist=(429, 502, 503, 504),
                    allowed_methods=frozenset({"GET"}), respect_retry_after_header=True)
 
+# If Wikipedia has already rate-limited us hard enough that WIKI_RETRY exhausted its
+# retries, hammering it again on the very next query just makes things worse. Trip a
+# process-local circuit breaker instead: stop calling Wikipedia for a cooldown period
+# and let the rate limit clear, rather than every subsequent request paying for its own
+# doomed retry-with-backoff sequence.
+WIKI_CIRCUIT_COOLDOWN_SECONDS = 60
+_wiki_circuit_lock = threading.Lock()
+_wiki_blocked_until = 0.0
+
+
+def _wiki_circuit_open() -> bool:
+    return time.monotonic() < _wiki_blocked_until
+
+
+def _trip_wiki_circuit():
+    global _wiki_blocked_until
+    with _wiki_circuit_lock:
+        _wiki_blocked_until = time.monotonic() + WIKI_CIRCUIT_COOLDOWN_SECONDS
+
 
 def get_wiki_url(title: str):
     return WIKI_URL_FORMAT.format(title=title.replace(" ", "_"))
@@ -376,6 +401,9 @@ def clean_html(s: str):
 
 
 def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
+    if _wiki_circuit_open():
+        return []
+
     escaped_query = urllib.parse.quote(s, safe='')
     headers = {
         'User-Agent': 'Mwmbl/0.1.0 (https://mwmbl.org; daoud@mwmbl.org) requests-cache'
@@ -385,13 +413,25 @@ def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
             session.mount("https://en.wikipedia.org", HTTPAdapter(max_retries=WIKI_RETRY))
             response = session.get(WIKI_SEARCH_API_URL.format(query=escaped_query), headers=headers, timeout=5)
             wiki_response = response.json()
-    except Exception:
-        logger.exception("Failed to fetch Wikipedia results for query %s", s)
+    except RetryError as e:
+        if "429" in str(e):
+            _trip_wiki_circuit()
+            logger.warning(
+                "Wikipedia is rate-limiting us; pausing wiki lookups for %ds", WIKI_CIRCUIT_COOLDOWN_SECONDS
+            )
+        else:
+            # Don't log str(e)/exc_info here - RetryError embeds the request URL, which
+            # embeds the (private) user query, and logger.exception would log both.
+            logger.warning("Failed to fetch Wikipedia results: %s", type(e).__name__)
+        return []
+    except Exception as e:
+        logger.warning("Failed to fetch Wikipedia results: %s", type(e).__name__)
         return []
 
     if 'query' not in wiki_response or 'search' not in wiki_response['query']:
         if 'error' in wiki_response:
-            logger.warning("Error in wiki response: %s", wiki_response['error'])
+            # Don't log the error body - it can echo back the (private) user query.
+            logger.warning("Wikipedia API returned an error response")
 
         return []
 

--- a/mwmbl/tinysearchengine/rank.py
+++ b/mwmbl/tinysearchengine/rank.py
@@ -393,6 +393,19 @@ def get_wiki_url(title: str):
     return WIKI_URL_FORMAT.format(title=title.replace(" ", "_"))
 
 
+def _is_wiki_rate_limited(e: RetryError) -> bool:
+    """True if a RetryError was caused by exhausting retries on 429s specifically.
+
+    Inspects the wrapped MaxRetryError's `reason` (e.g. "too many 429 error
+    responses") rather than str(e). str(e) also embeds the request URL - and with
+    it the user's (private) query - which both risks logging it and means a query
+    that happens to contain the substring "429" would be misread as a rate limit.
+    """
+    cause = e.args[0] if e.args else None
+    reason = getattr(cause, "reason", None)
+    return reason is not None and "429" in str(reason)
+
+
 HTML_TAG_REGEX = re.compile(r'<[^>]+>')
 
 
@@ -414,7 +427,7 @@ def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
             response = session.get(WIKI_SEARCH_API_URL.format(query=escaped_query), headers=headers, timeout=5)
             wiki_response = response.json()
     except RetryError as e:
-        if "429" in str(e):
+        if _is_wiki_rate_limited(e):
             _trip_wiki_circuit()
             logger.warning(
                 "Wikipedia is rate-limiting us; pausing wiki lookups for %ds", WIKI_CIRCUIT_COOLDOWN_SECONDS

--- a/test/test_rank.py
+++ b/test/test_rank.py
@@ -1,5 +1,12 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import RetryError
+from urllib3.exceptions import MaxRetryError, ResponseError
+
+from mwmbl.tinysearchengine import rank
 from mwmbl.tinysearchengine.indexer import Document
-from mwmbl.tinysearchengine.rank import HeuristicRanker
+from mwmbl.tinysearchengine.rank import HeuristicRanker, get_wiki_results
 
 
 def test_order_result():
@@ -15,3 +22,103 @@ def test_order_result():
     ordered_results = ranker.order_results(["bananas"], documents, True)
 
     assert ordered_results[0].title == 'Bananas and apples'
+
+
+class _TrackingRanker(HeuristicRanker):
+    """A ranker whose external_search (e.g. live Wikipedia lookups) is trackable."""
+
+    def __init__(self):
+        tiny_index = MagicMock()
+        tiny_index.retrieve.return_value = []
+        completer = MagicMock()
+        completer.complete.return_value = []
+        super().__init__(tiny_index, completer)
+        self.external_search_calls = []
+
+    def external_search(self, q):
+        self.external_search_calls.append(q)
+        return []
+
+
+def test_complete_never_triggers_external_search():
+    # Autocomplete fires on every keystroke, so it must never call external_search
+    # (e.g. a live Wikipedia lookup) - see fix-wiki-overuse.
+    ranker = _TrackingRanker()
+    ranker.complete("some quer")
+    assert ranker.external_search_calls == []
+
+
+def test_search_still_triggers_external_search():
+    ranker = _TrackingRanker()
+    ranker.search("some query", [])
+    assert ranker.external_search_calls == ["some query"]
+
+
+def _make_retry_error(status_code: int) -> RetryError:
+    reason = ResponseError(f"too many {status_code} error responses")
+    max_retry_error = MaxRetryError(
+        pool=None, url="https://en.wikipedia.org/w/api.php?srsearch=secret-query", reason=reason
+    )
+    return RetryError(max_retry_error)
+
+
+@pytest.fixture(autouse=True)
+def _reset_wiki_circuit():
+    rank._wiki_blocked_until = 0.0
+    yield
+    rank._wiki_blocked_until = 0.0
+
+
+def _get_wiki_results_with_session(session):
+    with patch.object(rank, "request_cache") as mock_request_cache:
+        mock_request_cache.return_value.__enter__.return_value = session
+        return get_wiki_results("query", 5)
+
+
+def test_wiki_429_retry_error_trips_circuit_breaker():
+    session = MagicMock()
+    session.get.side_effect = _make_retry_error(429)
+
+    results = _get_wiki_results_with_session(session)
+
+    assert results == []
+    assert rank._wiki_circuit_open()
+
+
+def test_wiki_non_429_retry_error_does_not_trip_circuit_breaker():
+    session = MagicMock()
+    session.get.side_effect = _make_retry_error(503)
+
+    results = _get_wiki_results_with_session(session)
+
+    assert results == []
+    assert not rank._wiki_circuit_open()
+
+
+def test_wiki_query_text_containing_429_is_not_mistaken_for_rate_limit():
+    # Regression: matching on str(e) (which embeds the request URL/query) meant a
+    # query merely containing "429" could be misread as a 429 rate limit.
+    session = MagicMock()
+    session.get.side_effect = _make_retry_error(503)
+
+    _get_wiki_results_with_session(session)
+
+    assert not rank._wiki_circuit_open()
+
+
+def test_open_wiki_circuit_short_circuits_without_calling_wikipedia():
+    rank._trip_wiki_circuit()
+
+    with patch.object(rank, "request_cache") as mock_request_cache:
+        results = get_wiki_results("query", 5)
+
+    mock_request_cache.assert_not_called()
+    assert results == []
+
+
+def test_is_wiki_rate_limited_detects_429_reason():
+    assert rank._is_wiki_rate_limited(_make_retry_error(429))
+
+
+def test_is_wiki_rate_limited_ignores_non_429_reason():
+    assert not rank._is_wiki_rate_limited(_make_retry_error(503))


### PR DESCRIPTION
Autocomplete-as-you-type was calling get_results() with the same external_search path as a real search, so every keystroke fired a live Wikipedia search API call. Under real traffic that flooded en.wikipedia.org and triggered sustained 429s. Autocomplete now skips external_search entirely, and get_wiki_results trips a 60s process-local circuit breaker after Wikipedia rate-limits us, instead of every subsequent query paying for its own doomed retry-with-backoff sequence.

Also stop logging the user's query on wiki-fetch failures: RetryError and MediaWiki error bodies can embed the raw query, so failures are now logged by exception type / generically instead.