### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Like "mumble". I live in
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mwmbl/mwmbl&type=Date)](https://www.star-history.com/#mwmbl/mwmbl&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mwmbl/mwmbl&type=Date)](https://star-history.dera.page/#mwmbl/mwmbl&Date)
 
 Acknowledgements
 ================


### PR DESCRIPTION
The star history chart in the README is currently broken. The GitHub stargazer API it depended on is restricted, so the chart no longer renders. This switches the chart to a working alternative service that does not require an API token, restoring the chart.