### PR TITLE
Add an MWMBL_APP for running the background task queue

### DIFF
--- a/mwmbl/main.py
+++ b/mwmbl/main.py
@@ -1,10 +1,43 @@
+import logging
 import multiprocessing
 import os
+from time import sleep
 
 import django
 from django.core.management import call_command
 from gunicorn.app.base import BaseApplication
 from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+# How long to wait before restarting the task queue if it ever exits. With --duration 0
+# process_tasks loops forever and, on Linux, does not even handle SIGTERM (its
+# SignalManager only binds that on Windows), so returning at all means something went
+# wrong - a database outage propagating out of run_next_task, say. Restarting matters
+# because the alternative is the queue silently stopping, which is how every periodic
+# task came to be months out of date in the first place.
+TASK_QUEUE_RESTART_SECONDS = 10
+
+
+def run_background_tasks():
+    """Run the django-background-tasks queue. Entry point for the child process.
+
+    Started with the 'spawn' method, so this gets a fresh interpreter and has to set
+    Django up itself. That is the point: a forked child would inherit the parent's
+    Postgres and Redis sockets, and two processes reading from one connection corrupts
+    both. Spawning costs a few seconds of startup, once per container.
+    """
+    django.setup()
+
+    # Importing the module is what registers the @background functions - the decorator
+    # runs at import time, and process_tasks' own autodiscover() only looks for
+    # <app>/tasks.py, which mwmbl does not have. test_process_tasks_worker.py guards this.
+    from mwmbl import background  # noqa: F401
+
+    while True:
+        call_command("process_tasks")
+        logger.error("Background task queue exited; restarting in %ds", TASK_QUEUE_RESTART_SECONDS)
+        sleep(TASK_QUEUE_RESTART_SECONDS)
 
 
 def run():
@@ -22,6 +55,11 @@ def run():
 
     call_command("migrate")
 
+    # DEPRECATED: update_urls, update_batches, copy_indexes and count_urls are no longer
+    # deployed. "server" is the only app that runs, and it now also runs the background
+    # task queue (see below). They are kept here rather than deleted because the code
+    # they call is still reachable from the management commands and the standalone
+    # crawler; treat them as unmaintained.
     mwmbl_app = os.environ["MWMBL_APP"]
     if mwmbl_app == "update_urls":
         redis: Redis = Redis.from_url(os.environ.get("REDIS_URL", "redis://127.0.0.1:6379"), decode_responses=True)
@@ -34,17 +72,25 @@ def run():
     elif mwmbl_app == "count_urls":
         count_urls_continuously()
     elif mwmbl_app == "process_tasks":
-        # Runs the django-background-tasks queue. Without a process running this, the
-        # @background functions in mwmbl.background only ever get *scheduled* - apps.ready()
-        # writes a Task row and nothing executes it - so they sit pending indefinitely,
-        # which is exactly what had happened to every periodic task in production.
-        #
-        # The tasks are registered by the @background decorator at import time, so this
-        # relies on `from mwmbl import background` above having run; process_tasks' own
-        # autodiscover() only looks for <app>/tasks.py, which mwmbl does not have.
-        # test_process_tasks_worker.py guards that.
-        call_command("process_tasks")
+        # The task queue on its own, for running it in a container of its own rather than
+        # alongside the server. Not currently deployed - RUN_BACKGROUND_TASKS on the
+        # server app is how it runs - but it is the way to isolate the queue if the tasks
+        # ever outgrow sharing a container with the web workers.
+        run_background_tasks()
     elif mwmbl_app == "server":
+        if settings.RUN_BACKGROUND_TASKS:
+            # Before gunicorn forks, so there is one queue process per container rather
+            # than one per worker. daemon=True ties its lifetime to this process, so it
+            # goes away when the container stops.
+            #
+            # Without this, the @background functions in mwmbl.background only ever get
+            # *scheduled*: apps.ready() writes a Task row and nothing executes it. Every
+            # periodic task in production had been pending, unattempted, for months.
+            process = multiprocessing.get_context("spawn").Process(
+                target=run_background_tasks, name="background-tasks", daemon=True)
+            process.start()
+            logger.info("Started the background task queue (pid %d)", process.pid)
+
         workers = multiprocessing.cpu_count() * 2 + 1
 
         class GunicornApp(BaseApplication):

--- a/mwmbl/main.py
+++ b/mwmbl/main.py
@@ -33,6 +33,17 @@ def run():
         background.copy_indexes_continuously()
     elif mwmbl_app == "count_urls":
         count_urls_continuously()
+    elif mwmbl_app == "process_tasks":
+        # Runs the django-background-tasks queue. Without a process running this, the
+        # @background functions in mwmbl.background only ever get *scheduled* - apps.ready()
+        # writes a Task row and nothing executes it - so they sit pending indefinitely,
+        # which is exactly what had happened to every periodic task in production.
+        #
+        # The tasks are registered by the @background decorator at import time, so this
+        # relies on `from mwmbl import background` above having run; process_tasks' own
+        # autodiscover() only looks for <app>/tasks.py, which mwmbl does not have.
+        # test_process_tasks_worker.py guards that.
+        call_command("process_tasks")
     elif mwmbl_app == "server":
         workers = multiprocessing.cpu_count() * 2 + 1
 

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -199,6 +199,17 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 # Gates database initialisation and background task scheduling; False for the crawler and tests.
 HAS_DATABASE = True
 
+# Whether this container runs the django-background-tasks queue (see mwmbl.main). Note the
+# distinction from HAS_DATABASE above: that gates *scheduling* the tasks, this gates
+# *running* them.
+#
+# Opt-in rather than on by default because beta shares its database, index and Redis with
+# production. Exactly one deployment should run the queue, and it should be production:
+# the tasks report billable usage to Polar and write to the index, so a beta container
+# picking up the same rows would do both against production. Turn it on with
+# `dokku config:set <app> RUN_BACKGROUND_TASKS=true`.
+RUN_BACKGROUND_TASKS = os.environ.get("RUN_BACKGROUND_TASKS", "false").lower() == "true"
+
 
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
 

--- a/test/test_process_tasks_worker.py
+++ b/test/test_process_tasks_worker.py
@@ -1,0 +1,92 @@
+"""Tests for the MWMBL_APP=process_tasks worker (mwmbl.main).
+
+The @background functions in mwmbl.background are only ever *scheduled* by
+apps.ready() - it writes a Task row and returns. Something has to execute those rows,
+and django-background-tasks' answer is `manage.py process_tasks`. Until this worker
+existed there was no way to deploy one from the app image, and every periodic task in
+production had sat pending, unattempted, for months.
+"""
+import pytest
+from background_task.models import Task
+from background_task.tasks import tasks
+from django.core.cache import cache
+
+from mwmbl import background, main
+from mwmbl.apps import MwmblConfig
+
+
+@pytest.fixture
+def clear_schedule_lock():
+    """_schedule_background_tasks() no-ops while the lock is held, and the lock lives in
+    the shared Redis cache rather than the test database."""
+    cache.delete(MwmblConfig._SCHEDULE_LOCK_KEY)
+    yield
+    cache.delete(MwmblConfig._SCHEDULE_LOCK_KEY)
+
+# The names apps.py schedules Task rows under.
+SCHEDULED_TASK_NAMES = [
+    "mwmbl.background.sync_search_counts",
+    "mwmbl.background.report_usage_to_polar",
+]
+
+
+def test_scheduled_tasks_are_registered_under_the_names_they_are_scheduled_as():
+    """The link between the scheduled row and the runnable function is a bare string.
+
+    DBTaskRunner.get_task_to_run skips any row whose task_name is not in the registry,
+    silently and without incrementing attempts, so a function renamed or moved out of
+    mwmbl.background would not fail - the rows would just stop being picked up and the
+    task would quietly never run again. That is the failure this asserts against.
+    """
+    for task_name in SCHEDULED_TASK_NAMES:
+        assert task_name in tasks._tasks
+
+
+def test_the_registry_points_at_the_real_functions_in_mwmbl_background():
+    """process_tasks' own autodiscover() imports <app>/tasks.py, which mwmbl does not
+    have - so registration comes from mwmbl.main importing mwmbl.background. Moving these
+    functions to a module nothing imports would leave the worker running with an empty
+    registry, which no other test would notice."""
+    for task_name in SCHEDULED_TASK_NAMES:
+        function_name = task_name.rsplit(".", 1)[1]
+        assert tasks._tasks[task_name].task_function is getattr(background, function_name).task_function
+
+
+@pytest.mark.django_db
+def test_every_task_apps_schedules_can_actually_be_run_by_the_worker(clear_schedule_lock):
+    """The end-to-end invariant, rather than the two lists agreeing by hand.
+
+    apps.ready() writes Task rows; the worker matches them back to functions by name. A
+    row whose name is not in the registry is skipped silently and forever, so scheduling
+    something the worker cannot run is a failure that produces no error anywhere.
+    """
+    MwmblConfig._schedule_background_tasks()
+
+    scheduled_names = set(Task.objects.values_list("task_name", flat=True))
+
+    assert scheduled_names  # guard against the assertion below passing vacuously
+    assert scheduled_names <= set(tasks._tasks)
+
+
+@pytest.fixture
+def recorded_commands(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "call_command", lambda command, *args, **kwargs: calls.append(command))
+    return calls
+
+
+def test_process_tasks_app_runs_the_queue(recorded_commands, monkeypatch):
+    monkeypatch.setenv("MWMBL_APP", "process_tasks")
+
+    main.run()
+
+    assert "process_tasks" in recorded_commands
+    # Migrations run first, as they do for every other MWMBL_APP.
+    assert recorded_commands.index("migrate") < recorded_commands.index("process_tasks")
+
+
+def test_unknown_app_still_raises(recorded_commands, monkeypatch):
+    monkeypatch.setenv("MWMBL_APP", "not_an_app")
+
+    with pytest.raises(ValueError, match="Unknown MWMBL_APP"):
+        main.run()

--- a/test/test_process_tasks_worker.py
+++ b/test/test_process_tasks_worker.py
@@ -75,14 +75,105 @@ def recorded_commands(monkeypatch):
     return calls
 
 
-def test_process_tasks_app_runs_the_queue(recorded_commands, monkeypatch):
-    monkeypatch.setenv("MWMBL_APP", "process_tasks")
+class StopLoop(Exception):
+    """Breaks run_background_tasks' otherwise infinite restart loop."""
+
+
+@pytest.fixture
+def stop_after_two_runs(monkeypatch, recorded_commands):
+    def fake_sleep(seconds):
+        assert seconds == main.TASK_QUEUE_RESTART_SECONDS
+        if recorded_commands.count("process_tasks") >= 2:
+            raise StopLoop
+    monkeypatch.setattr(main, "sleep", fake_sleep)
+
+
+def test_the_queue_is_restarted_if_it_ever_exits(recorded_commands, stop_after_two_runs):
+    """process_tasks with --duration 0 loops forever and, on Linux, does not even handle
+    SIGTERM - its SignalManager only binds that on Windows. So returning means something
+    went wrong, and the queue has to come back: the failure being guarded against is the
+    tasks silently stopping, which is how they came to be months out of date."""
+    with pytest.raises(StopLoop):
+        main.run_background_tasks()
+
+    assert recorded_commands == ["process_tasks", "process_tasks"]
+
+
+class FakeGunicorn:
+    """Stands in for BaseApplication so the server branch does not start a real server."""
+    runs = 0
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run(self):
+        FakeGunicorn.runs += 1
+
+
+@pytest.fixture
+def fake_server(monkeypatch):
+    FakeGunicorn.runs = 0
+    monkeypatch.setattr(main, "BaseApplication", FakeGunicorn)
+
+    spawned = []
+    monkeypatch.setattr(main.multiprocessing, "get_context",
+                        lambda method: _FakeContext(method, spawned))
+    monkeypatch.setenv("MWMBL_APP", "server")
+    return spawned
+
+
+class _FakeContext:
+    def __init__(self, method, spawned):
+        self.method = method
+        self.spawned = spawned
+
+    def Process(self, target, name, daemon):
+        self.spawned.append({"method": self.method, "target": target, "name": name, "daemon": daemon})
+        return _FakeProcess()
+
+
+class _FakeProcess:
+    pid = 4242
+
+    def start(self):
+        pass
+
+
+def test_server_starts_the_queue_when_enabled(settings, fake_server, recorded_commands):
+    settings.RUN_BACKGROUND_TASKS = True
 
     main.run()
 
-    assert "process_tasks" in recorded_commands
+    assert len(fake_server) == 1
+    started = fake_server[0]
+    assert started["target"] is main.run_background_tasks
+    # Spawn, not fork: a forked child would inherit the parent's Postgres and Redis
+    # sockets. Daemonic so it dies with the container rather than outliving it.
+    assert started["method"] == "spawn"
+    assert started["daemon"]
+    assert FakeGunicorn.runs == 1
+
+
+def test_server_does_not_start_the_queue_by_default(settings, fake_server, recorded_commands):
+    # Off unless opted in, because beta shares a database and index with production and
+    # only one deployment should be running the tasks.
+    settings.RUN_BACKGROUND_TASKS = False
+
+    main.run()
+
+    assert fake_server == []
+    assert FakeGunicorn.runs == 1
+
+
+def test_process_tasks_app_runs_the_queue(recorded_commands, stop_after_two_runs, monkeypatch):
+    monkeypatch.setenv("MWMBL_APP", "process_tasks")
+
+    with pytest.raises(StopLoop):
+        main.run()
+
     # Migrations run first, as they do for every other MWMBL_APP.
-    assert recorded_commands.index("migrate") < recorded_commands.index("process_tasks")
+    assert recorded_commands[0] == "migrate"
+    assert "process_tasks" in recorded_commands
 
 
 def test_unknown_app_still_raises(recorded_commands, monkeypatch):


### PR DESCRIPTION
The @background functions in mwmbl.background are only ever *scheduled*: apps.ready() writes a Task row and returns. Executing those rows is `manage.py process_tasks`' job, and there was no MWMBL_APP that ran it - so there was no way to deploy that worker from the app image at all.

The consequence is visible in production's task list: every row has a run_at in the past and 0 attempts, going back to sync_search_counts on 16 April. Task.create_repetition() winds run_at forward past now on each successful run, so a healthy repeating task always shows a *future* run_at - these have never been picked up. That includes report_usage_to_polar, which means billable usage overage has not been reported since the row was created.

Registration is by import: the @background decorator runs when mwmbl.background is imported, and process_tasks' own autodiscover() only looks for <app>/tasks.py, which mwmbl does not have. run() already imports the module, and the tests pin that along with the invariant that matters - every task name apps.py schedules is one the worker can actually run. A row whose name is missing from the registry is skipped silently and forever, without incrementing attempts, so this class of mistake produces no error anywhere.

Deploying the worker is a separate step, and starting one will immediately run everything that has accumulated.