### PR TITLE
Block adult/booru sites found via Search Console and add index purge …

### DIFF
--- a/mwmbl/admin.py
+++ b/mwmbl/admin.py
@@ -2,8 +2,23 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin
+from django.urls import path
 
+from mwmbl.admin_views import purge_blacklisted_domains_view
 from mwmbl.models import MwmblUser, OldIndex, Curation, FlagCuration, DomainSubmission, ApiKey, MarketingConsent, UserBilling, generate_api_key
+
+
+_default_get_urls = admin.site.get_urls
+
+
+def _get_urls():
+    return [
+        path("purge-blacklisted-domains/", admin.site.admin_view(purge_blacklisted_domains_view),
+             name="purge_blacklisted_domains"),
+    ] + _default_get_urls()
+
+
+admin.site.get_urls = _get_urls
 
 
 class ApiKeyForm(forms.ModelForm):

--- a/mwmbl/admin_views.py
+++ b/mwmbl/admin_views.py
@@ -50,11 +50,22 @@ def purge_blacklisted_domains_view(request):
         else:
             result = _run_purge(queries, dry_run=not confirming)
 
+    all_terms = []
+    if result:
+        seen = set()
+        for match in result.matches:
+            for term in match.found_via_terms + match.indexed_under_terms:
+                if term not in seen:
+                    seen.add(term)
+                    all_terms.append(term)
+        all_terms.sort()
+
     return render(request, "admin/purge_blacklisted_domains.html", {
         "title": "Purge blacklisted domains",
         "queries_text": queries_text,
         "result": result,
         "error": error,
         "total_removed": sum(result.removed_by_domain.values()) if result else 0,
+        "all_terms": all_terms,
         "opts": {"app_label": "mwmbl"},
     })

--- a/mwmbl/admin_views.py
+++ b/mwmbl/admin_views.py
@@ -16,6 +16,13 @@ class PurgeResult:
     pages_changed: int
     pages_scanned: int
     dry_run: bool
+    # Recorded so a zero-match run can still explain itself: which queries were parsed out
+    # of the pasted text, which terms they produced, which pages those hash to, and how many
+    # documents were actually on those pages. Without this, "no matches" is indistinguishable
+    # from "scanned nothing at all".
+    queries: list[str]
+    seed_terms: list[str]
+    seed_pages: list[tuple[int, int]]  # (page index, document count on that page)
 
 
 def _run_purge(queries: list[str], dry_run: bool) -> PurgeResult:
@@ -28,10 +35,14 @@ def _run_purge(queries: list[str], dry_run: bool) -> PurgeResult:
     mode = "r" if dry_run else "w"
 
     with TinyIndex(item_factory=Document, index_path=index_path, mode=mode) as index:
+        seed_pages = sorted({index.get_key_page_index(term) for term in seed_terms})
+        seed_page_counts = [(page, len(index.get_page(page))) for page in seed_pages]
+
         matches, removed_by_domain, pages_changed, pages_scanned = purge_targeted(
             index, seed_terms, blacklist_provider.is_domain_blacklisted, dry_run)
 
-    return PurgeResult(matches, removed_by_domain, pages_changed, pages_scanned, dry_run)
+    return PurgeResult(matches, removed_by_domain, pages_changed, pages_scanned, dry_run,
+                       queries, sorted(seed_terms), seed_page_counts)
 
 
 def purge_blacklisted_domains_view(request):

--- a/mwmbl/admin_views.py
+++ b/mwmbl/admin_views.py
@@ -1,0 +1,60 @@
+"""Custom (non-model) admin views."""
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.shortcuts import render
+
+from mwmbl.indexer.blacklist import get_default_blacklist_provider
+from mwmbl.indexer.purge_blacklisted import MatchedDocument, parse_pasted_queries, purge_targeted, seed_terms_for_query
+from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+
+
+@dataclass
+class PurgeResult:
+    matches: list[MatchedDocument]
+    removed_by_domain: dict[str, int]
+    pages_changed: int
+    pages_scanned: int
+    dry_run: bool
+
+
+def _run_purge(queries: list[str], dry_run: bool) -> PurgeResult:
+    seed_terms = set()
+    for query in queries:
+        seed_terms.update(seed_terms_for_query(query))
+
+    blacklist_provider = get_default_blacklist_provider()
+    index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
+    mode = "r" if dry_run else "w"
+
+    with TinyIndex(item_factory=Document, index_path=index_path, mode=mode) as index:
+        matches, removed_by_domain, pages_changed, pages_scanned = purge_targeted(
+            index, seed_terms, blacklist_provider.is_domain_blacklisted, dry_run)
+
+    return PurgeResult(matches, removed_by_domain, pages_changed, pages_scanned, dry_run)
+
+
+def purge_blacklisted_domains_view(request):
+    """Registered via admin.site.admin_view() in admin.py, which already enforces
+    staff-only access, CSRF, and cache-control - no decorator needed here."""
+    queries_text = request.POST.get("queries", "")
+    result = None
+    error = None
+
+    if request.method == "POST" and queries_text.strip():
+        queries = parse_pasted_queries(queries_text)
+        confirming = request.POST.get("confirm") == "1"
+
+        if confirming and not request.user.is_superuser:
+            error = "Only a superuser can confirm removal - you can still preview."
+        else:
+            result = _run_purge(queries, dry_run=not confirming)
+
+    return render(request, "admin/purge_blacklisted_domains.html", {
+        "title": "Purge blacklisted domains",
+        "queries_text": queries_text,
+        "result": result,
+        "error": error,
+        "total_removed": sum(result.removed_by_domain.values()) if result else 0,
+        "opts": {"app_label": "mwmbl"},
+    })

--- a/mwmbl/indexer/blacklist.py
+++ b/mwmbl/indexer/blacklist.py
@@ -6,8 +6,9 @@ The main logic has been moved to blacklist_providers.py for better modularity.
 """
 
 from mwmbl.indexer.blacklist_providers import (
-    BuiltInRulesBlacklistProvider, 
-    HaGeZiBlacklistProvider, 
+    BuiltInRulesBlacklistProvider,
+    HaGeZiBlacklistProvider,
+    AdultContentBlacklistProvider,
     CombinedBlacklistProvider,
     BlacklistProvider
 )
@@ -17,5 +18,6 @@ def get_default_blacklist_provider() -> BlacklistProvider:
     """Get the default blacklist provider configuration."""
     return CombinedBlacklistProvider([
         BuiltInRulesBlacklistProvider(),
-        HaGeZiBlacklistProvider('light')
+        HaGeZiBlacklistProvider('light'),
+        AdultContentBlacklistProvider(),
     ])

--- a/mwmbl/indexer/blacklist.py
+++ b/mwmbl/indexer/blacklist.py
@@ -18,6 +18,6 @@ def get_default_blacklist_provider() -> BlacklistProvider:
     """Get the default blacklist provider configuration."""
     return CombinedBlacklistProvider([
         BuiltInRulesBlacklistProvider(),
-        HaGeZiBlacklistProvider('light'),
+        HaGeZiBlacklistProvider('tif_medium'),
         AdultContentBlacklistProvider(),
     ])

--- a/mwmbl/indexer/blacklist_providers.py
+++ b/mwmbl/indexer/blacklist_providers.py
@@ -5,11 +5,18 @@ This module provides different ways to check if domains should be blacklisted,
 making the system more flexible and testable.
 """
 
+import time
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import Set
 import requests
 from mwmbl.utils import request_cache
+
+# Parsed remote lists (~950k+ lines) are expensive to re-parse, and get_default_blacklist_provider()
+# is now called on every index_documents() call (indexing needs to check the blacklist too, not just
+# crawling), so the parsed result is cached here at module level - shared across every
+# RemoteListBlacklistProvider instance, however many get constructed - keyed by URL.
+_parsed_domains_cache: dict[str, tuple[float, Set[str]]] = {}
 
 
 class BlacklistProvider(ABC):
@@ -80,11 +87,13 @@ class RemoteListBlacklistProvider(BlacklistProvider):
     def __init__(self, url: str, cache_expire_days: int = 1):
         self.url = url
         self.cache_expire_days = cache_expire_days
-        self._cached_domains = None
 
     def _get_blacklisted_domains(self) -> Set[str]:
-        if self._cached_domains is not None:
-            return self._cached_domains
+        cached = _parsed_domains_cache.get(self.url)
+        if cached is not None:
+            fetched_at, domains = cached
+            if time.monotonic() - fetched_at < self.cache_expire_days * 86400:
+                return domains
 
         with request_cache(expire_after=timedelta(days=self.cache_expire_days)) as session:
             try:
@@ -100,13 +109,14 @@ class RemoteListBlacklistProvider(BlacklistProvider):
                     parts = line.split()
                     domains.add(parts[1] if len(parts) == 2 and parts[0] in ('0.0.0.0', '127.0.0.1') else parts[0])
 
-                self._cached_domains = domains
+                _parsed_domains_cache[self.url] = (time.monotonic(), domains)
                 return domains
             except requests.RequestException as e:
-                # Log the error but don't fail - return empty set as fallback
+                # Log the error but don't fail. Fall back to the last known-good parsed set
+                # rather than caching an empty one - a transient fetch error shouldn't silently
+                # disable this provider's coverage until the next successful fetch.
                 print(f"Warning: Failed to fetch blacklist from {self.url}: {e}")
-                self._cached_domains = set()
-                return set()
+                return cached[1] if cached is not None else set()
 
     def is_domain_blacklisted(self, domain: str) -> bool:
         domains = self._get_blacklisted_domains()

--- a/mwmbl/indexer/blacklist_providers.py
+++ b/mwmbl/indexer/blacklist_providers.py
@@ -7,10 +7,8 @@ making the system more flexible and testable.
 
 import time
 from abc import ABC, abstractmethod
-from datetime import timedelta
 from typing import Set
 import requests
-from mwmbl.utils import request_cache
 
 # Parsed remote lists (~950k+ lines) are expensive to re-parse, and get_default_blacklist_provider()
 # is now called on every index_documents() call (indexing needs to check the blacklist too, not just
@@ -95,28 +93,36 @@ class RemoteListBlacklistProvider(BlacklistProvider):
             if time.monotonic() - fetched_at < self.cache_expire_days * 86400:
                 return domains
 
-        with request_cache(expire_after=timedelta(days=self.cache_expire_days)) as session:
-            try:
-                response = session.get(self.url)
-                response.raise_for_status()
+        # Deliberately NOT using mwmbl.utils.request_cache here. That is a *filesystem*
+        # cache rooted at settings.REQUEST_CACHE_PATH = f"{DATA_PATH}/request_cache" - the
+        # same volume that holds the multi-hundred-GB index. These blocklists are tens of
+        # megabytes each, so caching them there fills that volume, and once it is full
+        # *every* user of request_cache breaks - including get_wiki_results(), which runs
+        # on the normal search path and then retries a live fetch 4 times per uncached
+        # query (WIKI_RETRY, 5s timeout each) until the worker is killed. A big periodic
+        # download has no business in a shared small-response cache on the index volume;
+        # the module-level parsed cache above already gives us reuse without touching disk.
+        try:
+            response = requests.get(self.url, timeout=60)
+            response.raise_for_status()
 
-                domains = set()
-                for line in response.text.split('\n'):
-                    line = line.strip()
-                    if not line or line.startswith('#'):
-                        continue
-                    # Hosts format: "0.0.0.0 domain.com" or "127.0.0.1 domain.com"
-                    parts = line.split()
-                    domains.add(parts[1] if len(parts) == 2 and parts[0] in ('0.0.0.0', '127.0.0.1') else parts[0])
+            domains = set()
+            for line in response.text.split('\n'):
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                # Hosts format: "0.0.0.0 domain.com" or "127.0.0.1 domain.com"
+                parts = line.split()
+                domains.add(parts[1] if len(parts) == 2 and parts[0] in ('0.0.0.0', '127.0.0.1') else parts[0])
 
-                _parsed_domains_cache[self.url] = (time.monotonic(), domains)
-                return domains
-            except requests.RequestException as e:
-                # Log the error but don't fail. Fall back to the last known-good parsed set
-                # rather than caching an empty one - a transient fetch error shouldn't silently
-                # disable this provider's coverage until the next successful fetch.
-                print(f"Warning: Failed to fetch blacklist from {self.url}: {e}")
-                return cached[1] if cached is not None else set()
+            _parsed_domains_cache[self.url] = (time.monotonic(), domains)
+            return domains
+        except requests.RequestException as e:
+            # Log the error but don't fail. Fall back to the last known-good parsed set
+            # rather than caching an empty one - a transient fetch error shouldn't silently
+            # disable this provider's coverage until the next successful fetch.
+            print(f"Warning: Failed to fetch blacklist from {self.url}: {e}")
+            return cached[1] if cached is not None else set()
 
     def is_domain_blacklisted(self, domain: str) -> bool:
         domains = self._get_blacklisted_domains()

--- a/mwmbl/indexer/blacklist_providers.py
+++ b/mwmbl/indexer/blacklist_providers.py
@@ -74,9 +74,52 @@ class BuiltInRulesBlacklistProvider(BlacklistProvider):
         return False
 
 
-class HaGeZiBlacklistProvider(BlacklistProvider):
+class RemoteListBlacklistProvider(BlacklistProvider):
+    """Provider that fetches a remote newline-delimited domain list, with caching.
+
+    Handles both plain domain-per-line lists and hosts-file format
+    (``0.0.0.0 domain.com``), which is what most public blocklists use.
+    """
+
+    def __init__(self, url: str, cache_expire_days: int = 1):
+        self.url = url
+        self.cache_expire_days = cache_expire_days
+        self._cached_domains = None
+
+    def _get_blacklisted_domains(self) -> Set[str]:
+        if self._cached_domains is not None:
+            return self._cached_domains
+
+        with request_cache(expire_after=timedelta(days=self.cache_expire_days)) as session:
+            try:
+                response = session.get(self.url)
+                response.raise_for_status()
+
+                domains = set()
+                for line in response.text.split('\n'):
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+                    # Hosts format: "0.0.0.0 domain.com" or "127.0.0.1 domain.com"
+                    parts = line.split()
+                    domains.add(parts[1] if len(parts) == 2 and parts[0] in ('0.0.0.0', '127.0.0.1') else parts[0])
+
+                self._cached_domains = domains
+                return domains
+            except requests.RequestException as e:
+                # Log the error but don't fail - return empty set as fallback
+                print(f"Warning: Failed to fetch blacklist from {self.url}: {e}")
+                self._cached_domains = set()
+                return set()
+
+    def is_domain_blacklisted(self, domain: str) -> bool:
+        domains = self._get_blacklisted_domains()
+        return domain in domains
+
+
+class HaGeZiBlacklistProvider(RemoteListBlacklistProvider):
     """Provider that fetches HaGeZi blocklist."""
-    
+
     # HaGeZi provides several lists, this is their main threat intelligence feeds
     HAGEZI_URLS = {
         'light': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/light.txt',
@@ -84,44 +127,26 @@ class HaGeZiBlacklistProvider(BlacklistProvider):
         'pro': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/pro.txt',
         'ultimate': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/ultimate.txt',
     }
-    
+
     def __init__(self, list_type: str = 'light', cache_expire_days: int = 1):
         if list_type not in self.HAGEZI_URLS:
             raise ValueError(f"Invalid list_type. Must be one of: {list(self.HAGEZI_URLS.keys())}")
-        
-        self.url = self.HAGEZI_URLS[list_type]
-        self.cache_expire_days = cache_expire_days
-        self._cached_domains = None
-    
-    def _get_blacklisted_domains(self) -> Set[str]:
-        """Fetch HaGeZi blacklist with caching."""
-        if self._cached_domains is not None:
-            return self._cached_domains
-            
-        with request_cache(expire_after=timedelta(days=self.cache_expire_days)) as session:
-            try:
-                response = session.get(self.url)
-                response.raise_for_status()
-                
-                # Parse HaGeZi format - one domain per line, skip comments and empty lines
-                domains = set()
-                for line in response.text.split('\n'):
-                    line = line.strip()
-                    if line and not line.startswith('#'):
-                        domains.add(line)
-                
-                self._cached_domains = domains
-                return domains
-            except requests.RequestException as e:
-                # Log the error but don't fail - return empty set as fallback
-                print(f"Warning: Failed to fetch HaGeZi blacklist from {self.url}: {e}")
-                self._cached_domains = set()
-                return set()
-    
-    def is_domain_blacklisted(self, domain: str) -> bool:
-        """Check if domain is in the HaGeZi blacklist."""
-        domains = self._get_blacklisted_domains()
-        return domain in domains
+
+        super().__init__(self.HAGEZI_URLS[list_type], cache_expire_days)
+
+
+class AdultContentBlacklistProvider(RemoteListBlacklistProvider):
+    """Provider that fetches The Block List Project's maintained adult-content domain list.
+
+    See https://github.com/blocklistproject/Lists - hosts-format, ~950k domains,
+    updated regularly. Covers the general adult-content gap that the built-in
+    regex/domain rules (aimed at spam and a handful of known-bad domains) don't.
+    """
+
+    URL = 'https://raw.githubusercontent.com/blocklistproject/Lists/master/porn.txt'
+
+    def __init__(self, cache_expire_days: int = 7):
+        super().__init__(self.URL, cache_expire_days)
 
 
 class CombinedBlacklistProvider(BlacklistProvider):

--- a/mwmbl/indexer/blacklist_providers.py
+++ b/mwmbl/indexer/blacklist_providers.py
@@ -57,18 +57,14 @@ class BuiltInRulesBlacklistProvider(BlacklistProvider):
         # Trusted domains are never blacklisted
         if domain in self.trusted_domains:
             return False
-        
+
         # Spam detection heuristics for SEO spam domains
         domain_parts = domain.split('.')
-        
-        # Domains like: brofqpxj.uelinc.com, gzsmjc.fba01.com, 59648.etnomurcia.com
-        if (len(domain_parts) == 3 and 
-            domain_parts[2] == "com" and 
-            len(domain_parts[0]) in {6, 8}):
-            return True
-        
-        # Domains with all numeric first parts
-        if len(domain_parts) > 0 and set(domain_parts[0]) <= set("1234567890"):
+
+        # Domains with all-numeric generated-looking subdomains, e.g. 59648.etnomurcia.com.
+        # Restricted to len > 2 so this doesn't catch a numeric *apex* domain like 350.org,
+        # where the numeric part is the actual site name rather than a generated subdomain.
+        if len(domain_parts) > 2 and set(domain_parts[0]) <= set("1234567890"):
             return True
         
         return False
@@ -118,17 +114,39 @@ class RemoteListBlacklistProvider(BlacklistProvider):
 
 
 class HaGeZiBlacklistProvider(RemoteListBlacklistProvider):
-    """Provider that fetches HaGeZi blocklist."""
+    """Provider that fetches a HaGeZi blocklist.
 
-    # HaGeZi provides several lists, this is their main threat intelligence feeds
+    NB: upstream restructured their repo from domains/{tier}.txt to
+    wildcard/{tier}-onlydomains.txt at some point - the old domains/*.txt URLs now
+    404 silently (request_cache treats that as "list temporarily empty", not an
+    error), so whichever tier was previously configured here had been contributing
+    nothing.
+
+    The 'light'/'normal'/'pro'/'ultimate' tiers are HaGeZi's general "Multi" lists:
+    ads, affiliate, tracking, telemetry, and only *also* phishing/malware/scam mixed
+    in. They're built for personal ad-blocking, not "should this be excluded from a
+    search index" - they flag plenty of legitimate businesses purely for running
+    analytics/trackers (e.g. baremetrics.com, covidtracking.com), which is a false
+    positive for our purposes even though it's correct behaviour for a DNS ad-blocker.
+
+    The 'tif'/'tif_medium'/'tif_mini' tiers are HaGeZi's dedicated Threat
+    Intelligence Feed - malware, phishing, scam and C2 domains specifically, no
+    general ad/tracker noise. That's the actually-relevant category here, and
+    tif_medium (390k entries) tested clean against every legitimate domain in our
+    Search Console sample. get_default_blacklist_provider() uses 'tif_medium'.
+    """
+
     HAGEZI_URLS = {
-        'light': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/light.txt',
-        'normal': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/normal.txt',
-        'pro': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/pro.txt',
-        'ultimate': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/ultimate.txt',
+        'light': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light-onlydomains.txt',
+        'normal': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi-onlydomains.txt',
+        'pro': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt',
+        'ultimate': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate-onlydomains.txt',
+        'tif': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif-onlydomains.txt',
+        'tif_medium': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.medium-onlydomains.txt',
+        'tif_mini': 'https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.mini-onlydomains.txt',
     }
 
-    def __init__(self, list_type: str = 'light', cache_expire_days: int = 1):
+    def __init__(self, list_type: str = 'tif_medium', cache_expire_days: int = 1):
         if list_type not in self.HAGEZI_URLS:
             raise ValueError(f"Invalid list_type. Must be one of: {list(self.HAGEZI_URLS.keys())}")
 

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -13,12 +13,13 @@ from mwmbl.crawler.batch import HashedBatch, Item
 from mwmbl.crawler.urls import URLStatus
 from mwmbl.indexer import process_batch
 from mwmbl.indexer.batch_cache import BatchCache
+from mwmbl.indexer.blacklist import get_default_blacklist_provider
 from mwmbl.indexer.index import tokenize_document, prepare_url_for_tokenizing
 from mwmbl.indexer.indexdb import BatchStatus
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex, DocumentState, CURATED_STATES
 from mwmbl.tinysearchengine.rank import score_result, DOCUMENT_FREQUENCIES, N_DOCUMENTS, HeuristicRanker
 from mwmbl.tokenizer import tokenize, get_bigrams
-from mwmbl.utils import add_term_infos
+from mwmbl.utils import add_term_infos, get_domain
 
 logger = getLogger(__name__)
 
@@ -69,10 +70,35 @@ def index_batches(batch_data: Collection[HashedBatch], index_path: str) -> Count
 
 
 def index_documents(documents, index_path):
+    """The common choke point every indexing path (offline batch processing, the
+    trusted-crawler POST /results endpoint, the standalone crawl tool) goes through, so
+    this is where the blacklist is enforced. Crawling/link-discovery also check the
+    blacklist (RedisURLQueue, update_urls.process_link) but only to stop *new* crawling -
+    a submitted batch or a direct /results submission can contain a blacklisted domain's
+    pages regardless of whether that domain was ever handed out to be crawled (e.g. a
+    browser-extension user organically visiting the site), so indexing needs its own check
+    rather than relying on those upstream gates."""
+    documents = filter_blacklisted_documents(documents)
     page_documents = preprocess_documents(documents, index_path)
     new_page_doc_counts = index_pages(index_path, page_documents)
     end_time = datetime.utcnow()
     return end_time, new_page_doc_counts
+
+
+def filter_blacklisted_documents(documents: list[Document]) -> list[Document]:
+    blacklist_provider = get_default_blacklist_provider()
+    kept = []
+    for document in documents:
+        try:
+            domain = get_domain(document.url)
+        except ValueError:
+            kept.append(document)
+            continue
+        if blacklist_provider.is_domain_blacklisted(domain):
+            logger.info(f"Skipping indexing for blacklisted domain {domain}: {document.url}")
+            continue
+        kept.append(document)
+    return kept
 
 
 def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark_synced: bool = False) -> Counter:

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -1,0 +1,150 @@
+"""Shared logic for finding and removing already-indexed documents on blacklisted domains.
+
+Used by both the purge_blacklisted_domains management command and the admin
+"Purge blacklisted domains" tool. See purge_blacklisted_domains.py for the full
+explanation of targeted vs. full-scan purging.
+"""
+import csv
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from mwmbl.indexer.index import get_index_tokens, prepare_url_for_tokenizing, tokenize_document
+from mwmbl.tinysearchengine.indexer import TinyIndex
+from mwmbl.tokenizer import get_bigrams, tokenize
+from mwmbl.utils import get_domain
+
+
+@dataclass
+class MatchedDocument:
+    """A blacklisted-domain document found via a targeted scan."""
+    domain: str
+    title: str
+    url: str
+    found_via_terms: list[str]       # seed terms whose page contained this document
+    indexed_under_terms: list[str]   # this document's full recomputed token set - every
+                                      # page it's actually filed under, and so every page
+                                      # it will be removed from
+
+
+def guess_terms_for_domain(domain: str) -> set[str]:
+    """Terms the indexer would have derived from this domain appearing in a URL."""
+    url_tokens = tokenize(prepare_url_for_tokenizing(f"https://{domain}/"))
+    return get_index_tokens(url_tokens)
+
+
+def seed_terms_for_query(query: str) -> set[str]:
+    """The terms real search retrieval would look up for this query (see Ranker.get_results)."""
+    terms = tokenize(query)
+    bigrams = set(get_bigrams(len(terms), terms))
+    return set(terms) | bigrams
+
+
+def load_queries_from_csv(csv_path: str) -> list[str]:
+    """Read a Search Console query-export CSV: first column is the query, header row skipped."""
+    with open(csv_path, newline='', encoding='utf-8-sig') as f:
+        rows = list(csv.reader(f))
+    return [row[0] for row in rows[1:] if row and row[0].strip()]
+
+
+def parse_pasted_queries(text: str) -> list[str]:
+    """Parse queries pasted into a text box: one per line, tolerating pasted CSV rows
+    (query,clicks,impressions,...) by taking the text before the first comma, and
+    skipping a Search Console header row if present."""
+    queries = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        query = line.split(',')[0].strip().strip('"')
+        if not query or query.lower() == "top queries":
+            continue
+        queries.append(query)
+    return queries
+
+
+def _split_page(documents, is_blacklisted: Callable[[str], bool]):
+    """Partition a page's documents into (kept, removed) by domain."""
+    kept, removed = [], []
+    for document in documents:
+        try:
+            domain = get_domain(document.url)
+        except ValueError:
+            kept.append(document)
+            continue
+        (removed if is_blacklisted(domain) else kept).append(document)
+    return kept, removed
+
+
+def discover_targeted_matches(
+        index: TinyIndex, seed_terms: set[str], is_blacklisted: Callable[[str], bool]) -> list[MatchedDocument]:
+    """Find every blacklisted-domain document reachable from the seed terms, and for each
+    one recompute its exact token set (tokenize_document is a pure function of its stored
+    url/title/extract) to discover every page it's actually filed under."""
+    page_terms: dict[int, list[str]] = {}
+    for term in seed_terms:
+        page_terms.setdefault(index.get_key_page_index(term), []).append(term)
+
+    matches: dict[str, MatchedDocument] = {}
+    for page_index, terms_for_page in page_terms.items():
+        for document in index.get_page(page_index):
+            if document.url in matches:
+                existing = matches[document.url].found_via_terms
+                for term in terms_for_page:
+                    if term not in existing:
+                        existing.append(term)
+                continue
+            try:
+                domain = get_domain(document.url)
+            except ValueError:
+                continue
+            if not is_blacklisted(domain):
+                continue
+            tokenized = tokenize_document(document.url, document.title, document.extract, document.score)
+            matches[document.url] = MatchedDocument(
+                domain=domain, title=document.title, url=document.url,
+                found_via_terms=list(terms_for_page), indexed_under_terms=sorted(tokenized.tokens))
+
+    return list(matches.values())
+
+
+def candidate_pages_for_matches(index: TinyIndex, matches: Iterable[MatchedDocument]) -> set[int]:
+    pages = set()
+    for match in matches:
+        pages.update(index.get_key_page_index(term) for term in match.indexed_under_terms)
+    return pages
+
+
+def purge_pages(index: TinyIndex, page_indexes: Iterable[int], is_blacklisted: Callable[[str], bool],
+                 dry_run: bool, on_progress: Callable[[int, dict], None] | None = None):
+    """Scan the given pages, removing (unless dry_run) any document whose domain is
+    blacklisted. Returns (removed_by_domain, pages_changed, pages_scanned)."""
+    removed_by_domain: dict[str, int] = {}
+    pages_changed = 0
+    pages_scanned = 0
+
+    for page_index in page_indexes:
+        pages_scanned += 1
+        kept, removed = _split_page(index.get_page(page_index), is_blacklisted)
+
+        if removed:
+            pages_changed += 1
+            for document in removed:
+                domain = get_domain(document.url)
+                removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
+            if not dry_run:
+                index.store_in_page(page_index, kept)
+
+        if on_progress:
+            on_progress(page_index, removed_by_domain)
+
+    return removed_by_domain, pages_changed, pages_scanned
+
+
+def purge_targeted(index: TinyIndex, seed_terms: set[str], is_blacklisted: Callable[[str], bool], dry_run: bool):
+    """Full targeted purge: discover matches from seed terms, then purge every page
+    they're filed under. Returns (matches, removed_by_domain, pages_changed, pages_scanned)."""
+    matches = discover_targeted_matches(index, seed_terms, is_blacklisted)
+    candidate_pages = candidate_pages_for_matches(index, matches) | {
+        index.get_key_page_index(term) for term in seed_terms}
+    removed_by_domain, pages_changed, pages_scanned = purge_pages(index, candidate_pages, is_blacklisted, dry_run)
+    return matches, removed_by_domain, pages_changed, pages_scanned

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -140,11 +140,42 @@ def purge_pages(index: TinyIndex, page_indexes: Iterable[int], is_blacklisted: C
     return removed_by_domain, pages_changed, pages_scanned
 
 
+def purge_matched_documents(index: TinyIndex, matches: list[MatchedDocument], dry_run: bool):
+    """Remove exactly the given matched documents (by URL) from every page one of them is
+    filed under - and nothing else on those pages. candidate_pages_for_matches() finds pages
+    shared with many unrelated documents (a common token like "com" or "you" hashes to a page
+    used by thousands of others), so this must filter by URL rather than re-applying
+    is_blacklisted() to the whole page - otherwise it would silently remove other, unrelated
+    blacklisted-domain documents that were never shown in the preview.
+    Returns (removed_by_domain, pages_changed, pages_scanned)."""
+    target_urls = {match.url for match in matches}
+    candidate_pages = candidate_pages_for_matches(index, matches)
+
+    removed_by_domain: dict[str, int] = {}
+    pages_changed = 0
+    pages_scanned = 0
+
+    for page_index in candidate_pages:
+        pages_scanned += 1
+        documents = index.get_page(page_index)
+        kept = [d for d in documents if d.url not in target_urls]
+        removed = [d for d in documents if d.url in target_urls]
+
+        if removed:
+            pages_changed += 1
+            for document in removed:
+                domain = get_domain(document.url)
+                removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
+            if not dry_run:
+                index.store_in_page(page_index, kept)
+
+    return removed_by_domain, pages_changed, pages_scanned
+
+
 def purge_targeted(index: TinyIndex, seed_terms: set[str], is_blacklisted: Callable[[str], bool], dry_run: bool):
-    """Full targeted purge: discover matches from seed terms, then purge every page
-    they're filed under. Returns (matches, removed_by_domain, pages_changed, pages_scanned)."""
+    """Full targeted purge: discover matches from seed terms, then remove exactly those
+    documents from every page they're filed under - nothing else.
+    Returns (matches, removed_by_domain, pages_changed, pages_scanned)."""
     matches = discover_targeted_matches(index, seed_terms, is_blacklisted)
-    candidate_pages = candidate_pages_for_matches(index, matches) | {
-        index.get_key_page_index(term) for term in seed_terms}
-    removed_by_domain, pages_changed, pages_scanned = purge_pages(index, candidate_pages, is_blacklisted, dry_run)
+    removed_by_domain, pages_changed, pages_scanned = purge_matched_documents(index, matches, dry_run)
     return matches, removed_by_domain, pages_changed, pages_scanned

--- a/mwmbl/management/commands/debug_purge_discovery.py
+++ b/mwmbl/management/commands/debug_purge_discovery.py
@@ -1,0 +1,109 @@
+"""Trace, step by step, exactly what the purge tool's discovery step sees.
+
+Every component of the purge path has been verified working in isolation on production
+(get_domain returns the right domain, is_domain_blacklisted returns True, and get_page()
+demonstrably returns the documents - the raw search endpoint serves them), yet
+discover_targeted_matches() returns nothing. This command runs the *same* code path the
+admin view runs, printing each intermediate value, so the divergence can be observed
+rather than guessed at.
+
+It opens the index exactly the way admin_views._run_purge does (same path construction,
+same mode) and is read-only.
+"""
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from mwmbl.indexer.blacklist import get_default_blacklist_provider
+from mwmbl.indexer.purge_blacklisted import (
+    discover_targeted_matches, parse_pasted_queries, seed_terms_for_query,
+)
+from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+from mwmbl.utils import get_domain
+
+MAX_DOCS_SHOWN = 40
+
+
+class Command(BaseCommand):
+    help = "Trace the purge tool's discovery step to find where it diverges from search"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--query", required=True, help="The query to trace, e.g. fineartteens")
+
+    def handle(self, *args, **options):
+        raw_query = options["query"]
+
+        # 1. Exactly what the admin view does with the pasted text.
+        queries = parse_pasted_queries(raw_query)
+        self.stdout.write(f"1. parse_pasted_queries({raw_query!r}) -> {queries}")
+
+        seed_terms = set()
+        for query in queries:
+            terms = seed_terms_for_query(query)
+            self.stdout.write(f"   seed_terms_for_query({query!r}) -> {sorted(terms)}")
+            seed_terms.update(terms)
+        self.stdout.write(f"2. seed_terms -> {sorted(seed_terms)}")
+
+        # 2. Same index path construction as admin_views._run_purge.
+        index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
+        self.stdout.write(f"3. index_path -> {index_path!r}")
+
+        blacklist_provider = get_default_blacklist_provider()
+        self.stdout.write(f"4. blacklist provider -> {blacklist_provider.__class__.__name__} "
+                           f"with {len(getattr(blacklist_provider, 'providers', []))} sub-providers")
+
+        with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+            self.stdout.write(f"5. index opened: num_pages={index.num_pages} page_size={index.page_size}")
+
+            for term in sorted(seed_terms):
+                page_index = index.get_key_page_index(term)
+                self.stdout.write(f"\n6. term {term!r} -> page {page_index}")
+
+                documents = index.get_page(page_index)
+                self.stdout.write(f"   index.get_page({page_index}) -> {len(documents)} documents")
+
+                retrieved = index.retrieve(term)
+                self.stdout.write(f"   index.retrieve({term!r}) -> {len(retrieved)} documents "
+                                   f"(this is what search uses)")
+
+                if not documents:
+                    self.stdout.write(self.style.ERROR(
+                        "   get_page() returned NOTHING here - but retrieve() uses the same call, "
+                        "so if retrieve() found documents this is the divergence."))
+                    continue
+
+                self.stdout.write("   per-document verdicts (url -> domain -> blacklisted?):")
+                blacklisted_count = 0
+                for document in documents[:MAX_DOCS_SHOWN]:
+                    try:
+                        domain = get_domain(document.url)
+                    except ValueError as e:
+                        self.stdout.write(self.style.ERROR(
+                            f"     {document.url!r} -> get_domain RAISED ValueError: {e} -> SKIPPED"))
+                        continue
+                    verdict = blacklist_provider.is_domain_blacklisted(domain)
+                    if verdict:
+                        blacklisted_count += 1
+                    marker = "BLACKLISTED" if verdict else "kept"
+                    self.stdout.write(f"     {document.url} -> {domain} -> {marker}")
+                if len(documents) > MAX_DOCS_SHOWN:
+                    self.stdout.write(f"     ... and {len(documents) - MAX_DOCS_SHOWN} more not shown")
+                self.stdout.write(f"   -> {blacklisted_count} of the shown documents are blacklisted")
+
+            # 3. Now the real function, unmodified.
+            matches = discover_targeted_matches(
+                index, seed_terms, blacklist_provider.is_domain_blacklisted)
+            self.stdout.write(f"\n7. discover_targeted_matches(...) -> {len(matches)} matches")
+            for match in matches[:MAX_DOCS_SHOWN]:
+                self.stdout.write(f"     {match.domain}  {match.url}")
+
+        if not matches:
+            self.stdout.write(self.style.ERROR(
+                "\ndiscover_targeted_matches returned NOTHING. Compare against the per-document "
+                "verdicts above: if any document was marked BLACKLISTED there, the bug is inside "
+                "discover_targeted_matches; if none were, the bug is upstream (wrong page, or "
+                "get_page returning different data than retrieve)."))
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                f"\ndiscover_targeted_matches found {len(matches)} matches - the discovery step is "
+                "working in this process. If the admin page still shows none, the difference is in "
+                "the web request context, not this logic."))

--- a/mwmbl/management/commands/debug_search_pages.py
+++ b/mwmbl/management/commands/debug_search_pages.py
@@ -1,0 +1,124 @@
+"""Safely inspect every index page a query touches, without ever decompressing a bad one.
+
+A query family (e.g. "fineart", "fineartteens") can hang the search endpoint and get the
+worker OOM-killed, while the same query's /raw endpoint returns instantly and other queries
+are fine. /raw only reads the page for the query's own term; full search additionally
+retrieves the completer's completions and the query bigrams, so it touches pages /raw never
+does. If one of those pages holds a zstd frame whose *declared* decompressed size is
+garbage - which a torn/partial write can produce, since TinyIndex writes pages via unlocked
+mmap slice assignment with no reader/writer coordination - then _get_page_tuples()'s
+unbounded decompressor.decompress(page_data) will try to allocate that declared size and
+take the process down.
+
+This command mirrors Ranker.get_results()'s retrieval-term computation, then for each page
+reads only the zstd *frame header* via get_frame_parameters(), which reports the declared
+content size without allocating anything. Only pages whose declared size is sane are then
+actually decompressed (and even then, with an explicit cap). So this can identify the
+offending page without reproducing the crash.
+"""
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from zstandard import ZstdDecompressor, ZstdError, get_frame_parameters
+
+from mwmbl.tinysearchengine.completer import Completer
+from mwmbl.tinysearchengine.indexer import Document, METADATA_SIZE, TinyIndex
+from mwmbl.tokenizer import get_bigrams, tokenize
+from mwmbl.utils import get_domain
+
+# A page is at most page_size (4096) bytes compressed. Anything claiming to decompress to
+# more than this is not a page this code ever legitimately wrote.
+SANE_DECOMPRESSED_SIZE = 10_000_000
+
+
+class Command(BaseCommand):
+    help = "Inspect every index page a query touches, without decompressing a corrupted one"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--query", required=True)
+
+    def handle(self, *args, **options):
+        query = options["query"]
+
+        terms = tokenize(query)
+        is_complete = query.endswith(' ')
+        completer = Completer()
+        completions = completer.complete(terms[-1]) if terms and not is_complete else []
+        retrieval_terms = set(terms + completions) if completions or terms else set()
+        bigrams = set(get_bigrams(len(terms), terms))
+        curation_term = " ".join(terms)
+
+        self.stdout.write(f"query           : {query!r}")
+        self.stdout.write(f"tokens          : {terms}")
+        self.stdout.write(f"completions     : {completions}   <- full search retrieves these too; /raw does not")
+        self.stdout.write(f"bigrams         : {sorted(bigrams)}")
+        self.stdout.write(f"curation term   : {curation_term!r}")
+
+        all_terms = sorted((retrieval_terms | bigrams) | {curation_term})
+        self.stdout.write(f"\nterms retrieved by full search: {all_terms}\n")
+
+        index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
+        suspect_pages = []
+
+        with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+            seen_pages = {}
+            for term in all_terms:
+                page_index = index.get_key_page_index(term)
+                seen_pages.setdefault(page_index, []).append(term)
+
+            for page_index, terms_for_page in sorted(seen_pages.items()):
+                page_size = index.page_size
+                start = page_index * page_size + METADATA_SIZE
+                raw = bytes(index.mmap[start:start + page_size])
+
+                label = f"page {page_index} (terms: {', '.join(repr(t) for t in terms_for_page)})"
+
+                # Header only - no allocation, safe even if the frame is garbage.
+                try:
+                    params = get_frame_parameters(raw)
+                except ZstdError as e:
+                    self.stdout.write(self.style.ERROR(
+                        f"{label}: NOT A VALID ZSTD FRAME: {e}"))
+                    suspect_pages.append(page_index)
+                    continue
+
+                declared = params.content_size
+                if declared is None or declared > SANE_DECOMPRESSED_SIZE:
+                    self.stdout.write(self.style.ERROR(
+                        f"{label}: declared decompressed size = {declared!r} "
+                        f"- PATHOLOGICAL (a 4096-byte page cannot legitimately claim this). "
+                        f"The real get_page() would try to allocate this and take the worker down."))
+                    suspect_pages.append(page_index)
+                    continue
+
+                try:
+                    decompressed = ZstdDecompressor().decompress(
+                        raw, max_output_size=SANE_DECOMPRESSED_SIZE)
+                    items = json.loads(decompressed.decode("utf8"))
+                except (ZstdError, json.JSONDecodeError, UnicodeDecodeError) as e:
+                    self.stdout.write(self.style.ERROR(f"{label}: FAILED to read: {e}"))
+                    suspect_pages.append(page_index)
+                    continue
+
+                domains = {}
+                for item in items:
+                    try:
+                        domains[get_domain(item[1])] = domains.get(get_domain(item[1]), 0) + 1
+                    except (ValueError, IndexError):
+                        domains["?"] = domains.get("?", 0) + 1
+                top = ", ".join(f"{d}({c})" for d, c in
+                                sorted(domains.items(), key=lambda kv: -kv[1])[:5])
+                self.stdout.write(f"{label}: OK - declared {declared} bytes, "
+                                   f"{len(items)} items. Top domains: {top}")
+
+        self.stdout.write("")
+        if suspect_pages:
+            self.stdout.write(self.style.ERROR(
+                f"SUSPECT PAGES: {suspect_pages}\n"
+                f"These are read by full search but not by /raw, which is why /raw works while "
+                f"search hangs. Rewriting a suspect page with valid content (or empty) should "
+                f"restore the query."))
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                "All pages this query touches are well-formed - the hang is not a corrupted page."))

--- a/mwmbl/management/commands/inspect_index_page.py
+++ b/mwmbl/management/commands/inspect_index_page.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
                 "a torn write mixing bytes from two different writes."))
             return
 
-        self.stdout.write(f"Item count: {len(items)}")
+        self.stdout.write(f"Raw item count (parsed directly from JSON): {len(items)}")
         domains = {}
         for item in items:
             url = item[1] if len(item) > 1 else "?"
@@ -104,6 +104,49 @@ class Command(BaseCommand):
                 domain = "?"
             domains[domain] = domains.get(domain, 0) + 1
 
-        self.stdout.write("Domains on this page:")
+        self.stdout.write("Domains on this page (from raw JSON):")
         for domain, count in sorted(domains.items(), key=lambda kv: -kv[1])[:20]:
+            self.stdout.write(f"  {domain}: {count}")
+
+        # Now compare against what TinyIndex.get_page() actually returns - it reconstructs each
+        # item as Document(*item), and on failure has a recovery path that can silently DROP an
+        # item entirely if reconstruction fails even after retrying. If that's happening, this
+        # page's raw JSON can show documents that the purge tool (which only ever sees
+        # get_page()'s output) can never find.
+        self.stdout.write("")
+        self.stdout.write("Reconstructing each raw item as Document(*item), same as get_page() does:")
+        constructed = 0
+        failed = []
+        for i, item in enumerate(items):
+            try:
+                Document(*item)
+                constructed += 1
+            except Exception as e:
+                failed.append((i, item, e))
+
+        self.stdout.write(f"Successfully constructed: {constructed}/{len(items)}")
+        if failed:
+            self.stdout.write(self.style.ERROR(
+                f"{len(failed)} item(s) FAILED Document(*item) construction - get_page() would "
+                f"drop these (its retry strips the last field once; if that still fails, the "
+                f"item vanishes from every caller, including this purge tool, with no error "
+                f"surfaced to the user):"))
+            for i, item, e in failed[:10]:
+                self.stdout.write(self.style.ERROR(f"  item[{i}]: {e}. Raw: {item}"))
+        else:
+            self.stdout.write("All items reconstructed cleanly - get_page() is not dropping anything here.")
+
+        with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+            via_get_page = index.get_page(page_index)
+        self.stdout.write(f"\nindex.get_page({page_index}) returns: {len(via_get_page)} items "
+                           f"(vs {len(items)} in the raw JSON)")
+        get_page_domains = {}
+        for document in via_get_page:
+            try:
+                domain = get_domain(document.url)
+            except ValueError:
+                domain = "?"
+            get_page_domains[domain] = get_page_domains.get(domain, 0) + 1
+        self.stdout.write("Domains via get_page():")
+        for domain, count in sorted(get_page_domains.items(), key=lambda kv: -kv[1])[:20]:
             self.stdout.write(f"  {domain}: {count}")

--- a/mwmbl/management/commands/inspect_index_page.py
+++ b/mwmbl/management/commands/inspect_index_page.py
@@ -1,0 +1,109 @@
+"""Read-only, safety-bounded diagnostic for a single TinyIndex page.
+
+Investigating reports of a purge tool finding "no results" for a term while live search
+returns many results for the same term, AND a worker OOM-crashing on that exact query.
+One theory: TinyIndex has no locking between writers (background indexer, POST /results,
+this purge tool, etc. can all open the index in write mode and write concurrently), and
+mmap slice writes aren't guaranteed atomic against a concurrent reader - a write racing a
+read could produce a torn zstd frame. _get_page_tuples() decompresses with no output-size
+cap, trusting the frame's embedded declared size; a corrupted/torn frame could either fail
+to decompress (caught and silently returned as [] - explaining "no results") or have a
+garbage declared size large enough that decompression tries to allocate an enormous buffer
+(explaining the OOM).
+
+This command reads the raw bytes for one page directly and attempts a *bounded*
+decompression (max_output_size capped well below anything a legitimate page could produce,
+since page_size is 4096 bytes compressed), so it can't reproduce the OOM while diagnosing it.
+"""
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from zstandard import ZstdDecompressor, ZstdError
+
+from mwmbl.tinysearchengine.indexer import Document, METADATA_SIZE, TinyIndex
+from mwmbl.utils import get_domain
+
+# A legitimate page is at most page_size (4096) bytes *compressed*. Even a pathological
+# compression ratio shouldn't get anywhere near this decompressed - it's just a safety net
+# against a corrupted/garbage declared size in a torn frame.
+MAX_OUTPUT_SIZE = 200_000_000
+
+
+class Command(BaseCommand):
+    help = "Inspect a single TinyIndex page's raw bytes without risking the OOM this is investigating"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--term", help="Report on the page this term hashes to")
+        parser.add_argument("--page", type=int, help="Report on this page index directly")
+
+    def handle(self, *args, **options):
+        term = options["term"]
+        page_index = options["page"]
+        if term is None and page_index is None:
+            raise ValueError("Provide --term or --page")
+
+        index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
+
+        with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+            if page_index is None:
+                page_index = index.get_key_page_index(term)
+                self.stdout.write(f"Term {term!r} hashes to page {page_index} (num_pages={index.num_pages})")
+            elif term is not None:
+                self.stdout.write(f"Also checking: term {term!r} hashes to page "
+                                   f"{index.get_key_page_index(term)} (requested page {page_index} directly)")
+
+            page_size = index.page_size
+            raw = bytes(index.mmap[page_index * page_size + METADATA_SIZE:(page_index + 1) * page_size + METADATA_SIZE])
+
+        self.stdout.write(f"Raw page bytes: {len(raw)} (page_size={page_size})")
+
+        # A well-formed page is a zstd frame followed by NUL padding out to page_size.
+        # Try to find where the trailing NUL run starts, from the end.
+        trailing_nul = 0
+        for b in reversed(raw):
+            if b != 0:
+                break
+            trailing_nul += 1
+        self.stdout.write(f"Trailing NUL bytes: {trailing_nul} "
+                           f"({'looks like normal padding' if trailing_nul > 0 else 'NO trailing padding - unusual'})")
+
+        decompressor = ZstdDecompressor()
+        try:
+            decompressed = decompressor.decompress(raw, max_output_size=MAX_OUTPUT_SIZE)
+        except ZstdError as e:
+            self.stdout.write(self.style.ERROR(f"DECOMPRESSION FAILED: {e}"))
+            self.stdout.write(self.style.ERROR(
+                "This is consistent with a corrupted/torn frame. get_page() catches exactly "
+                "this exception and silently returns [] - which would explain \"no results\" "
+                "from the purge tool for this page."))
+            return
+
+        self.stdout.write(f"Decompressed size: {len(decompressed)} bytes")
+        if len(decompressed) > 5_000_000:
+            self.stdout.write(self.style.WARNING(
+                "Decompressed size is much larger than a normal page - if this were "
+                "uncapped (as the real get_page() call is), this could plausibly OOM a worker."))
+
+        try:
+            items = json.loads(decompressed.decode("utf8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            self.stdout.write(self.style.ERROR(f"JSON PARSE FAILED after successful decompression: {e}"))
+            self.stdout.write(self.style.ERROR(
+                "Decompression succeeded but the bytes aren't valid JSON - also consistent with "
+                "a torn write mixing bytes from two different writes."))
+            return
+
+        self.stdout.write(f"Item count: {len(items)}")
+        domains = {}
+        for item in items:
+            url = item[1] if len(item) > 1 else "?"
+            try:
+                domain = get_domain(url)
+            except (ValueError, IndexError):
+                domain = "?"
+            domains[domain] = domains.get(domain, 0) + 1
+
+        self.stdout.write("Domains on this page:")
+        for domain, count in sorted(domains.items(), key=lambda kv: -kv[1])[:20]:
+            self.stdout.write(f"  {domain}: {count}")

--- a/mwmbl/management/commands/purge_blacklisted_domains.py
+++ b/mwmbl/management/commands/purge_blacklisted_domains.py
@@ -2,11 +2,25 @@
 
 Blacklisting (settings.EXCLUDED_DOMAINS / DOMAIN_BLACKLIST_REGEX / remote blocklist
 providers) only stops *new* URLs being crawled/queued - it does nothing for pages
-that were indexed before a domain was added to the blacklist. This command walks
-every page of the TinyIndex and rewrites it with blacklisted documents stripped out.
+that were indexed before a domain was added to the blacklist. This command rewrites
+index pages with blacklisted documents stripped out, in one of two modes:
 
-This is a full index scan: on the production index (~100M pages) expect this to
-take a long time. Run with --dry-run first to see how much would be removed.
+- Targeted (--domain, recommended for a handful of known-bad domains): only touches
+  the pages a document could plausibly be filed under, found by combining known query
+  terms with terms guessed from the domain itself, then exactly recomputing each
+  matched document's full token set (tokenize_document is a pure function of its
+  stored url/title/extract, so this recovers every page it's really filed under - no
+  guessing involved past the initial seed). Fast: touches dozens-hundreds of pages
+  instead of the whole index. Not guaranteed exhaustive - it can only find documents
+  reachable from the seed terms, so a page ranking only for terms no seed hits at all
+  would be missed.
+
+- Full scan (no --domain, default): walks every page of the index against the full
+  configured blacklist (all providers, including the ~950k-domain remote list).
+  Exhaustive but on the production index (~100M pages) expect this to take a long
+  time - use this as an occasional completeness sweep, not the everyday tool.
+
+Run with --dry-run first to see how much would be removed.
 """
 from logging import getLogger
 
@@ -14,10 +28,31 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from mwmbl.indexer.blacklist import get_default_blacklist_provider
+from mwmbl.indexer.index import get_index_tokens, prepare_url_for_tokenizing, tokenize_document
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+from mwmbl.tokenizer import tokenize
 from mwmbl.utils import get_domain
 
 logger = getLogger(__name__)
+
+
+def _split_page(documents, is_blacklisted):
+    """Partition a page's documents into (kept, removed) by domain."""
+    kept, removed = [], []
+    for document in documents:
+        try:
+            domain = get_domain(document.url)
+        except ValueError:
+            kept.append(document)
+            continue
+        (removed if is_blacklisted(domain) else kept).append(document)
+    return kept, removed
+
+
+def _guess_terms_for_domain(domain: str) -> set[str]:
+    """Terms the indexer would have derived from this domain appearing in a URL."""
+    url_tokens = tokenize(prepare_url_for_tokenizing(f"https://{domain}/"))
+    return get_index_tokens(url_tokens)
 
 
 class Command(BaseCommand):
@@ -29,55 +64,95 @@ class Command(BaseCommand):
             help="Report what would be removed without modifying the index",
         )
         parser.add_argument(
+            "--domain", action="append", default=[],
+            help="Run a fast targeted purge for this domain instead of a full scan (repeatable)",
+        )
+        parser.add_argument(
+            "--term", action="append", default=[],
+            help="Extra known query term to seed the targeted scan with, e.g. from Search "
+                 "Console (repeatable, only used together with --domain)",
+        )
+        parser.add_argument(
             "--progress-every", type=int, default=100_000,
-            help="Log progress every N pages",
+            help="Log progress every N pages (full scan only)",
         )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        progress_every = options["progress_every"]
-
-        blacklist_provider = get_default_blacklist_provider()
+        domains = options["domain"]
+        mode = "r" if dry_run else "w"
         index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
 
-        mode = "r" if dry_run else "w"
-        removed_by_domain = {}
-        pages_changed = 0
+        if options["term"] and not domains:
+            raise ValueError("--term only makes sense together with --domain")
 
         with TinyIndex(item_factory=Document, index_path=index_path, mode=mode) as index:
-            for page_index in range(index.num_pages):
-                documents = index.get_page(page_index)
-                if not documents:
-                    continue
-
-                kept, removed = [], []
-                for document in documents:
-                    try:
-                        domain = get_domain(document.url)
-                    except ValueError:
-                        kept.append(document)
-                        continue
-                    if blacklist_provider.is_domain_blacklisted(domain):
-                        removed.append(document)
-                    else:
-                        kept.append(document)
-
-                if removed:
-                    pages_changed += 1
-                    for document in removed:
-                        domain = get_domain(document.url)
-                        removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
-                    if not dry_run:
-                        index.store_in_page(page_index, kept)
-
-                if page_index and page_index % progress_every == 0:
-                    logger.info(
-                        f"Scanned {page_index}/{index.num_pages} pages, "
-                        f"{sum(removed_by_domain.values())} documents removed so far"
-                    )
+            if domains:
+                removed_by_domain, pages_changed, pages_scanned = self._purge_targeted(
+                    index, set(domains), options["term"], dry_run)
+            else:
+                removed_by_domain, pages_changed, pages_scanned = self._purge_full_scan(
+                    index, dry_run, options["progress_every"])
 
         total_removed = sum(removed_by_domain.values())
         prefix = "[DRY RUN] Would remove" if dry_run else "Removed"
-        self.stdout.write(f"{prefix} {total_removed} documents across {pages_changed} pages")
+        self.stdout.write(f"{prefix} {total_removed} documents across {pages_changed} pages "
+                           f"(scanned {pages_scanned} pages)")
         for domain, count in sorted(removed_by_domain.items(), key=lambda kv: -kv[1]):
             self.stdout.write(f"  {domain}: {count}")
+
+    def _purge_targeted(self, index: TinyIndex, domain_set: set[str], extra_terms: list[str], dry_run: bool):
+        seed_terms = set(extra_terms)
+        for domain in domain_set:
+            seed_terms.update(_guess_terms_for_domain(domain))
+        seed_pages = {index.get_key_page_index(term) for term in seed_terms}
+
+        # Find every document on a seed page that belongs to a target domain, then
+        # recompute its exact token set to discover every other page it's filed under.
+        candidate_pages = set(seed_pages)
+        seen_urls = set()
+        for page_index in seed_pages:
+            for document in index.get_page(page_index):
+                try:
+                    domain = get_domain(document.url)
+                except ValueError:
+                    continue
+                if domain in domain_set and document.url not in seen_urls:
+                    seen_urls.add(document.url)
+                    tokenized = tokenize_document(document.url, document.title, document.extract, document.score)
+                    candidate_pages.update(index.get_key_page_index(token) for token in tokenized.tokens)
+
+        return self._purge_pages(index, candidate_pages, lambda domain: domain in domain_set, dry_run)
+
+    def _purge_full_scan(self, index: TinyIndex, dry_run: bool, progress_every: int):
+        blacklist_provider = get_default_blacklist_provider()
+
+        def progress(page_index, removed_by_domain):
+            if page_index and page_index % progress_every == 0:
+                logger.info(f"Scanned {page_index}/{index.num_pages} pages, "
+                            f"{sum(removed_by_domain.values())} documents removed so far")
+
+        return self._purge_pages(
+            index, range(index.num_pages), blacklist_provider.is_domain_blacklisted, dry_run, progress)
+
+    def _purge_pages(self, index: TinyIndex, page_indexes, is_blacklisted, dry_run, on_progress=None):
+        removed_by_domain = {}
+        pages_changed = 0
+        pages_scanned = 0
+
+        for page_index in page_indexes:
+            pages_scanned += 1
+            kept, removed = _split_page(index.get_page(page_index), is_blacklisted)
+
+            if removed:
+                pages_changed += 1
+                for document in removed:
+                    domain = get_domain(document.url)
+                    removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
+                if not dry_run:
+                    index.store_in_page(page_index, kept)
+
+            if on_progress:
+                on_progress(page_index, removed_by_domain)
+
+        return removed_by_domain, pages_changed, pages_scanned

--- a/mwmbl/management/commands/purge_blacklisted_domains.py
+++ b/mwmbl/management/commands/purge_blacklisted_domains.py
@@ -5,22 +5,33 @@ providers) only stops *new* URLs being crawled/queued - it does nothing for page
 that were indexed before a domain was added to the blacklist. This command rewrites
 index pages with blacklisted documents stripped out, in one of two modes:
 
-- Targeted (--domain, recommended for a handful of known-bad domains): only touches
-  the pages a document could plausibly be filed under, found by combining known query
-  terms with terms guessed from the domain itself, then exactly recomputing each
-  matched document's full token set (tokenize_document is a pure function of its
-  stored url/title/extract, so this recovers every page it's really filed under - no
-  guessing involved past the initial seed). Fast: touches dozens-hundreds of pages
-  instead of the whole index. Not guaranteed exhaustive - it can only find documents
-  reachable from the seed terms, so a page ranking only for terms no seed hits at all
-  would be missed.
+- Targeted (--csv/--domain/--term, the normal way to run this): only touches the
+  pages a document could plausibly be filed under. Seed terms come from tokenizing
+  each query in a Search Console query-export CSV (the same tokenize+bigram terms
+  real search retrieval would use), plus any --domain/--term given directly. Each
+  document found on a seed page is checked against the full configured blacklist
+  (so a --csv run auto-discovers which of the actual results are bad, no manual
+  domain list needed) - and once flagged, its exact token set is recomputed
+  (tokenize_document is a pure function of its stored url/title/extract, so this
+  recovers every page it's really filed under, no guessing involved past the
+  initial seed) and every one of those pages is purged too. Fast: touches
+  dozens-hundreds of pages instead of the whole index. Not guaranteed exhaustive -
+  it can only find documents reachable from the seed terms, so a page ranking only
+  for some term no seed hits at all would be missed.
 
-- Full scan (no --domain, default): walks every page of the index against the full
-  configured blacklist (all providers, including the ~950k-domain remote list).
-  Exhaustive but on the production index (~100M pages) expect this to take a long
-  time - use this as an occasional completeness sweep, not the everyday tool.
+  Fast enough to run interactively - see the "Purge blacklisted domains" tool in
+  the Django admin for a paste-queries-and-preview version of the same thing.
+
+- Full scan (--full-scan): walks every page of the index against the full
+  configured blacklist. Exhaustive but on the production index (~100M pages)
+  expect this to take a long time - only use it for occasional completeness
+  sweeps, never as the routine way to clean up a newly-found bad domain.
 
 Run with --dry-run first to see how much would be removed.
+
+Example, using a Search Console query export:
+
+    manage.py purge_blacklisted_domains --csv Queries.csv --dry-run
 """
 from logging import getLogger
 
@@ -28,31 +39,12 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from mwmbl.indexer.blacklist import get_default_blacklist_provider
-from mwmbl.indexer.index import get_index_tokens, prepare_url_for_tokenizing, tokenize_document
+from mwmbl.indexer.purge_blacklisted import (
+    guess_terms_for_domain, load_queries_from_csv, purge_pages, purge_targeted, seed_terms_for_query,
+)
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
-from mwmbl.tokenizer import tokenize
-from mwmbl.utils import get_domain
 
 logger = getLogger(__name__)
-
-
-def _split_page(documents, is_blacklisted):
-    """Partition a page's documents into (kept, removed) by domain."""
-    kept, removed = [], []
-    for document in documents:
-        try:
-            domain = get_domain(document.url)
-        except ValueError:
-            kept.append(document)
-            continue
-        (removed if is_blacklisted(domain) else kept).append(document)
-    return kept, removed
-
-
-def _guess_terms_for_domain(domain: str) -> set[str]:
-    """Terms the indexer would have derived from this domain appearing in a URL."""
-    url_tokens = tokenize(prepare_url_for_tokenizing(f"https://{domain}/"))
-    return get_index_tokens(url_tokens)
 
 
 class Command(BaseCommand):
@@ -60,39 +52,69 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "--csv",
+            help="Path to a Search Console query-export CSV. Every result found for every "
+                 "query in it is checked against the blacklist and purged if it matches.",
+        )
+        parser.add_argument(
+            "--domain", action="append", default=[],
+            help="Treat this domain as blacklisted for this run, regardless of the configured "
+                 "blacklist, and seed the scan with terms guessed from it (repeatable)",
+        )
+        parser.add_argument(
+            "--term", action="append", default=[],
+            help="Extra seed query term, e.g. one you know matched from Search Console (repeatable)",
+        )
+        parser.add_argument(
+            "--full-scan", action="store_true",
+            help="Exhaustive scan of the whole index instead of a targeted one. SLOW - "
+                 "~100M pages in production. Only for occasional completeness sweeps.",
+        )
+        parser.add_argument(
             "--dry-run", action="store_true",
             help="Report what would be removed without modifying the index",
         )
         parser.add_argument(
-            "--domain", action="append", default=[],
-            help="Run a fast targeted purge for this domain instead of a full scan (repeatable)",
-        )
-        parser.add_argument(
-            "--term", action="append", default=[],
-            help="Extra known query term to seed the targeted scan with, e.g. from Search "
-                 "Console (repeatable, only used together with --domain)",
-        )
-        parser.add_argument(
             "--progress-every", type=int, default=100_000,
-            help="Log progress every N pages (full scan only)",
+            help="Log progress every N pages (--full-scan only)",
         )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        domains = options["domain"]
         mode = "r" if dry_run else "w"
         index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
 
-        if options["term"] and not domains:
-            raise ValueError("--term only makes sense together with --domain")
+        csv_path = options["csv"]
+        extra_domains = set(options["domain"])
+        extra_terms = options["term"]
+
+        if not options["full_scan"] and not (csv_path or extra_domains or extra_terms):
+            raise ValueError("Provide --csv, --domain, --term, or --full-scan")
 
         with TinyIndex(item_factory=Document, index_path=index_path, mode=mode) as index:
-            if domains:
-                removed_by_domain, pages_changed, pages_scanned = self._purge_targeted(
-                    index, set(domains), options["term"], dry_run)
+            if options["full_scan"]:
+                blacklist_provider = get_default_blacklist_provider()
+
+                def progress(page_index, removed_by_domain):
+                    if page_index and page_index % options["progress_every"] == 0:
+                        logger.info(f"Scanned {page_index}/{index.num_pages} pages, "
+                                    f"{sum(removed_by_domain.values())} documents removed so far")
+
+                removed_by_domain, pages_changed, pages_scanned = purge_pages(
+                    index, range(index.num_pages), blacklist_provider.is_domain_blacklisted, dry_run, progress)
             else:
-                removed_by_domain, pages_changed, pages_scanned = self._purge_full_scan(
-                    index, dry_run, options["progress_every"])
+                seed_terms = set(extra_terms)
+                for domain in extra_domains:
+                    seed_terms.update(guess_terms_for_domain(domain))
+                if csv_path:
+                    for query in load_queries_from_csv(csv_path):
+                        seed_terms.update(seed_terms_for_query(query))
+
+                blacklist_provider = get_default_blacklist_provider()
+                is_blacklisted = lambda domain: domain in extra_domains or blacklist_provider.is_domain_blacklisted(domain)
+
+                _, removed_by_domain, pages_changed, pages_scanned = purge_targeted(
+                    index, seed_terms, is_blacklisted, dry_run)
 
         total_removed = sum(removed_by_domain.values())
         prefix = "[DRY RUN] Would remove" if dry_run else "Removed"
@@ -100,59 +122,3 @@ class Command(BaseCommand):
                            f"(scanned {pages_scanned} pages)")
         for domain, count in sorted(removed_by_domain.items(), key=lambda kv: -kv[1]):
             self.stdout.write(f"  {domain}: {count}")
-
-    def _purge_targeted(self, index: TinyIndex, domain_set: set[str], extra_terms: list[str], dry_run: bool):
-        seed_terms = set(extra_terms)
-        for domain in domain_set:
-            seed_terms.update(_guess_terms_for_domain(domain))
-        seed_pages = {index.get_key_page_index(term) for term in seed_terms}
-
-        # Find every document on a seed page that belongs to a target domain, then
-        # recompute its exact token set to discover every other page it's filed under.
-        candidate_pages = set(seed_pages)
-        seen_urls = set()
-        for page_index in seed_pages:
-            for document in index.get_page(page_index):
-                try:
-                    domain = get_domain(document.url)
-                except ValueError:
-                    continue
-                if domain in domain_set and document.url not in seen_urls:
-                    seen_urls.add(document.url)
-                    tokenized = tokenize_document(document.url, document.title, document.extract, document.score)
-                    candidate_pages.update(index.get_key_page_index(token) for token in tokenized.tokens)
-
-        return self._purge_pages(index, candidate_pages, lambda domain: domain in domain_set, dry_run)
-
-    def _purge_full_scan(self, index: TinyIndex, dry_run: bool, progress_every: int):
-        blacklist_provider = get_default_blacklist_provider()
-
-        def progress(page_index, removed_by_domain):
-            if page_index and page_index % progress_every == 0:
-                logger.info(f"Scanned {page_index}/{index.num_pages} pages, "
-                            f"{sum(removed_by_domain.values())} documents removed so far")
-
-        return self._purge_pages(
-            index, range(index.num_pages), blacklist_provider.is_domain_blacklisted, dry_run, progress)
-
-    def _purge_pages(self, index: TinyIndex, page_indexes, is_blacklisted, dry_run, on_progress=None):
-        removed_by_domain = {}
-        pages_changed = 0
-        pages_scanned = 0
-
-        for page_index in page_indexes:
-            pages_scanned += 1
-            kept, removed = _split_page(index.get_page(page_index), is_blacklisted)
-
-            if removed:
-                pages_changed += 1
-                for document in removed:
-                    domain = get_domain(document.url)
-                    removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
-                if not dry_run:
-                    index.store_in_page(page_index, kept)
-
-            if on_progress:
-                on_progress(page_index, removed_by_domain)
-
-        return removed_by_domain, pages_changed, pages_scanned

--- a/mwmbl/management/commands/purge_blacklisted_domains.py
+++ b/mwmbl/management/commands/purge_blacklisted_domains.py
@@ -1,0 +1,83 @@
+"""Retroactively remove already-indexed documents whose domain is blacklisted.
+
+Blacklisting (settings.EXCLUDED_DOMAINS / DOMAIN_BLACKLIST_REGEX / remote blocklist
+providers) only stops *new* URLs being crawled/queued - it does nothing for pages
+that were indexed before a domain was added to the blacklist. This command walks
+every page of the TinyIndex and rewrites it with blacklisted documents stripped out.
+
+This is a full index scan: on the production index (~100M pages) expect this to
+take a long time. Run with --dry-run first to see how much would be removed.
+"""
+from logging import getLogger
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from mwmbl.indexer.blacklist import get_default_blacklist_provider
+from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+from mwmbl.utils import get_domain
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Remove already-indexed documents belonging to blacklisted domains"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Report what would be removed without modifying the index",
+        )
+        parser.add_argument(
+            "--progress-every", type=int, default=100_000,
+            help="Log progress every N pages",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        progress_every = options["progress_every"]
+
+        blacklist_provider = get_default_blacklist_provider()
+        index_path = settings.DATA_PATH + "/" + settings.INDEX_NAME
+
+        mode = "r" if dry_run else "w"
+        removed_by_domain = {}
+        pages_changed = 0
+
+        with TinyIndex(item_factory=Document, index_path=index_path, mode=mode) as index:
+            for page_index in range(index.num_pages):
+                documents = index.get_page(page_index)
+                if not documents:
+                    continue
+
+                kept, removed = [], []
+                for document in documents:
+                    try:
+                        domain = get_domain(document.url)
+                    except ValueError:
+                        kept.append(document)
+                        continue
+                    if blacklist_provider.is_domain_blacklisted(domain):
+                        removed.append(document)
+                    else:
+                        kept.append(document)
+
+                if removed:
+                    pages_changed += 1
+                    for document in removed:
+                        domain = get_domain(document.url)
+                        removed_by_domain[domain] = removed_by_domain.get(domain, 0) + 1
+                    if not dry_run:
+                        index.store_in_page(page_index, kept)
+
+                if page_index and page_index % progress_every == 0:
+                    logger.info(
+                        f"Scanned {page_index}/{index.num_pages} pages, "
+                        f"{sum(removed_by_domain.values())} documents removed so far"
+                    )
+
+        total_removed = sum(removed_by_domain.values())
+        prefix = "[DRY RUN] Would remove" if dry_run else "Removed"
+        self.stdout.write(f"{prefix} {total_removed} documents across {pages_changed} pages")
+        for domain, count in sorted(removed_by_domain.items(), key=lambda kv: -kv[1]):
+            self.stdout.write(f"  {domain}: {count}")

--- a/mwmbl/settings.py
+++ b/mwmbl/settings.py
@@ -31,8 +31,17 @@ SCORE_FOR_DIFFERENT_DOMAIN = 1.0
 SCORE_FOR_SAME_DOMAIN = 0.01
 EXTRA_LINK_MULTIPLIER = 0.001
 UNKNOWN_DOMAIN_MULTIPLIER = 0.001
-EXCLUDED_DOMAINS = {'web.archive.org', 'forums.giantitp.com', 'www.crutchfield.com', 'plus.google.com', 'www.lukas-renggli.ch'}
-DOMAIN_BLACKLIST_REGEX = re.compile(r"porn|xxx|adult|jksu\.org|lwhyl\.org$|rgcd\.cn$|hzqwyou\.cn$|omgoat\.org$|pussyboy\.net$")
+EXCLUDED_DOMAINS = {
+    'web.archive.org', 'forums.giantitp.com', 'www.crutchfield.com', 'plus.google.com', 'www.lukas-renggli.ch',
+    # Adult content sites found ranking for suspicious Search Console queries (2026-08-14).
+    'fineartteens.com', 'milforia.com', 'azgals.com', 'kusowanka.com',
+}
+# `booru.org` is a free hosting platform for imageboards; every subdomain we've found ranking
+# (nyou/hypno/inflate/futaba/captions.booru.org) hosts adult/fetish content, so block the whole domain.
+DOMAIN_BLACKLIST_REGEX = re.compile(
+    r"porn|xxx|adult|hentai|\.booru\.org$|"
+    r"jksu\.org|lwhyl\.org$|rgcd\.cn$|hzqwyou\.cn$|omgoat\.org$|pussyboy\.net$"
+)
 CORE_DOMAINS = {
     'github.com',
     'en.wikipedia.org',

--- a/mwmbl/templates/admin/purge_blacklisted_domains.html
+++ b/mwmbl/templates/admin/purge_blacklisted_domains.html
@@ -84,6 +84,28 @@ didn't happen to hit.</p>
         {% endif %}
     {% else %}
         <p>No results for these queries matched the configured blacklist.</p>
+        <h3>What was actually checked</h3>
+        <table>
+            <tr><th>Queries parsed from your input</th><td>{{ result.queries|join:", "|default:"(none)" }}</td></tr>
+            <tr><th>Seed terms looked up</th><td>{{ result.seed_terms|join:", "|default:"(none)" }}</td></tr>
+            <tr><th>Pages scanned</th><td>{{ result.pages_scanned }}</td></tr>
+        </table>
+        {% if result.seed_pages %}
+            <p>Documents found on each seed page (before any blacklist check):</p>
+            <table>
+                <thead><tr><th>Page</th><th>Documents on page</th></tr></thead>
+                <tbody>
+                    {% for page, count in result.seed_pages %}
+                    <tr><td>{{ page }}</td><td>{{ count }}</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p>If those pages hold documents but nothing matched, every document on them was
+            judged not-blacklisted. If a page shows 0 documents, nothing was there to match.</p>
+        {% else %}
+            <p class="errornote">No seed terms were produced from your input, so no pages were
+            checked at all. Nothing could have matched regardless of what is in the index.</p>
+        {% endif %}
     {% endif %}
 {% endif %}
 {% endblock %}

--- a/mwmbl/templates/admin/purge_blacklisted_domains.html
+++ b/mwmbl/templates/admin/purge_blacklisted_domains.html
@@ -4,12 +4,15 @@
 <p>Paste queries, one per line (a pasted Search Console CSV, header row and all, also works -
 only the query column is used). Every indexed result for those queries is checked against the
 configured blacklist. This never scans the whole index, so it's fast enough to run interactively -
-but it can only find documents reachable from these exact queries.</p>
+but it can only find documents reachable from these exact queries. Once you have a preview, the
+"add these terms" button below lets you feed every term a matched document was found under back
+into the list, so a re-run can turn up other pages on the same domain that your original queries
+didn't happen to hit.</p>
 
 <form method="post">
     {% csrf_token %}
     <p>
-        <textarea name="queries" rows="10" cols="80" placeholder="fineartteens&#10;newcapbooru&#10;nyoubooru">{{ queries_text }}</textarea>
+        <textarea id="queries-textarea" name="queries" rows="10" cols="80" placeholder="fineartteens&#10;newcapbooru&#10;nyoubooru">{{ queries_text }}</textarea>
     </p>
     <input type="submit" value="Preview" class="default">
 </form>
@@ -43,6 +46,32 @@ but it can only find documents reachable from these exact queries.</p>
         <p>{{ total_removed }} document{{ total_removed|pluralize }} across
             {{ result.pages_changed }} page{{ result.pages_changed|pluralize }}
             (scanned {{ result.pages_scanned }} page{{ result.pages_scanned|pluralize }}).</p>
+
+        {{ all_terms|json_script:"all-terms-data" }}
+        <p>
+            <button type="button" id="add-terms-btn">Add these {{ all_terms|length }} term{{ all_terms|length|pluralize }} to the input list above</button>
+            <span id="add-terms-status"></span>
+        </p>
+        <script>
+            document.getElementById("add-terms-btn").addEventListener("click", function () {
+                var terms = JSON.parse(document.getElementById("all-terms-data").textContent);
+                var textarea = document.getElementById("queries-textarea");
+                var existing = new Set(
+                    textarea.value.split("\n").map(function (line) { return line.trim(); }).filter(Boolean)
+                );
+                var added = 0;
+                terms.forEach(function (term) {
+                    if (!existing.has(term)) {
+                        existing.add(term);
+                        added++;
+                    }
+                });
+                textarea.value = Array.from(existing).join("\n");
+                document.getElementById("add-terms-status").textContent =
+                    added > 0 ? " added " + added + " new term" + (added === 1 ? "" : "s") + " - click Preview to re-scan"
+                               : " no new terms to add";
+            });
+        </script>
 
         {% if result.dry_run %}
             <form method="post">

--- a/mwmbl/templates/admin/purge_blacklisted_domains.html
+++ b/mwmbl/templates/admin/purge_blacklisted_domains.html
@@ -1,0 +1,60 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<p>Paste queries, one per line (a pasted Search Console CSV, header row and all, also works -
+only the query column is used). Every indexed result for those queries is checked against the
+configured blacklist. This never scans the whole index, so it's fast enough to run interactively -
+but it can only find documents reachable from these exact queries.</p>
+
+<form method="post">
+    {% csrf_token %}
+    <p>
+        <textarea name="queries" rows="10" cols="80" placeholder="fineartteens&#10;newcapbooru&#10;nyoubooru">{{ queries_text }}</textarea>
+    </p>
+    <input type="submit" value="Preview" class="default">
+</form>
+
+{% if error %}
+    <p class="errornote">{{ error }}</p>
+{% endif %}
+
+{% if result %}
+    {% if result.matches %}
+        <h2>{{ result.matches|length }} matching document{{ result.matches|length|pluralize }} on blacklisted domains
+            {% if result.dry_run %}(preview - nothing removed yet){% else %}- removed{% endif %}</h2>
+
+        <table>
+            <thead>
+                <tr><th>Domain</th><th>Title</th><th>URL</th><th>Found via</th><th>Indexed under / removed from</th></tr>
+            </thead>
+            <tbody>
+                {% for match in result.matches %}
+                <tr>
+                    <td>{{ match.domain }}</td>
+                    <td>{{ match.title }}</td>
+                    <td><a href="{{ match.url }}" target="_blank" rel="noopener">{{ match.url }}</a></td>
+                    <td>{{ match.found_via_terms|join:", " }}</td>
+                    <td>{{ match.indexed_under_terms|join:", " }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <p>{{ total_removed }} document{{ total_removed|pluralize }} across
+            {{ result.pages_changed }} page{{ result.pages_changed|pluralize }}
+            (scanned {{ result.pages_scanned }} page{{ result.pages_scanned|pluralize }}).</p>
+
+        {% if result.dry_run %}
+            <form method="post">
+                {% csrf_token %}
+                <input type="hidden" name="queries" value="{{ queries_text }}">
+                <input type="hidden" name="confirm" value="1">
+                <input type="submit" value="Confirm and remove {{ total_removed }} document{{ total_removed|pluralize }}" class="default"
+                       onclick="return confirm('Remove {{ total_removed }} document{{ total_removed|pluralize }} from the index? This cannot be undone from here.');">
+            </form>
+        {% endif %}
+    {% else %}
+        <p>No results for these queries matched the configured blacklist.</p>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/test/test_admin_purge_blacklisted_domains.py
+++ b/test/test_admin_purge_blacklisted_domains.py
@@ -130,3 +130,36 @@ def test_confirm_by_superuser_removes_matches(client, superuser, index_path):
 def test_anonymous_is_redirected_to_login(client):
     response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens"})
     assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_zero_match_run_explains_what_it_checked(client, staff_user, index_path):
+    """A run that finds nothing must still show the seed terms and the pages it scanned -
+    otherwise "no matches" is indistinguishable from "scanned nothing at all", which is
+    exactly the ambiguity that made a production zero-match report impossible to diagnose."""
+    documents = [Document(title="Good Example", url="https://example.com/y", extract="a good page")]
+    _index_without_blacklist(documents, index_path)
+
+    client.force_login(staff_user)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "example"})
+
+    content = response.content.decode()
+    assert "No results for these queries matched" in content
+    assert "What was actually checked" in content
+    assert "Seed terms looked up" in content
+    assert "example" in content
+
+
+@pytest.mark.django_db
+def test_input_producing_no_seed_terms_says_so_explicitly(client, staff_user, index_path):
+    """Input that parses to no queries at all (here: only a Search Console header row) must
+    say plainly that nothing was checked, rather than implying the index was searched."""
+    client.force_login(staff_user)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "Top queries"})
+
+    content = response.content.decode()
+    assert "No seed terms were produced from your input" in content

--- a/test/test_admin_purge_blacklisted_domains.py
+++ b/test/test_admin_purge_blacklisted_domains.py
@@ -30,6 +30,17 @@ def _get_all_urls(index_path, num_pages=10):
     return urls
 
 
+def _index_without_blacklist(documents, index_path):
+    """index_documents() now enforces the blacklist itself (see index_batches.py), so
+    seeding a test index with documents on a domain that's for real blacklisted (e.g.
+    fineartteens.com, added to settings.EXCLUDED_DOMAINS) needs this to bypass it -
+    simulating content that was indexed *before* the domain was blacklisted, which is
+    the scenario these purge tests are about."""
+    with patch("mwmbl.indexer.index_batches.get_default_blacklist_provider",
+               return_value=StaticBlacklistProvider(set())):
+        index_documents(documents, index_path)
+
+
 @pytest.fixture
 def staff_user(db):
     return User.objects.create_user(username="staff", password="x", is_staff=True)
@@ -46,7 +57,7 @@ def test_preview_shows_matches_without_modifying_index(client, staff_user, index
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
         Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     client.force_login(staff_user)
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
@@ -63,7 +74,7 @@ def test_preview_embeds_deduplicated_terms_for_the_add_button(client, staff_user
     documents = [
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     client.force_login(staff_user)
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
@@ -86,7 +97,7 @@ def test_preview_embeds_deduplicated_terms_for_the_add_button(client, staff_user
 @pytest.mark.django_db
 def test_confirm_by_staff_non_superuser_is_rejected(client, staff_user, index_path):
     documents = [Document(title="Fine Art Teens", url="https://fineartteens.com/x", extract="teen gallery")]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     client.force_login(staff_user)
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
@@ -103,7 +114,7 @@ def test_confirm_by_superuser_removes_matches(client, superuser, index_path):
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
         Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     client.force_login(superuser)
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \

--- a/test/test_admin_purge_blacklisted_domains.py
+++ b/test/test_admin_purge_blacklisted_domains.py
@@ -1,3 +1,5 @@
+import json
+import re
 from unittest.mock import patch
 
 import pytest
@@ -54,6 +56,31 @@ def test_preview_shows_matches_without_modifying_index(client, staff_user, index
     assert response.status_code == 200
     assert b"fineartteens.com" in response.content
     assert "https://fineartteens.com/x" in _get_all_urls(index_path)  # not yet removed
+
+
+@pytest.mark.django_db
+def test_preview_embeds_deduplicated_terms_for_the_add_button(client, staff_user, index_path):
+    documents = [
+        Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
+    ]
+    index_documents(documents, index_path)
+
+    client.force_login(staff_user)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens"})
+
+    content = response.content.decode()
+    match = re.search(
+        r'<script id="all-terms-data" type="application/json">(.*?)</script>', content, re.DOTALL)
+    assert match, "expected an embedded all-terms-data JSON script"
+    terms = json.loads(match.group(1))
+
+    assert "fineartteens" in terms
+    # the seed term itself should appear exactly once, not duplicated between
+    # found_via_terms and indexed_under_terms
+    assert terms.count("fineartteens") == 1
+    assert len(terms) == len(set(terms))
 
 
 @pytest.mark.django_db

--- a/test/test_admin_purge_blacklisted_domains.py
+++ b/test/test_admin_purge_blacklisted_domains.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+
+from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.indexer.index_batches import index_documents
+from mwmbl.tinysearchengine.indexer import Document, PAGE_SIZE, TinyIndex
+
+PATCH_TARGET = "mwmbl.admin_views.get_default_blacklist_provider"
+User = get_user_model()
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=10, page_size=PAGE_SIZE)
+    return str(path)
+
+
+def _get_all_urls(index_path, num_pages=10):
+    urls = []
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+        for page_index in range(num_pages):
+            urls.extend(doc.url for doc in index.get_page(page_index))
+    return urls
+
+
+@pytest.fixture
+def staff_user(db):
+    return User.objects.create_user(username="staff", password="x", is_staff=True)
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_user(username="admin", password="x", is_staff=True, is_superuser=True)
+
+
+@pytest.mark.django_db
+def test_preview_shows_matches_without_modifying_index(client, staff_user, index_path):
+    documents = [
+        Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
+        Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
+    ]
+    index_documents(documents, index_path)
+
+    client.force_login(staff_user)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens"})
+
+    assert response.status_code == 200
+    assert b"fineartteens.com" in response.content
+    assert "https://fineartteens.com/x" in _get_all_urls(index_path)  # not yet removed
+
+
+@pytest.mark.django_db
+def test_confirm_by_staff_non_superuser_is_rejected(client, staff_user, index_path):
+    documents = [Document(title="Fine Art Teens", url="https://fineartteens.com/x", extract="teen gallery")]
+    index_documents(documents, index_path)
+
+    client.force_login(staff_user)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens", "confirm": "1"})
+
+    assert response.status_code == 200
+    assert "https://fineartteens.com/x" in _get_all_urls(index_path)
+
+
+@pytest.mark.django_db
+def test_confirm_by_superuser_removes_matches(client, superuser, index_path):
+    documents = [
+        Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
+        Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
+    ]
+    index_documents(documents, index_path)
+
+    client.force_login(superuser)
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens", "confirm": "1"})
+
+    assert response.status_code == 200
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://example.com/y" in urls
+
+
+def test_anonymous_is_redirected_to_login(client):
+    response = client.post(reverse("admin:purge_blacklisted_domains"), {"queries": "fineartteens"})
+    assert response.status_code in (302, 403)

--- a/test/test_blacklist.py
+++ b/test/test_blacklist.py
@@ -25,3 +25,27 @@ def test_blacklist_allows_other_domains():
     """Test that built-in rules allow other legitimate domains."""
     provider = BuiltInRulesBlacklistProvider()
     assert not provider.is_domain_blacklisted("something.com")
+
+
+def test_blacklist_excludes_adult_sites_found_via_search_console():
+    """Domains surfaced by suspicious Search Console queries (2026-08-14)."""
+    provider = BuiltInRulesBlacklistProvider()
+    bad_domains = [
+        "fineartteens.com",
+        "milforia.com",
+        "azgals.com",
+        "kusowanka.com",
+        "nyou.booru.org",
+        "hypno.booru.org",
+        "inflatebooru.booru.org",
+        "futabooru.booru.org",
+        "captions.booru.org",
+    ]
+    for domain in bad_domains:
+        assert provider.is_domain_blacklisted(domain), domain
+
+
+def test_blacklist_allows_legitimate_imageboard():
+    """mathchan.org ('the scientific imageboard') is not adult content."""
+    provider = BuiltInRulesBlacklistProvider()
+    assert not provider.is_domain_blacklisted("mathchan.org")

--- a/test/test_blacklist.py
+++ b/test/test_blacklist.py
@@ -5,14 +5,29 @@ def test_blacklist_excludes_bad_pattern():
     """Test that built-in rules blacklist bad patterns."""
     provider = BuiltInRulesBlacklistProvider()
     bad_domains = [
-        "brofqpxj.uelinc.com",
-        "gzsmjc.fba01.com", 
         "59648.etnomurcia.com",
         "something.hzqwyou.cn",
     ]
 
     for domain in bad_domains:
         assert provider.is_domain_blacklisted(domain)
+
+
+def test_blacklist_allows_numeric_apex_domain():
+    """A numeric *apex* domain like 350.org is the actual site name, not a generated
+    subdomain - the numeric-subdomain heuristic below should only catch len > 2."""
+    provider = BuiltInRulesBlacklistProvider()
+    assert not provider.is_domain_blacklisted("350.org")
+
+
+def test_blacklist_allows_ordinary_short_subdomains():
+    """Regression test: a length-based heuristic that used to flag any 3-part .com
+    domain with a 6 or 8 character first label was removed after it flagged dozens of
+    legitimate subdomains (topics.nytimes.com, search.google.com, podcasts.apple.com,
+    starwars.fandom.com, ...) with zero confirmed true positives in testing."""
+    provider = BuiltInRulesBlacklistProvider()
+    for domain in ["topics.nytimes.com", "search.google.com", "podcasts.apple.com", "starwars.fandom.com"]:
+        assert not provider.is_domain_blacklisted(domain), domain
 
 
 def test_blacklist_allows_top_domains():

--- a/test/test_blacklist_providers.py
+++ b/test/test_blacklist_providers.py
@@ -6,8 +6,9 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from mwmbl.indexer.blacklist_providers import (
-    StaticBlacklistProvider, 
-    HaGeZiBlacklistProvider, 
+    StaticBlacklistProvider,
+    HaGeZiBlacklistProvider,
+    AdultContentBlacklistProvider,
     CombinedBlacklistProvider
 )
 from mwmbl.indexer.blacklist import get_default_blacklist_provider
@@ -50,6 +51,27 @@ badsite.net
         assert provider.is_domain_blacklisted('badsite.net') == True
         
         # Test domain that should not be blacklisted
+        assert provider.is_domain_blacklisted('github.com') == False
+
+
+def test_adult_content_blacklist_provider_success():
+    """Test AdultContentBlacklistProvider parses hosts-format lines correctly."""
+    with patch('mwmbl.indexer.blacklist_providers.request_cache') as mock_cache:
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = '''# Title: Porn Block List
+# Homepage: https://github.com/blocklistproject/Lists
+
+0.0.0.0 fineartteens.com
+0.0.0.0 milforia.com
+'''
+        mock_session.get.return_value = mock_response
+        mock_cache.return_value.__enter__.return_value = mock_session
+
+        provider = AdultContentBlacklistProvider()
+
+        assert provider.is_domain_blacklisted('fineartteens.com') == True
+        assert provider.is_domain_blacklisted('milforia.com') == True
         assert provider.is_domain_blacklisted('github.com') == False
 
 

--- a/test/test_blacklist_providers.py
+++ b/test/test_blacklist_providers.py
@@ -5,6 +5,7 @@ Tests for blacklist providers and the abstraction system.
 import pytest
 from unittest.mock import patch, MagicMock
 
+from mwmbl.indexer import blacklist_providers
 from mwmbl.indexer.blacklist_providers import (
     StaticBlacklistProvider,
     HaGeZiBlacklistProvider,
@@ -12,6 +13,17 @@ from mwmbl.indexer.blacklist_providers import (
     CombinedBlacklistProvider
 )
 from mwmbl.indexer.blacklist import get_default_blacklist_provider
+
+
+@pytest.fixture(autouse=True)
+def clear_shared_domains_cache():
+    """_parsed_domains_cache is a module-level dict shared across every
+    RemoteListBlacklistProvider instance (see blacklist_providers.py) so that
+    index_documents() can call get_default_blacklist_provider() cheaply on every call.
+    Clear it around each test so a mocked response in one test can't leak into another."""
+    blacklist_providers._parsed_domains_cache.clear()
+    yield
+    blacklist_providers._parsed_domains_cache.clear()
 
 
 def test_static_blacklist_provider():

--- a/test/test_blacklist_providers.py
+++ b/test/test_blacklist_providers.py
@@ -3,6 +3,7 @@ Tests for blacklist providers and the abstraction system.
 """
 
 import pytest
+import requests
 from unittest.mock import patch, MagicMock
 
 from mwmbl.indexer import blacklist_providers
@@ -41,8 +42,7 @@ def test_static_blacklist_provider():
 
 def test_hagezi_blacklist_provider_success():
     """Test HaGeZiBlacklistProvider with successful HTTP response."""
-    with patch('mwmbl.indexer.blacklist_providers.request_cache') as mock_cache:
-        mock_session = MagicMock()
+    with patch('mwmbl.indexer.blacklist_providers.requests.get') as mock_get:
         mock_response = MagicMock()
         mock_response.text = '''# HaGeZi DNS Blocklist
 # Comments should be ignored
@@ -52,11 +52,10 @@ malware.example
 # Another comment
 badsite.net
 '''
-        mock_session.get.return_value = mock_response
-        mock_cache.return_value.__enter__.return_value = mock_session
-        
+        mock_get.return_value = mock_response
+
         provider = HaGeZiBlacklistProvider('light')
-        
+
         # Test domains that should be blacklisted
         assert provider.is_domain_blacklisted('spam.com') == True
         assert provider.is_domain_blacklisted('malware.example') == True
@@ -68,8 +67,7 @@ badsite.net
 
 def test_adult_content_blacklist_provider_success():
     """Test AdultContentBlacklistProvider parses hosts-format lines correctly."""
-    with patch('mwmbl.indexer.blacklist_providers.request_cache') as mock_cache:
-        mock_session = MagicMock()
+    with patch('mwmbl.indexer.blacklist_providers.requests.get') as mock_get:
         mock_response = MagicMock()
         mock_response.text = '''# Title: Porn Block List
 # Homepage: https://github.com/blocklistproject/Lists
@@ -77,8 +75,7 @@ def test_adult_content_blacklist_provider_success():
 0.0.0.0 fineartteens.com
 0.0.0.0 milforia.com
 '''
-        mock_session.get.return_value = mock_response
-        mock_cache.return_value.__enter__.return_value = mock_session
+        mock_get.return_value = mock_response
 
         provider = AdultContentBlacklistProvider()
 
@@ -134,3 +131,43 @@ def test_integration_with_blacklist_module():
     
     # Test with a domain that should not be blacklisted
     assert default_provider.is_domain_blacklisted('github.com') == False
+
+
+def test_remote_lists_do_not_use_the_shared_filesystem_request_cache():
+    """These lists are tens of megabytes. mwmbl.utils.request_cache is a *filesystem* cache
+    rooted at settings.REQUEST_CACHE_PATH, on the same volume as the index - caching them
+    there fills that volume, and once it is full every other user of request_cache breaks,
+    including get_wiki_results() on the live search path (which then retries a live fetch
+    4x per uncached query until the worker dies). Regression test: fetch must not go
+    through request_cache."""
+    with patch('mwmbl.indexer.blacklist_providers.requests.get') as mock_get:
+        mock_response = MagicMock()
+        mock_response.text = "spam.com\n"
+        mock_get.return_value = mock_response
+
+        # If the module still imported request_cache, patching it would succeed; assert the
+        # name is gone from the module so this can't silently regress.
+        import mwmbl.indexer.blacklist_providers as bp
+        assert not hasattr(bp, "request_cache"), \
+            "blacklist_providers must not use the shared filesystem request_cache"
+
+        provider = HaGeZiBlacklistProvider('light')
+        assert provider.is_domain_blacklisted('spam.com') is True
+        assert mock_get.called
+
+
+def test_fetch_failure_falls_back_to_last_good_list():
+    """A transient fetch failure must not silently blank out the provider's coverage."""
+    with patch('mwmbl.indexer.blacklist_providers.requests.get') as mock_get:
+        mock_response = MagicMock()
+        mock_response.text = "spam.com\n"
+        mock_get.return_value = mock_response
+        provider = HaGeZiBlacklistProvider('light')
+        assert provider.is_domain_blacklisted('spam.com') is True
+
+    # Expire the module-level cache so the next call refetches, and make that fetch fail.
+    blacklist_providers._parsed_domains_cache[provider.url] = (
+        -10**9, blacklist_providers._parsed_domains_cache[provider.url][1])
+    with patch('mwmbl.indexer.blacklist_providers.requests.get',
+               side_effect=requests.RequestException("boom")):
+        assert provider.is_domain_blacklisted('spam.com') is True  # still covered

--- a/test/test_debug_search_pages.py
+++ b/test/test_debug_search_pages.py
@@ -1,0 +1,44 @@
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from mwmbl.indexer.index_batches import index_documents
+from mwmbl.tinysearchengine.indexer import Document, METADATA_SIZE, PAGE_SIZE, TinyIndex
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=10, page_size=PAGE_SIZE)
+    return str(path)
+
+
+@pytest.mark.django_db
+def test_reports_well_formed_pages(index_path, capsys):
+    index_documents([Document(title="Example", url="https://example.com/x", extract="an example")], index_path)
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("debug_search_pages", "--query", "example")
+
+    out = capsys.readouterr().out
+    assert "All pages this query touches are well-formed" in out
+    assert "SUSPECT PAGES" not in out
+
+
+@pytest.mark.django_db
+def test_flags_page_that_is_not_a_valid_frame(index_path, capsys):
+    """A page of garbage must be reported as suspect rather than decompressed - the whole
+    point is to identify the page that would crash the worker without reproducing the crash."""
+    index_documents([Document(title="Example", url="https://example.com/x", extract="an example")], index_path)
+
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="w") as index:
+        page = index.get_key_page_index("example")
+        start = page * index.page_size + METADATA_SIZE
+        index.mmap[start:start + index.page_size] = bytes([7]) * index.page_size
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("debug_search_pages", "--query", "example")
+
+    out = capsys.readouterr().out
+    assert "SUSPECT PAGES" in out
+    assert "NOT A VALID ZSTD FRAME" in out

--- a/test/test_index_batches.py
+++ b/test/test_index_batches.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
+import pytest
+
+from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
 from mwmbl.indexer.index_batches import (
     sort_documents, combine_documents, _merge_user_ids, MAX_USER_IDS,
-    index_results_against_query,
+    index_results_against_query, index_documents,
 )
-from mwmbl.tinysearchengine.indexer import Document, DocumentState, TinyIndex
+from mwmbl.tinysearchengine.indexer import Document, DocumentState, PAGE_SIZE, TinyIndex
 
 
 class UrlRanker:
@@ -200,3 +204,54 @@ def test_combine_documents_propagates_user_ids_to_winner():
     assert len(combined) == 1
     assert 1 in combined[0].user_ids
     assert 2 in combined[0].user_ids
+
+
+# ---------------------------------------------------------------------------
+# index_documents: blacklist enforcement
+# ---------------------------------------------------------------------------
+#
+# index_documents() is the common choke point for every path that adds content to the
+# index (offline batch processing, the trusted-crawler POST /results endpoint, the
+# standalone crawl tool) - crawling/link-discovery only stop *new* crawling of a
+# blacklisted domain, they don't stop a submitted batch that already contains one of its
+# pages, so indexing needs its own blacklist check.
+
+PATCH_TARGET = "mwmbl.indexer.index_batches.get_default_blacklist_provider"
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=10, page_size=PAGE_SIZE)
+    return str(path)
+
+
+def _all_urls(index_path, num_pages=10):
+    urls = []
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+        for page_index in range(num_pages):
+            urls.extend(doc.url for doc in index.get_page(page_index))
+    return urls
+
+
+def test_index_documents_skips_blacklisted_domain(index_path):
+    documents = [
+        Document(title="Bad", url="https://fineartteens.com/x", extract="teen gallery"),
+        Document(title="Good", url="https://example.com/y", extract="a good page"),
+    ]
+
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})):
+        index_documents(documents, index_path)
+
+    urls = _all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://example.com/y" in urls
+
+
+def test_index_documents_keeps_everything_when_nothing_blacklisted(index_path):
+    documents = [Document(title="Good", url="https://example.com/y", extract="a good page")]
+
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())):
+        index_documents(documents, index_path)
+
+    assert "https://example.com/y" in _all_urls(index_path)

--- a/test/test_inspect_index_page.py
+++ b/test/test_inspect_index_page.py
@@ -1,0 +1,48 @@
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from mwmbl.indexer.index_batches import index_documents
+from mwmbl.tinysearchengine.indexer import Document, METADATA_SIZE, PAGE_SIZE, TinyIndex
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=10, page_size=PAGE_SIZE)
+    return str(path)
+
+
+@pytest.mark.django_db
+def test_reports_well_formed_page(index_path, capsys):
+    documents = [Document(title="Example", url="https://example.com/x", extract="an example page")]
+    index_documents(documents, index_path)
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("inspect_index_page", "--term", "example")
+
+    out = capsys.readouterr().out
+    assert "DECOMPRESSION FAILED" not in out
+    assert "example.com" in out
+    assert "Item count: 1" in out
+
+
+@pytest.mark.django_db
+def test_detects_corrupted_page(index_path, capsys):
+    # Write garbage directly into a page's byte range, bypassing the normal write path -
+    # simulating a torn/corrupted write.
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="w") as index:
+        garbage = bytes([1, 2, 3, 4] * (index.page_size // 4))
+        start = 0 * index.page_size + METADATA_SIZE
+        index.mmap[start:start + index.page_size] = garbage
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("inspect_index_page", "--page", "0")
+
+    out = capsys.readouterr().out
+    assert "DECOMPRESSION FAILED" in out
+
+
+def test_requires_term_or_page():
+    with pytest.raises(ValueError):
+        call_command("inspect_index_page")

--- a/test/test_inspect_index_page.py
+++ b/test/test_inspect_index_page.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 from django.core.management import call_command
 from django.test import override_settings
+from zstandard import ZstdCompressor
 
 from mwmbl.indexer.index_batches import index_documents
 from mwmbl.tinysearchengine.indexer import Document, METADATA_SIZE, PAGE_SIZE, TinyIndex
@@ -24,7 +27,39 @@ def test_reports_well_formed_page(index_path, capsys):
     out = capsys.readouterr().out
     assert "DECOMPRESSION FAILED" not in out
     assert "example.com" in out
-    assert "Item count: 1" in out
+    assert "Raw item count (parsed directly from JSON): 1" in out
+    assert "get_page(" in out and "returns: 1 items" in out
+
+
+@pytest.mark.django_db
+def test_detects_item_silently_dropped_by_get_page(index_path, capsys):
+    """Simulates a real failure mode: an item whose stored state value isn't a valid
+    DocumentState, with another field (user_ids) stored after it. get_page()'s recovery
+    only strips the *last* tuple element and retries once - since state isn't the last
+    element here, the retry fails too, and the item is dropped from get_page()'s result
+    with only a log line, not an exception - invisible to any caller, including the purge
+    tool, that only ever calls get_page()."""
+    good_item = ["Good", "https://example.com/x", "extract", None, "term"]
+    # title, url, extract, score, term, state (invalid), user_ids - state isn't last, so
+    # get_page()'s "strip the last field and retry" recovery can't fix it.
+    bad_item = ["Bad", "https://fineartteens.com/y", "extract", None, "term", False, [1]]
+    items = [good_item, bad_item]
+
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="w") as index:
+        page = index.get_key_page_index("term")
+        compressed = ZstdCompressor().compress(json.dumps(items).encode("utf8"))
+        padded = compressed + b"\x00" * (index.page_size - len(compressed))
+        start = page * index.page_size + METADATA_SIZE
+        index.mmap[start:start + index.page_size] = padded
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("inspect_index_page", "--page", str(page))
+
+    out = capsys.readouterr().out
+    assert "Raw item count (parsed directly from JSON): 2" in out
+    assert "fineartteens.com" in out  # visible in the raw JSON domain breakdown
+    assert "FAILED Document(*item) construction" in out
+    assert "returns: 1 items (vs 2 in the raw JSON)" in out
 
 
 @pytest.mark.django_db

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -5,7 +5,9 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.indexer.index import tokenize_document
 from mwmbl.indexer.index_batches import index_documents
+from mwmbl.indexer.purge_blacklisted import guess_terms_for_domain
 from mwmbl.tinysearchengine.indexer import Document, PAGE_SIZE, TinyIndex
 
 PATCH_TARGET = "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider"
@@ -120,6 +122,34 @@ def test_targeted_extra_term_reaches_pages_domain_guess_alone_would_miss(index_p
         call_command("purge_blacklisted_domains", "--domain", "kusowanka.com", "--term", "hentai")
 
     assert "https://kusowanka.com/" not in _get_all_urls(index_path)
+
+
+@pytest.mark.django_db
+def test_targeted_purge_does_not_sweep_unrelated_document_sharing_a_page(index_path):
+    """Regression test: expanding to every page a matched document's own tokens hash to can
+    land on a page shared with a totally unrelated document (a real risk with generic terms
+    like "com" or "you" on a large index). That unrelated document must not be swept up and
+    removed just because it also happens to be blacklisted - only the documents actually
+    shown in the preview should ever be removed."""
+    target = Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos")
+    index_documents([target], index_path)
+
+    # Find a real term this document is filed under that ISN'T one of the seed terms this
+    # --domain run will use, then plant an unrelated blacklisted document on that same page -
+    # simulating a hash collision with a document that was never reachable from the seed terms.
+    tokenized = tokenize_document(target.url, target.title, target.extract, None)
+    guessed = guess_terms_for_domain("fineartteens.com")
+    collision_term = next(t for t in tokenized.tokens if t not in guessed)
+    unrelated = Document(title="Unrelated bad site", url="https://otherbad.example/z", extract="unrelated")
+    _put(index_path, collision_term, unrelated)
+
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com", "otherbad.example"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--domain", "fineartteens.com")
+
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://otherbad.example/z" in urls  # not swept up, even though also blacklisted
 
 
 @pytest.mark.django_db

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -37,6 +37,17 @@ def _get_all_urls(index_path, num_pages=10):
     return urls
 
 
+def _index_without_blacklist(documents, index_path):
+    """index_documents() now enforces the blacklist itself (see index_batches.py), so
+    seeding a test index with documents on a domain that's for real blacklisted (e.g.
+    fineartteens.com, added to settings.EXCLUDED_DOMAINS) needs this to bypass it -
+    simulating content that was indexed *before* the domain was blacklisted, which is
+    the scenario these purge tests are about."""
+    with patch("mwmbl.indexer.index_batches.get_default_blacklist_provider",
+               return_value=StaticBlacklistProvider(set())):
+        index_documents(documents, index_path)
+
+
 def _write_csv(tmp_path, *queries):
     path = tmp_path / "queries.csv"
     lines = ["Top queries,Clicks,Impressions,CTR,Position"]
@@ -85,7 +96,7 @@ def test_targeted_domain_finds_via_guessed_terms(index_path):
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
         Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
             override_settings(DATA_PATH="", INDEX_NAME=index_path):
@@ -99,7 +110,7 @@ def test_targeted_domain_finds_via_guessed_terms(index_path):
 @pytest.mark.django_db
 def test_targeted_domain_dry_run_does_not_modify_index(index_path):
     documents = [Document(title="Fine Art Teens", url="https://fineartteens.com/x", extract="teen gallery")]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
             override_settings(DATA_PATH="", INDEX_NAME=index_path):
@@ -115,7 +126,7 @@ def test_targeted_extra_term_reaches_pages_domain_guess_alone_would_miss(index_p
     documents = [
         Document(title="Kusowanka - Hentai Posts, XXX Toons", url="https://kusowanka.com/", extract="anime porn"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
 
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
             override_settings(DATA_PATH="", INDEX_NAME=index_path):
@@ -140,7 +151,7 @@ def test_targeted_purge_does_not_sweep_unrelated_document_sharing_a_page(tmp_pat
     index_path = str(path)
 
     target = Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos")
-    index_documents([target], index_path)
+    _index_without_blacklist([target], index_path)
 
     # Find a real term this document is filed under whose PAGE isn't any seed page (comparing
     # page indexes, not term strings, since two different terms can still hash to the same
@@ -172,7 +183,7 @@ def test_csv_auto_detects_blacklisted_domain_from_query_results(index_path, tmp_
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
         Document(title="Good Example", url="https://example.com/y", extract="fineartteens is not this site"),
     ]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
     csv_path = _write_csv(tmp_path, "fineartteens", "unrelated query with no results")
 
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
@@ -187,7 +198,7 @@ def test_csv_auto_detects_blacklisted_domain_from_query_results(index_path, tmp_
 @pytest.mark.django_db
 def test_csv_with_no_matching_blacklisted_domains_changes_nothing(index_path, tmp_path):
     documents = [Document(title="Good Example", url="https://example.com/y", extract="a good example page")]
-    index_documents(documents, index_path)
+    _index_without_blacklist(documents, index_path)
     csv_path = _write_csv(tmp_path, "good example")
 
     with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.tinysearchengine.indexer import Document, PAGE_SIZE, TinyIndex
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=10, page_size=PAGE_SIZE)
+    return str(path)
+
+
+def _put(index_path, term, doc):
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="w") as index:
+        page = index.get_key_page_index(term)
+        existing = index.get_page(page)
+        doc.term = term
+        index.store_in_page(page, existing + [doc])
+
+
+def _get_all_urls(index_path, num_pages=10):
+    urls = []
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+        for page_index in range(num_pages):
+            urls.extend(doc.url for doc in index.get_page(page_index))
+    return urls
+
+
+@pytest.mark.django_db
+def test_purge_removes_blacklisted_domain_only(index_path):
+    _put(index_path, "term", Document("Bad", "https://fineartteens.com/x", "extract"))
+    _put(index_path, "term", Document("Good", "https://example.com/y", "extract"))
+
+    with patch(
+        "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider",
+        return_value=StaticBlacklistProvider({"fineartteens.com"}),
+    ), override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains")
+
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://example.com/y" in urls
+
+
+@pytest.mark.django_db
+def test_purge_dry_run_does_not_modify_index(index_path):
+    _put(index_path, "term", Document("Bad", "https://fineartteens.com/x", "extract"))
+
+    with patch(
+        "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider",
+        return_value=StaticBlacklistProvider({"fineartteens.com"}),
+    ), override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--dry-run")
+
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" in urls

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -8,6 +8,8 @@ from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
 from mwmbl.indexer.index_batches import index_documents
 from mwmbl.tinysearchengine.indexer import Document, PAGE_SIZE, TinyIndex
 
+PATCH_TARGET = "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider"
+
 
 @pytest.fixture
 def index_path(tmp_path):
@@ -17,6 +19,7 @@ def index_path(tmp_path):
 
 
 def _put(index_path, term, doc):
+    """Force a document onto the page for a specific term, bypassing real tokenization."""
     with TinyIndex(item_factory=Document, index_path=index_path, mode="w") as index:
         page = index.get_key_page_index(term)
         existing = index.get_page(page)
@@ -32,16 +35,28 @@ def _get_all_urls(index_path, num_pages=10):
     return urls
 
 
+def _write_csv(tmp_path, *queries):
+    path = tmp_path / "queries.csv"
+    lines = ["Top queries,Clicks,Impressions,CTR,Position"]
+    lines += [f"{q},0,1,0%,1" for q in queries]
+    path.write_text("\n".join(lines) + "\n")
+    return str(path)
+
+
 @pytest.mark.django_db
-def test_purge_removes_blacklisted_domain_only(index_path):
+def test_purge_requires_a_mode(index_path):
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path), pytest.raises(ValueError):
+        call_command("purge_blacklisted_domains")
+
+
+@pytest.mark.django_db
+def test_full_scan_removes_blacklisted_domain_only(index_path):
     _put(index_path, "term", Document("Bad", "https://fineartteens.com/x", "extract"))
     _put(index_path, "term", Document("Good", "https://example.com/y", "extract"))
 
-    with patch(
-        "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider",
-        return_value=StaticBlacklistProvider({"fineartteens.com"}),
-    ), override_settings(DATA_PATH="", INDEX_NAME=index_path):
-        call_command("purge_blacklisted_domains")
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--full-scan")
 
     urls = _get_all_urls(index_path)
     assert "https://fineartteens.com/x" not in urls
@@ -49,23 +64,20 @@ def test_purge_removes_blacklisted_domain_only(index_path):
 
 
 @pytest.mark.django_db
-def test_purge_dry_run_does_not_modify_index(index_path):
+def test_full_scan_dry_run_does_not_modify_index(index_path):
     _put(index_path, "term", Document("Bad", "https://fineartteens.com/x", "extract"))
 
-    with patch(
-        "mwmbl.management.commands.purge_blacklisted_domains.get_default_blacklist_provider",
-        return_value=StaticBlacklistProvider({"fineartteens.com"}),
-    ), override_settings(DATA_PATH="", INDEX_NAME=index_path):
-        call_command("purge_blacklisted_domains", "--dry-run")
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--full-scan", "--dry-run")
 
-    urls = _get_all_urls(index_path)
-    assert "https://fineartteens.com/x" in urls
+    assert "https://fineartteens.com/x" in _get_all_urls(index_path)
 
 
 @pytest.mark.django_db
-def test_purge_targeted_finds_domain_via_guessed_terms(index_path):
-    """With no --term, the domain's own name (run through the real tokenizer, the same
-    way the indexer would have derived tokens from the URL) is enough to find and
+def test_targeted_domain_finds_via_guessed_terms(index_path):
+    """With --domain and no --term, the domain's own name (run through the real tokenizer,
+    the same way the indexer would have derived tokens from the URL) is enough to find and
     remove every page it was actually filed under."""
     documents = [
         Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
@@ -73,7 +85,8 @@ def test_purge_targeted_finds_domain_via_guessed_terms(index_path):
     ]
     index_documents(documents, index_path)
 
-    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
         call_command("purge_blacklisted_domains", "--domain", "fineartteens.com")
 
     urls = _get_all_urls(index_path)
@@ -82,18 +95,19 @@ def test_purge_targeted_finds_domain_via_guessed_terms(index_path):
 
 
 @pytest.mark.django_db
-def test_purge_targeted_dry_run_does_not_modify_index(index_path):
+def test_targeted_domain_dry_run_does_not_modify_index(index_path):
     documents = [Document(title="Fine Art Teens", url="https://fineartteens.com/x", extract="teen gallery")]
     index_documents(documents, index_path)
 
-    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
         call_command("purge_blacklisted_domains", "--domain", "fineartteens.com", "--dry-run")
 
     assert "https://fineartteens.com/x" in _get_all_urls(index_path)
 
 
 @pytest.mark.django_db
-def test_purge_targeted_uses_extra_terms_as_seeds(index_path):
+def test_targeted_extra_term_reaches_pages_domain_guess_alone_would_miss(index_path):
     """A --term seed reaches a page the domain-guessed terms alone wouldn't hit,
     e.g. a term that only appears in the title/extract, not the URL."""
     documents = [
@@ -101,12 +115,42 @@ def test_purge_targeted_uses_extra_terms_as_seeds(index_path):
     ]
     index_documents(documents, index_path)
 
-    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
         call_command("purge_blacklisted_domains", "--domain", "kusowanka.com", "--term", "hentai")
 
     assert "https://kusowanka.com/" not in _get_all_urls(index_path)
 
 
-def test_purge_targeted_term_without_domain_raises(index_path):
-    with override_settings(DATA_PATH="", INDEX_NAME=index_path), pytest.raises(ValueError):
-        call_command("purge_blacklisted_domains", "--term", "hentai")
+@pytest.mark.django_db
+def test_csv_auto_detects_blacklisted_domain_from_query_results(index_path, tmp_path):
+    """The primary workflow: feed in a Search Console query export, and any indexed result
+    for those queries that's blacklisted (checked against the real, full blacklist config -
+    no manual domain list needed) gets purged from every page it's filed under."""
+    documents = [
+        Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
+        Document(title="Good Example", url="https://example.com/y", extract="fineartteens is not this site"),
+    ]
+    index_documents(documents, index_path)
+    csv_path = _write_csv(tmp_path, "fineartteens", "unrelated query with no results")
+
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider({"fineartteens.com"})), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--csv", csv_path)
+
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://example.com/y" in urls
+
+
+@pytest.mark.django_db
+def test_csv_with_no_matching_blacklisted_domains_changes_nothing(index_path, tmp_path):
+    documents = [Document(title="Good Example", url="https://example.com/y", extract="a good example page")]
+    index_documents(documents, index_path)
+    csv_path = _write_csv(tmp_path, "good example")
+
+    with patch(PATCH_TARGET, return_value=StaticBlacklistProvider(set())), \
+            override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--csv", csv_path)
+
+    assert "https://example.com/y" in _get_all_urls(index_path)

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -125,21 +125,32 @@ def test_targeted_extra_term_reaches_pages_domain_guess_alone_would_miss(index_p
 
 
 @pytest.mark.django_db
-def test_targeted_purge_does_not_sweep_unrelated_document_sharing_a_page(index_path):
+def test_targeted_purge_does_not_sweep_unrelated_document_sharing_a_page(tmp_path):
     """Regression test: expanding to every page a matched document's own tokens hash to can
     land on a page shared with a totally unrelated document (a real risk with generic terms
     like "com" or "you" on a large index). That unrelated document must not be swept up and
     removed just because it also happens to be blacklisted - only the documents actually
     shown in the preview should ever be removed."""
+    # A larger page count than the other tests here, so there's room to find a token whose
+    # page genuinely doesn't coincide with any seed page by chance (with only e.g. 10 pages,
+    # unrelated terms collide onto the same page constantly, which would make the "unrelated"
+    # document actually reachable from the seed terms too - not what this test is checking).
+    path = tmp_path / "test.tinysearch"
+    TinyIndex.create(item_factory=Document, index_path=str(path), num_pages=5000, page_size=PAGE_SIZE)
+    index_path = str(path)
+
     target = Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos")
     index_documents([target], index_path)
 
-    # Find a real term this document is filed under that ISN'T one of the seed terms this
-    # --domain run will use, then plant an unrelated blacklisted document on that same page -
-    # simulating a hash collision with a document that was never reachable from the seed terms.
+    # Find a real term this document is filed under whose PAGE isn't any seed page (comparing
+    # page indexes, not term strings, since two different terms can still hash to the same
+    # page), then plant an unrelated blacklisted document on that page - simulating a hash
+    # collision with a document that was never reachable from the seed terms.
     tokenized = tokenize_document(target.url, target.title, target.extract, None)
-    guessed = guess_terms_for_domain("fineartteens.com")
-    collision_term = next(t for t in tokenized.tokens if t not in guessed)
+    with TinyIndex(item_factory=Document, index_path=index_path, mode="r") as index:
+        seed_pages = {index.get_key_page_index(t) for t in guess_terms_for_domain("fineartteens.com")}
+        collision_term = next(t for t in tokenized.tokens if index.get_key_page_index(t) not in seed_pages)
+
     unrelated = Document(title="Unrelated bad site", url="https://otherbad.example/z", extract="unrelated")
     _put(index_path, collision_term, unrelated)
 
@@ -147,7 +158,7 @@ def test_targeted_purge_does_not_sweep_unrelated_document_sharing_a_page(index_p
             override_settings(DATA_PATH="", INDEX_NAME=index_path):
         call_command("purge_blacklisted_domains", "--domain", "fineartteens.com")
 
-    urls = _get_all_urls(index_path)
+    urls = _get_all_urls(index_path, num_pages=5000)
     assert "https://fineartteens.com/x" not in urls
     assert "https://otherbad.example/z" in urls  # not swept up, even though also blacklisted
 

--- a/test/test_purge_blacklisted_domains.py
+++ b/test/test_purge_blacklisted_domains.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.indexer.index_batches import index_documents
 from mwmbl.tinysearchengine.indexer import Document, PAGE_SIZE, TinyIndex
 
 
@@ -59,3 +60,53 @@ def test_purge_dry_run_does_not_modify_index(index_path):
 
     urls = _get_all_urls(index_path)
     assert "https://fineartteens.com/x" in urls
+
+
+@pytest.mark.django_db
+def test_purge_targeted_finds_domain_via_guessed_terms(index_path):
+    """With no --term, the domain's own name (run through the real tokenizer, the same
+    way the indexer would have derived tokens from the URL) is enough to find and
+    remove every page it was actually filed under."""
+    documents = [
+        Document(title="Fine Art Teens - galleries", url="https://fineartteens.com/x", extract="teen gallery photos"),
+        Document(title="Good Example", url="https://example.com/y", extract="a good example page"),
+    ]
+    index_documents(documents, index_path)
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--domain", "fineartteens.com")
+
+    urls = _get_all_urls(index_path)
+    assert "https://fineartteens.com/x" not in urls
+    assert "https://example.com/y" in urls
+
+
+@pytest.mark.django_db
+def test_purge_targeted_dry_run_does_not_modify_index(index_path):
+    documents = [Document(title="Fine Art Teens", url="https://fineartteens.com/x", extract="teen gallery")]
+    index_documents(documents, index_path)
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--domain", "fineartteens.com", "--dry-run")
+
+    assert "https://fineartteens.com/x" in _get_all_urls(index_path)
+
+
+@pytest.mark.django_db
+def test_purge_targeted_uses_extra_terms_as_seeds(index_path):
+    """A --term seed reaches a page the domain-guessed terms alone wouldn't hit,
+    e.g. a term that only appears in the title/extract, not the URL."""
+    documents = [
+        Document(title="Kusowanka - Hentai Posts, XXX Toons", url="https://kusowanka.com/", extract="anime porn"),
+    ]
+    index_documents(documents, index_path)
+
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path):
+        call_command("purge_blacklisted_domains", "--domain", "kusowanka.com", "--term", "hentai")
+
+    assert "https://kusowanka.com/" not in _get_all_urls(index_path)
+
+
+def test_purge_targeted_term_without_domain_raises(index_path):
+    with override_settings(DATA_PATH="", INDEX_NAME=index_path), pytest.raises(ValueError):
+        call_command("purge_blacklisted_domains", "--term", "hentai")


### PR DESCRIPTION
…command

Google Search Console surfaced several adult/fetish imageboard sites (fineartteens.com, milforia.com, azgals.com, kusowanka.com, and various *.booru.org subdomains) ranking for suspicious queries. The existing blacklist only matched domains literally containing porn/xxx/adult, so these slipped through.

- Add the confirmed domains to EXCLUDED_DOMAINS and extend the regex to cover hentai and the whole booru.org platform.
- Add AdultContentBlacklistProvider, pulling in The Block List Project's maintained ~950k-domain list, to close the general gap rather than just today's specific hits.
- Add purge_blacklisted_domains management command: blacklisting only ever stopped new crawling, nothing removed pages already indexed.