### PR TITLE
Cache Wikipedia results in the index instead of on disk

### DIFF
--- a/mwmbl/apps.py
+++ b/mwmbl/apps.py
@@ -88,14 +88,15 @@ class MwmblConfig(AppConfig):
         try:
             from background_task.models import Task
             from mwmbl.background import (
-                purge_blacklisted_from_queue, refresh_blacklist_snapshot, report_usage_to_polar,
-                sync_search_counts,
+                index_wiki_results_from_queue, purge_blacklisted_from_queue,
+                refresh_blacklist_snapshot, report_usage_to_polar, sync_search_counts,
             )
 
             SYNC_TASK = "mwmbl.background.sync_search_counts"
             POLAR_REPORT_TASK = "mwmbl.background.report_usage_to_polar"
             BLACKLIST_SNAPSHOT_TASK = "mwmbl.background.refresh_blacklist_snapshot"
             BLACKLIST_PURGE_TASK = "mwmbl.background.purge_blacklisted_from_queue"
+            WIKI_INDEX_TASK = "mwmbl.background.index_wiki_results_from_queue"
 
             # Sync search counts once per hour (3600 seconds)
             if not Task.objects.filter(task_name=SYNC_TASK).exists():
@@ -117,6 +118,12 @@ class MwmblConfig(AppConfig):
             if not Task.objects.filter(task_name=BLACKLIST_PURGE_TASK).exists():
                 purge_blacklisted_from_queue(
                     repeat=settings.BLACKLIST_PURGE_INTERVAL_SECONDS, repeat_until=None)
+
+            # Write the Wikipedia results searches have found into the index. Until this
+            # runs, a repeated query re-fetches from Wikipedia, so the interval is short.
+            if not Task.objects.filter(task_name=WIKI_INDEX_TASK).exists():
+                index_wiki_results_from_queue(
+                    repeat=settings.WIKI_CACHE_INDEX_INTERVAL_SECONDS, repeat_until=None)
 
         except Exception:
             # Don't prevent startup if background task scheduling fails

--- a/mwmbl/background.py
+++ b/mwmbl/background.py
@@ -6,9 +6,11 @@ Also contains Django Background Tasks for periodic maintenance:
   - report_usage_to_polar: reports billable usage overage to Polar once per hour
   - refresh_blacklist_snapshot: rebuilds the blacklist the search path filters against
   - purge_blacklisted_from_queue: removes retrieval-filtered documents from the index
+  - index_wiki_results_from_queue: writes searches' Wikipedia results into the index
 """
 import logging
 import sys
+from collections import defaultdict
 from datetime import datetime, timezone
 from logging import getLogger, basicConfig
 from pathlib import Path
@@ -26,10 +28,13 @@ from mwmbl.indexer.batch_cache import BatchCache
 from mwmbl.indexer.blacklist_snapshot import get_snapshot_blacklist, refresh_snapshot
 from mwmbl.indexer.purge_blacklisted import purge_documents
 from mwmbl.indexer.purge_queue import drain_purge_queue, queue_size
+from mwmbl.indexer.wiki_cache import drain_wiki_queue, unseen_wiki_urls, wiki_queue_size
 from mwmbl.models import OldIndex, UsageBucket
 from mwmbl.quota import MONTHLY_TTL, _monthly_key, get_all_monthly_keys
 from mwmbl.tinysearchengine.copy_index import copy_pages
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+from mwmbl.tinysearchengine.rank import get_wiki_intro_extracts
+from mwmbl.utils import batch
 
 NUM_PAGES_TO_COPY = 1024
 
@@ -182,6 +187,99 @@ def purge_blacklisted_from_queue():
 
     logger.info("Purged %d documents from the index across %d domains; %d still queued",
                 num_removed, len(removed_by_domain), queue_size())
+
+
+# ---------------------------------------------------------------------------
+# Wikipedia results (Django Background Tasks)
+# ---------------------------------------------------------------------------
+
+def _index_wiki_term_copies(documents: list[Document], index_path: str) -> None:
+    """Write the queued per-term copies: the cache entry, plus any real query terms."""
+    page_documents = defaultdict(list)
+    with TinyIndex(Document, index_path, 'r') as index:
+        for document in documents:
+            page_documents[index.get_key_page_index(document.term)].append(document)
+
+    # Highest score first. Under the query-hash term sort_documents scores every document
+    # against a term none of them can match, so they all tie and it keeps whatever order
+    # they arrived in - and the queue is a SET drained with SPOP, so that order is
+    # arbitrary. Sorting here means a page too full to take all of a query's results keeps
+    # Wikipedia's top ones rather than three at random.
+    for documents_for_page in page_documents.values():
+        documents_for_page.sort(key=lambda document: -(document.score or 0.0))
+
+    index_batches.index_pages(index_path, page_documents)
+
+
+def _with_intro_extracts(documents: list[Document]) -> list[Document]:
+    """The same documents with the query-chosen snippet replaced by the article intro.
+
+    A search result's extract is the snippet Wikipedia picked because it matched the query.
+    For a document about to be filed under its own tokens that is doubly wrong: it is
+    arbitrary as index content, and tokenize_document tokenizes the extract, so it decides
+    which pages the document lands on. Anything we could not fetch keeps its snippet.
+
+    The term is dropped: these are going through preprocess_documents, which files them
+    under their own tokens, so a query term has no business travelling with them.
+    """
+    extracts = {}
+    titles = [document.title for document in documents]
+    for title_batch in batch(titles, settings.WIKI_INTRO_BATCH_SIZE):
+        extracts.update(get_wiki_intro_extracts(title_batch))
+
+    return [Document(title=document.title,
+                     url=document.url,
+                     extract=extracts.get(document.title, document.extract),
+                     score=document.score,
+                     state=document.state,
+                     last_crawled=document.last_crawled)
+            for document in documents]
+
+
+def _index_unseen_wiki_pages(documents: list[Document], index_path: str) -> int:
+    """Send Wikipedia pages we have not seen before through the standard indexing path."""
+    if not settings.WIKI_CACHE_GENERAL_INDEX:
+        return 0
+
+    unseen = unseen_wiki_urls(documents, settings.WIKI_CACHE_GENERAL_BATCH_SIZE)
+    if not unseen:
+        return 0
+
+    index_batches.index_documents(_with_intro_extracts(unseen), index_path)
+    return len(unseen)
+
+
+@background(schedule=0)
+def index_wiki_results_from_queue():
+    """
+    Write the Wikipedia results that searches have found into the index.
+
+    Search workers only enqueue. An index page write is a read-modify-write, and doing it
+    from every gunicorn worker on a large fraction of searches would have them fighting
+    over the same 4 KB pages, so it is serialised here - the same arrangement as the
+    blacklist purge.
+
+    Each batch does two things: writes the queued per-term copies (the cache entry under
+    the query hash, plus real query terms for the results that passed the anonymisation
+    gate), and sends any URL we have not seen before through the standard indexing path so
+    the page is discoverable generally and not only for the query that surfaced it.
+    """
+    documents = drain_wiki_queue(settings.WIKI_CACHE_INDEX_BATCH_SIZE)
+    if not documents:
+        return
+
+    index_path = str(Path(settings.DATA_PATH) / settings.INDEX_NAME)
+    # General indexing first, term copies second. combine_documents dedupes by URL across a
+    # whole page, not per term, so when a document's own tokens put it on the same page as
+    # one of its term copies, one of the two is dropped - and whichever is written last
+    # wins. The term copies are the ones a search looks up by, so they go last: losing one
+    # of ~57 general copies costs a little discoverability, while losing the cache entry
+    # would mean re-fetching from Wikipedia on every repeat of the query.
+    num_indexed = _index_unseen_wiki_pages(documents, index_path)
+    _index_wiki_term_copies(documents, index_path)
+
+    logger.info("Wrote %d Wikipedia term copies and generally indexed %d new pages; "
+                "%d entries still queued", len(documents), num_indexed, wiki_queue_size())
 
 
 @background(schedule=0)

--- a/mwmbl/indexer/index.py
+++ b/mwmbl/indexer/index.py
@@ -4,7 +4,7 @@ Create a search index
 from typing import Iterable
 from urllib.parse import unquote
 
-from mwmbl.tinysearchengine.indexer import TokenizedDocument
+from mwmbl.tinysearchengine.indexer import Document, TokenizedDocument
 from mwmbl.tokenizer import tokenize, get_bigrams
 
 DEFAULT_SCORE = 0
@@ -64,3 +64,16 @@ def tokenize_document(url, title_cleaned, extract, score):
     # print("High scoring", len(high_scoring_tokens), token_scores, doc)
     document = TokenizedDocument(tokens=list(tokens), url=url, title=title_cleaned, extract=extract, score=score)
     return document
+
+
+def document_token_set(document: Document) -> set[str]:
+    """Unigram tokens of a document's title, URL and extract (no bigrams).
+
+    Lives here rather than next to its callers in index_batches because
+    mwmbl.indexer.wiki_cache needs it too, and index_batches imports
+    mwmbl.tinysearchengine.rank, which imports wiki_cache.
+    """
+    prepared_url = prepare_url_for_tokenizing(unquote(document.url))
+    return (set(tokenize(document.title))
+            | set(tokenize(prepared_url))
+            | set(tokenize(document.extract)))

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -7,15 +7,15 @@ from datetime import datetime
 from functools import reduce
 from logging import getLogger
 from typing import Collection, Iterable, Optional
-from urllib.parse import unquote
 
 from mwmbl.crawler.batch import HashedBatch, Item
 from mwmbl.crawler.urls import URLStatus
 from mwmbl.indexer import process_batch
 from mwmbl.indexer.batch_cache import BatchCache
 from mwmbl.indexer.blacklist_snapshot import get_snapshot_blacklist
-from mwmbl.indexer.index import tokenize_document, prepare_url_for_tokenizing
+from mwmbl.indexer.index import document_token_set, tokenize_document
 from mwmbl.indexer.indexdb import BatchStatus
+from mwmbl.indexer.wiki_cache import drop_expired_wiki_cache
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex, DocumentState, CURATED_STATES
 from mwmbl.tinysearchengine.rank import score_result, DOCUMENT_FREQUENCIES, N_DOCUMENTS, HeuristicRanker
 from mwmbl.tokenizer import tokenize, get_bigrams
@@ -115,7 +115,7 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
         for page, documents in page_documents.items():
-            existing_documents = indexer.get_page(page)
+            existing_documents = drop_expired_wiki_cache(indexer.get_page(page))
             combined_documents = combine_documents(existing_documents, documents, mark_synced, ranker)
             logger.info(f"Storing {len(combined_documents)} documents for page {page}, originally {len(existing_documents)}")
             indexer.store_in_page(page, combined_documents)
@@ -123,14 +123,6 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
             term_new_doc_counts.update(document.term for document in combined_documents
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
     return term_new_doc_counts
-
-
-def _document_token_set(doc: Document) -> set[str]:
-    """Unigram tokens of a document's title, URL and extract (no bigrams)."""
-    prepared_url = prepare_url_for_tokenizing(unquote(doc.url))
-    return (set(tokenize(doc.title))
-            | set(tokenize(prepared_url))
-            | set(tokenize(doc.extract)))
 
 
 def index_results_against_query(documents: list[Document], query: str, index_path: str) -> int:
@@ -163,7 +155,7 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
         for doc in documents:
             if not (doc.url and doc.title):
                 continue
-            doc_tokens = _document_token_set(doc)
+            doc_tokens = document_token_set(doc)
             for term, words in query_terms.items():
                 if not (words <= doc_tokens):
                     continue
@@ -249,6 +241,7 @@ def preprocess_documents(documents, index_path):
                 term_document = Document(
                     document.title, document.url, document.extract,
                     term=token,
+                    state=document.state,
                     user_ids=document.user_ids,
                     last_crawled=document.last_crawled,
                 )

--- a/mwmbl/indexer/wiki_cache.py
+++ b/mwmbl/indexer/wiki_cache.py
@@ -1,0 +1,278 @@
+"""Wikipedia search results, cached in the index rather than on disk.
+
+get_wiki_results() used to cache through mwmbl.utils.request_cache, a requests-cache
+*filesystem* session with a 10-week expiry. That writes one JSON file per response into
+REQUEST_CACHE_PATH - the same volume as the index - with no LRU, no size cap and nothing
+ever calling delete(expired=True), so it grew without bound; and because the stored JSON
+holds the whole request, it wrote the raw user query to disk. The index is a fixed-size
+preallocated file, so caching in it costs no additional disk at all.
+
+A result set has up to three destinations, in increasing generality:
+
+  * the *query-hash term* (always) - `#wiki-<hmac>`, which is the cache entry. Only a
+    process holding SECRET_KEY can work out which term a query maps to.
+  * the *real query terms* (gated) - so the document turns up as an ordinary result for
+    anyone else's matching query, with source `wikipedia`.
+  * the *standard indexing path* (see mwmbl.background), for URLs not seen before, filed
+    under the document's own tokens exactly like a crawled page.
+
+Only the first two involve the query at all, and the gate is what keeps the second one
+anonymous: a document takes a real query term only if it contains every word of the
+query, so the term->document link is derivable from the document itself and says nothing
+about the query that produced it. Everything else is reachable only through the hash.
+
+Be straight about what the hash does and does not do: it removes the query *text*, not the
+fact that somebody searched for something in that area, since the entry still holds the
+Wikipedia articles that were returned. That is strictly less than the disk cache gave away.
+"""
+import hashlib
+import hmac
+import json
+import time
+from logging import getLogger
+from typing import Optional
+
+import mmh3
+import redis
+from django.conf import settings
+
+from mwmbl.indexer.index import document_token_set
+from mwmbl.tinysearchengine.indexer import Document, DocumentState, TinyIndex
+from mwmbl.tokenizer import get_bigrams, tokenize
+
+logger = getLogger(__name__)
+
+
+# Terms under this prefix are cache entries rather than words anybody searched for.
+WIKI_CACHE_TERM_PREFIX = "#wiki-"
+WIKI_CACHE_QUEUE_KEY = "wiki:index-queue"
+WIKI_GENERAL_INDEXED_KEY = "wiki:general-indexed"
+
+WIKI_STATES = {DocumentState.FROM_WIKI, DocumentState.FROM_WIKI_APPROVED}
+
+
+_redis: Optional[redis.Redis] = None
+
+
+def get_redis() -> redis.Redis:
+    global _redis
+    if _redis is None:
+        _redis = redis.from_url(settings.REDIS_URL, decode_responses=True)
+    return _redis
+
+
+def wiki_cache_term(query: str) -> str:
+    """The term a query's Wikipedia results are cached under.
+
+    Keyed on SECRET_KEY rather than a bare digest: a plain hash of a one- or two-word
+    query is trivially brute-forced from a wordlist, so an index dump would hand over the
+    queries. Keyed, the mapping is not reproducible without the key. Rotating SECRET_KEY
+    invalidates the cache, which is harmless - it is a cache.
+
+    The query is normalised through tokenize() first, so "Python" and " python " share an
+    entry.
+    """
+    normalised = " ".join(tokenize(query))
+    digest = hmac.new(settings.SECRET_KEY.encode("utf8"), normalised.encode("utf8"), hashlib.sha256)
+    return WIKI_CACHE_TERM_PREFIX + digest.hexdigest()[:16]
+
+
+def is_fresh(document: Document, now: int) -> bool:
+    """Whether a cached document is still within the TTL. Untimestamped means stale."""
+    return (document.last_crawled is not None
+            and now - document.last_crawled < settings.WIKI_CACHE_TTL_SECONDS)
+
+
+def get_cached_wiki_results(tiny_index: TinyIndex, query: str, now: Optional[int] = None) -> list[Document]:
+    """A query's cached Wikipedia results, or [] if we have none that are still fresh."""
+    if not settings.WIKI_CACHE_ENABLED:
+        return []
+
+    now = int(time.time()) if now is None else now
+    term = wiki_cache_term(query)
+    cached = [document for document in tiny_index.retrieve(term)
+              if document.term == term
+              and document.state in WIKI_STATES
+              and is_fresh(document, now)]
+
+    # Order comes from the score, not from storage order. The queue is a Redis SET drained
+    # with SPOP, so batch order is arbitrary; and under the hash term the write path scores
+    # every document against a token none of them can match, so they all tie and keep
+    # whatever order they arrived in.
+    return sorted(cached, key=lambda document: -(document.score or 0.0))
+
+
+def wiki_terms_for_documents(query: str, documents: list[Document]) -> list[Document]:
+    """The per-term index copies to write for a set of Wikipedia results.
+
+    Every usable document is filed under the query-hash term. A document is filed under
+    the real query terms as well only if the query is short enough and the document
+    contains all of its words - Wikipedia does spelling correction and partial matching,
+    so a returned document need not contain the query words at all.
+
+    last_crawled is left unset; the drain stamps it, which keeps identical results
+    enqueued seconds apart on the same payload so the queue's SET dedupe still works.
+    """
+    usable = [document for document in documents if document.url and document.title]
+    if not usable:
+        return []
+
+    cache_term = wiki_cache_term(query)
+    copies = [_term_copy(document, cache_term) for document in usable]
+
+    tokens = tokenize(query)
+    if not tokens or len(tokens) > settings.WIKI_CACHE_MAX_ORGANIC_TERM_TOKENS:
+        return copies
+
+    organic_terms = tokens + get_bigrams(len(tokens), tokens)
+    required = set(tokens)
+    for document in usable:
+        if not required <= document_token_set(document):
+            continue
+        copies += [_term_copy(document, term) for term in organic_terms]
+    return copies
+
+
+def _term_copy(document: Document, term: str) -> Document:
+    return Document(
+        title=document.title,
+        url=document.url,
+        extract=document.extract,
+        score=document.score,
+        term=term,
+        state=DocumentState.FROM_WIKI,
+    )
+
+
+def _payload(document: Document) -> str:
+    return json.dumps({
+        "url": document.url,
+        "title": document.title,
+        "extract": document.extract,
+        "score": document.score,
+        "term": document.term,
+    }, sort_keys=True)
+
+
+def enqueue_wiki_results(query: str, documents: list[Document],
+                         redis_client: Optional[redis.Redis] = None) -> int:
+    """Queue a query's Wikipedia results to be written into the index. Never raises.
+
+    The gate runs here, in the search worker, so the queue itself only ever holds terms
+    derived from the documents plus the opaque hash - the query text never leaves the
+    process. Losing an entry costs one re-fetch, which is why every failure is swallowed:
+    nothing here may affect a search response.
+    """
+    if not settings.WIKI_CACHE_ENABLED:
+        return 0
+
+    copies = wiki_terms_for_documents(query, documents)
+    if not copies:
+        return 0
+
+    payloads = list(dict.fromkeys(_payload(document) for document in copies))
+    try:
+        client = redis_client if redis_client is not None else get_redis()
+        if client.scard(WIKI_CACHE_QUEUE_KEY) >= settings.WIKI_CACHE_MAX_QUEUE_SIZE:
+            logger.warning("Wikipedia index queue is full (%d); dropping %d documents",
+                           settings.WIKI_CACHE_MAX_QUEUE_SIZE, len(payloads))
+            return 0
+        return client.sadd(WIKI_CACHE_QUEUE_KEY, *payloads)
+    except Exception:
+        logger.warning("Could not enqueue %d Wikipedia results for indexing",
+                       len(payloads), exc_info=True)
+        return 0
+
+
+def drain_wiki_queue(limit: int, redis_client: Optional[redis.Redis] = None) -> list[Document]:
+    """Remove and return up to `limit` queued documents, stamped with the current time."""
+    client = redis_client if redis_client is not None else get_redis()
+    payloads = client.spop(WIKI_CACHE_QUEUE_KEY, limit) or []
+    now = int(time.time())
+
+    documents = []
+    for payload in payloads:
+        try:
+            fields = json.loads(payload)
+            if not fields["term"]:
+                # Without a term there is no page to file it under, and
+                # get_key_page_index would raise on the background task's next run.
+                raise ValueError("queue entry has no term")
+            documents.append(Document(
+                title=fields["title"],
+                url=fields["url"],
+                extract=fields["extract"],
+                score=fields["score"],
+                term=fields["term"],
+                state=DocumentState.FROM_WIKI,
+                last_crawled=now,
+            ))
+        except (ValueError, KeyError, TypeError):
+            logger.warning("Discarding unreadable Wikipedia queue entry: %r", payload)
+    return documents
+
+
+def wiki_queue_size(redis_client: Optional[redis.Redis] = None) -> int:
+    client = redis_client if redis_client is not None else get_redis()
+    return client.scard(WIKI_CACHE_QUEUE_KEY)
+
+
+def _url_digest(url: str) -> str:
+    return format(mmh3.hash64(url, signed=False)[0], 'x')
+
+
+def unseen_wiki_urls(documents: list[Document], limit: int,
+                     redis_client: Optional[redis.Redis] = None) -> list[Document]:
+    """One document per URL not yet sent through the standard indexing path.
+
+    Records only the URLs it returns, so a document dropped by `limit` is picked up by a
+    later run rather than marked done and lost. Hashes the URLs rather than storing them
+    to keep the set small.
+
+    Being wrong is cheap in both directions - a false "seen" skips one document, a false
+    "new" repeats ~57 page writes that combine_documents dedupes by URL anyway - which is
+    also why it does not matter that prod Redis runs allkeys-lru and may evict this key.
+    """
+    by_url = {}
+    for document in documents:
+        if document.url and document.title and document.url not in by_url:
+            by_url[document.url] = document
+    if not by_url:
+        return []
+
+    urls = list(by_url)
+    try:
+        client = redis_client if redis_client is not None else get_redis()
+        pipeline = client.pipeline()
+        for url in urls:
+            pipeline.sismember(WIKI_GENERAL_INDEXED_KEY, _url_digest(url))
+        already_seen = pipeline.execute()
+
+        unseen = [url for url, seen in zip(urls, already_seen) if not seen][:limit]
+        if unseen:
+            client.sadd(WIKI_GENERAL_INDEXED_KEY, *[_url_digest(url) for url in unseen])
+    except Exception:
+        logger.warning("Could not work out which Wikipedia URLs are new", exc_info=True)
+        return []
+
+    return [by_url[url] for url in unseen]
+
+
+def drop_expired_wiki_cache(documents: list[Document], now: Optional[int] = None) -> list[Document]:
+    """Cache entries past their TTL, dropped from a page that is being rewritten anyway.
+
+    Pages are fixed-size and silently truncate their tail, so hash-term entries would
+    otherwise pile up on whatever page they landed on and never leave. Doing it here makes
+    it self-limiting: a page under write pressure cleans itself, and a page nobody rewrites
+    is not under pressure. Only hash-term copies expire - copies filed under a document's
+    own tokens are ordinary index content, not cache.
+    """
+    now = int(time.time()) if now is None else now
+    return [document for document in documents if not _is_expired_cache_entry(document, now)]
+
+
+def _is_expired_cache_entry(document: Document, now: int) -> bool:
+    return (document.term is not None
+            and document.term.startswith(WIKI_CACHE_TERM_PREFIX)
+            and document.state == DocumentState.FROM_WIKI
+            and not is_fresh(document, now))

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -332,3 +332,21 @@ BLACKLIST_SNAPSHOT_CHECK_SECONDS = 300     # how often a worker checks Redis for
 BLACKLIST_SNAPSHOT_REFRESH_SECONDS = 6 * 60 * 60   # how often the snapshot is rebuilt from the remote lists
 BLACKLIST_PURGE_INTERVAL_SECONDS = 300     # how often the purge queue is drained
 BLACKLIST_PURGE_BATCH_SIZE = 1000          # documents removed from the index per purge run
+
+# Wikipedia result caching in the index. Results used to be cached by requests-cache in a
+# filesystem backend under REQUEST_CACHE_PATH, which sits on the same volume as the index,
+# grew without bound (one file per response, no LRU, nothing calling delete(expired=True))
+# and wrote the raw user query to disk. They now live in the index itself, which is a
+# fixed-size preallocated file, so caching costs no additional disk at all.
+WIKI_CACHE_ENABLED = os.environ.get("WIKI_CACHE_ENABLED", "true").lower() != "false"
+WIKI_CACHE_TTL_SECONDS = 10 * 7 * 24 * 60 * 60   # matches the old request_cache expiry
+WIKI_CACHE_MAX_ORGANIC_TERM_TOKENS = 2   # queries up to this length can take real query terms
+WIKI_CACHE_INDEX_INTERVAL_SECONDS = 60   # how often the queue of results to index is drained
+WIKI_CACHE_INDEX_BATCH_SIZE = 1000       # queued term-copies written per run
+WIKI_CACHE_MAX_QUEUE_SIZE = 100_000
+# Wikipedia pages we have not seen before also go through the standard indexing path, filed
+# under their own tokens, so they are discoverable generally and not only for the query that
+# surfaced them. That is ~57 pages per document, so it is capped per run.
+WIKI_CACHE_GENERAL_INDEX = os.environ.get("WIKI_CACHE_GENERAL_INDEX", "true").lower() != "false"
+WIKI_CACHE_GENERAL_BATCH_SIZE = 100      # distinct new URLs generally indexed per run
+WIKI_INTRO_BATCH_SIZE = 20               # titles per prop=extracts call

--- a/mwmbl/tinysearchengine/rank.py
+++ b/mwmbl/tinysearchengine/rank.py
@@ -7,13 +7,13 @@ import time
 import urllib
 from abc import abstractmethod
 from collections import defaultdict
-from datetime import timedelta
 from logging import getLogger
 from operator import itemgetter
 from pathlib import Path
 from urllib.parse import urlparse
 
 import numpy as np
+import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter, Retry
 from requests.exceptions import RetryError
@@ -22,10 +22,13 @@ from mwmbl.format import get_query_regex
 from mwmbl.hn_top_domains_filtered import DOMAINS
 from mwmbl.indexer.blacklist_snapshot import get_snapshot_blacklist
 from mwmbl.indexer.purge_queue import enqueue_for_purge
+from mwmbl.indexer.wiki_cache import (
+    WIKI_CACHE_TERM_PREFIX, enqueue_wiki_results, get_cached_wiki_results,
+)
 from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import TinyIndex, Document, DocumentState
 from mwmbl.tokenizer import tokenize, get_bigrams
-from mwmbl.utils import get_domain, request_cache
+from mwmbl.utils import get_domain
 
 
 logger = getLogger(__name__)
@@ -51,7 +54,11 @@ def score_result(terms: list[str], result: Document, is_complete: bool):
     match_score = (4 * features['match_score_title'] + features['match_score_extract'] + 2 * features[
         'match_score_domain'] + 2 * features['match_score_domain_tokenized'] + features['match_score_path'])
 
-    if features[f'match_terms'] <= len(terms) / 2 and result.state is None:
+    # A curated document is exempt from the minimum-term-match rule: a curator put it
+    # there deliberately. FROM_WIKI is not curation - it is crawled-equivalent content,
+    # now stored in the index like any other document - so it gets no exemption, either
+    # at query time or in the write-time page ordering in sort_documents.
+    if features[f'match_terms'] <= len(terms) / 2 and result.state in (None, DocumentState.FROM_WIKI):
         return 0.0
 
     if match_score > MATCH_SCORE_THRESHOLD:
@@ -269,6 +276,11 @@ def remove_curate_state(state: DocumentState):
 
 
 class Ranker:
+    # Whether Wikipedia results are cached in the index. Off for rankers that read a
+    # remote index - there a lookup is an HTTP round trip to /raw, which does not serve
+    # cache terms anyway - or that fetch Wikipedia themselves.
+    cache_wiki_results = True
+
     def __init__(self, tiny_index: TinyIndex, completer: Completer):
         self.tiny_index = tiny_index
         self.completer = completer
@@ -322,16 +334,28 @@ class Ranker:
             completions = []
             retrieval_terms = set(terms)
 
-        # Check for curation
+        # Check for curation. A query that happens to look like a cache term is not one:
+        # see lookup_terms below.
         curation_term = " ".join(terms)
-        curation_items = self.tiny_index.retrieve(curation_term)
-        curated_items = [d for d in curation_items if d.state is not None
+        curation_items = ([] if curation_term.startswith(WIKI_CACHE_TERM_PREFIX)
+                          else self.tiny_index.retrieve(curation_term))
+        # FROM_WIKI is the one non-None state that nobody curated: it is stamped on
+        # Wikipedia results stored automatically by the cache, which for a one- or two-word
+        # query land under exactly this term. Treating those as curated would pin them above
+        # everything and skip ranking entirely. FROM_WIKI_APPROVED is real curation and stays.
+        curated_items = [d for d in curation_items
+                         if d.state is not None and d.state != DocumentState.FROM_WIKI
                          and d.term == curation_term]
 
         bigrams = set(get_bigrams(len(terms), terms))
 
+        # A user's own query must never be usable as a cache lookup, or searching for a
+        # literal "#wiki-0123456789abcdef" would read whatever query hashes to it.
+        lookup_terms = {term for term in retrieval_terms | bigrams
+                        if not term.startswith(WIKI_CACHE_TERM_PREFIX)}
+
         pages = []
-        for term in retrieval_terms | bigrams:
+        for term in lookup_terms:
             # An optimisation - we have already retrieved this, so make use of it
             if term == curation_term:
                 items = curation_items
@@ -349,9 +373,25 @@ class Ranker:
             if items is not None:
                 pages += items
 
-        external_search_items = self.external_search(q) if use_external_search else []
+        # Wikipedia results are cached in the index, under a term derived from the query by
+        # keyed hash. A hit means we neither call Wikipedia nor write anything; a miss
+        # fetches live and queues the results for a background write - see wiki_cache.
+        use_cache = use_external_search and self.cache_wiki_results
+        cached_wiki = get_cached_wiki_results(self.tiny_index, q) if use_cache else []
+        if cached_wiki:
+            external_search_items = cached_wiki
+        elif use_external_search:
+            external_search_items = self.external_search(q)
+            if use_cache:
+                enqueue_wiki_results(q, external_search_items)
+        else:
+            external_search_items = []
+
         candidates = pages + additional_results + external_search_items
-        candidates, curated_items = self._remove_blacklisted(candidates, curated_items, index_items=pages)
+        # Cached wiki results count as index items: unlike a live Wikipedia lookup they are
+        # in the index, so a blacklisted one has something to purge.
+        candidates, curated_items = self._remove_blacklisted(
+            candidates, curated_items, index_items=pages + cached_wiki)
 
         ordered_results = self.order_results(terms, candidates, is_complete)
         deduplicated_results = deduplicate(curated_items + ordered_results, set())
@@ -391,6 +431,9 @@ class Ranker:
     def get_raw_results(self, query: str):
         tokens = tokenize(query)
         term = ' '.join(tokens)
+        if term.startswith(WIKI_CACHE_TERM_PREFIX):
+            # /raw is not a way to read the Wikipedia cache either - see get_results.
+            return []
         results = self.tiny_index.retrieve(term)
         # /raw bypasses get_results(), so it needs its own filter or it is a way to read
         # blacklisted documents straight out of the index.
@@ -421,6 +464,7 @@ class HeuristicRanker(Ranker):
         return filtered_results
 
 
+WIKI_USER_AGENT = 'Mwmbl/0.1.0 (https://mwmbl.org; daoud@mwmbl.org)'
 WIKI_SEARCH_API_URL = "https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={query}&format=json"
 WIKI_URL_FORMAT = "https://en.wikipedia.org/wiki/{title}"
 
@@ -428,7 +472,9 @@ WIKI_URL_FORMAT = "https://en.wikipedia.org/wiki/{title}"
 # calls — e.g. an evaluation run that queries it once per gold query. Retry with
 # backoff, honouring any Retry-After, so a transient 429 doesn't silently drop a
 # query's wiki results. Live search never bursts, so this adds no latency in
-# normal operation. Successful responses are cached for weeks (see request_cache).
+# normal operation. Successful responses are cached in the index for weeks - see
+# mwmbl.indexer.wiki_cache, which replaced a filesystem HTTP cache that grew
+# without bound on the same volume as the index.
 WIKI_RETRY = Retry(total=4, backoff_factor=0.5, status_forcelist=(429, 502, 503, 504),
                    allowed_methods=frozenset({"GET"}), respect_retry_after_header=True)
 
@@ -481,11 +527,9 @@ def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
         return []
 
     escaped_query = urllib.parse.quote(s, safe='')
-    headers = {
-        'User-Agent': 'Mwmbl/0.1.0 (https://mwmbl.org; daoud@mwmbl.org) requests-cache'
-    }
+    headers = {'User-Agent': WIKI_USER_AGENT}
     try:
-        with request_cache(timedelta(weeks=10)) as session:
+        with requests.Session() as session:
             session.mount("https://en.wikipedia.org", HTTPAdapter(max_retries=WIKI_RETRY))
             response = session.get(WIKI_SEARCH_API_URL.format(query=escaped_query), headers=headers, timeout=5)
             wiki_response = response.json()
@@ -517,7 +561,55 @@ def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
     return wiki_results
 
 
+WIKI_EXTRACTS_API_URL = ("https://en.wikipedia.org/w/api.php?action=query&prop=extracts"
+                         "&exintro&explaintext&redirects=1&format=json&titles={titles}")
+
+
+def get_wiki_intro_extracts(titles: list[str]) -> dict[str, str]:
+    """The intro paragraph of each of these articles, keyed by title.
+
+    The extract on a search result is the snippet Wikipedia chose *because* it matched the
+    query. That is exactly right for a cache entry, but as permanent index content it is
+    arbitrary - and tokenize_document tokenizes the extract, so it also decides which pages
+    the document ends up filed under. The intro is query-independent, which is both better
+    index content and what leaves the generally indexed copies with nothing whatsoever
+    derived from a user's query.
+
+    Unlike get_wiki_results this runs in the background task, never on the search path.
+    Returns whatever it managed to fetch; the caller keeps the snippet for the rest.
+    """
+    if not titles or _wiki_circuit_open():
+        return {}
+
+    escaped_titles = urllib.parse.quote("|".join(titles), safe='|')
+    headers = {'User-Agent': WIKI_USER_AGENT}
+    try:
+        with requests.Session() as session:
+            session.mount("https://en.wikipedia.org", HTTPAdapter(max_retries=WIKI_RETRY))
+            response = session.get(WIKI_EXTRACTS_API_URL.format(titles=escaped_titles),
+                                   headers=headers, timeout=10)
+            wiki_response = response.json()
+    except RetryError as e:
+        if _is_wiki_rate_limited(e):
+            _trip_wiki_circuit()
+        logger.warning("Failed to fetch Wikipedia intros: %s", type(e).__name__)
+        return {}
+    except Exception as e:
+        logger.warning("Failed to fetch Wikipedia intros: %s", type(e).__name__)
+        return {}
+
+    pages = wiki_response.get('query', {}).get('pages', {})
+    return {page['title']: page['extract'].strip()
+            for page in pages.values()
+            if page.get('title') and page.get('extract', '').strip()}
+
+
 class HeuristicAndWikiRanker(HeuristicRanker):
+    # This ranker fetches Wikipedia itself in search() rather than through
+    # external_search(), and every caller in the tree hands it a RemoteIndex, so the index
+    # cache is both unusable and unreachable here - see Ranker.cache_wiki_results.
+    cache_wiki_results = False
+
     def __init__(
             self,
             tiny_index: TinyIndex,

--- a/scripts/index_page_occupancy.py
+++ b/scripts/index_page_occupancy.py
@@ -1,0 +1,87 @@
+"""How full are the index's pages?
+
+Pages are a fixed size and silently truncate their tail, so anything added to a page costs
+whatever was at the end of it. That makes page occupancy the number that decides how much a
+feature like the Wikipedia cache (mwmbl.indexer.wiki_cache) actually costs: on a page with
+room to spare it costs nothing, on a saturated page it evicts about as much as it adds.
+
+Run it against prod before turning the general Wikipedia indexing up:
+
+    DJANGO_SETTINGS_MODULE=mwmbl.settings_prod uv run python scripts/index_page_occupancy.py
+
+For reference, the dev index (2560 pages) measures ~35 documents and 4037 of 4096 bytes per
+page - every page over 90% full.
+"""
+import argparse
+import json
+import os
+from random import Random
+
+import django
+from zstandard import ZstdDecompressor, ZstdError
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mwmbl.settings_dev")
+django.setup()
+
+from django.conf import settings                                       # noqa: E402
+from pathlib import Path                                               # noqa: E402
+from mwmbl.tinysearchengine.indexer import (                           # noqa: E402
+    Document, METADATA_SIZE, TinyIndex,
+)
+
+
+def percentile(values: list[int], fraction: float) -> int:
+    return values[min(int(len(values) * fraction), len(values) - 1)]
+
+
+def summarise(name: str, values: list[int]) -> str:
+    values = sorted(values)
+    return (f"{name}: mean {sum(values) / len(values):.1f}  median {percentile(values, 0.5)}  "
+            f"p90 {percentile(values, 0.9)}  p99 {percentile(values, 0.99)}  max {values[-1]}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sample", type=int, default=2000, help="pages to sample")
+    parser.add_argument("--seed", type=int, default=1)
+    args = parser.parse_args()
+
+    index_path = Path(settings.DATA_PATH) / settings.INDEX_NAME
+    decompressor = ZstdDecompressor()
+
+    with TinyIndex(item_factory=Document, index_path=index_path) as index:
+        sample = Random(args.seed).sample(range(index.num_pages),
+                                          min(args.sample, index.num_pages))
+        doc_counts = []
+        bytes_used = []
+        unreadable = 0
+        for page in sample:
+            start = page * index.page_size + METADATA_SIZE
+            raw = index.mmap[start:start + index.page_size]
+            try:
+                items = json.loads(decompressor.decompress(raw).decode('utf8'))
+            except (ZstdError, ValueError):
+                unreadable += 1
+                continue
+            doc_counts.append(len(items))
+            bytes_used.append(len(raw.rstrip(b'\x00')))
+
+        page_size = index.page_size
+        num_pages = index.num_pages
+
+    sampled = len(doc_counts)
+    empty = sum(1 for count in doc_counts if count == 0)
+    nearly_full = sum(1 for used in bytes_used if used > 0.9 * page_size)
+
+    print(f"{index_path}: {num_pages} pages of {page_size} bytes")
+    print(f"sampled {sampled} pages ({unreadable} unreadable)")
+    print(summarise("documents per page", doc_counts))
+    print(summarise(f"bytes used of {page_size}", bytes_used))
+    print(f"empty pages: {100 * empty / sampled:.1f}%")
+    print(f"pages over 90% full: {100 * nearly_full / sampled:.1f}%")
+    print(f"estimated documents in the index: "
+          f"{int(sum(doc_counts) / sampled * num_pages):,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_apps_background_scheduling.py
+++ b/test/test_apps_background_scheduling.py
@@ -21,8 +21,10 @@ SYNC_TASK = "mwmbl.background.sync_search_counts"
 POLAR_REPORT_TASK = "mwmbl.background.report_usage_to_polar"
 BLACKLIST_SNAPSHOT_TASK = "mwmbl.background.refresh_blacklist_snapshot"
 BLACKLIST_PURGE_TASK = "mwmbl.background.purge_blacklisted_from_queue"
+WIKI_INDEX_TASK = "mwmbl.background.index_wiki_results_from_queue"
 
-ALL_TASKS = {SYNC_TASK, POLAR_REPORT_TASK, BLACKLIST_SNAPSHOT_TASK, BLACKLIST_PURGE_TASK}
+ALL_TASKS = {SYNC_TASK, POLAR_REPORT_TASK, BLACKLIST_SNAPSHOT_TASK, BLACKLIST_PURGE_TASK,
+             WIKI_INDEX_TASK}
 
 
 @pytest.fixture(autouse=True)
@@ -83,3 +85,12 @@ def test_blacklist_tasks_repeat_at_the_configured_intervals():
 
     assert snapshot.repeat == settings.BLACKLIST_SNAPSHOT_REFRESH_SECONDS
     assert purge.repeat == settings.BLACKLIST_PURGE_INTERVAL_SECONDS
+
+
+@pytest.mark.django_db
+def test_wiki_index_task_repeats_at_the_configured_interval():
+    MwmblConfig._schedule_background_tasks()
+
+    wiki_index = Task.objects.get(task_name=WIKI_INDEX_TASK)
+
+    assert wiki_index.repeat == settings.WIKI_CACHE_INDEX_INTERVAL_SECONDS

--- a/test/test_index_batches.py
+++ b/test/test_index_batches.py
@@ -1,16 +1,19 @@
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import fakeredis
 import pytest
+from django.conf import settings
 
 from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
 from mwmbl.indexer.blacklist_snapshot import SnapshotBlacklist
 from mwmbl.indexer.index_batches import (
     sort_documents, combine_documents, _merge_user_ids, MAX_USER_IDS,
-    index_results_against_query, index_documents,
+    index_results_against_query, index_documents, index_pages, preprocess_documents,
 )
+from mwmbl.indexer.wiki_cache import wiki_cache_term
 from mwmbl.tinysearchengine.indexer import Document, DocumentState, PAGE_SIZE, TinyIndex
 
 
@@ -269,3 +272,44 @@ def test_index_documents_keeps_everything_when_nothing_blacklisted(index_path):
         index_documents(documents, index_path)
 
     assert "https://example.com/y" in _all_urls(index_path)
+
+
+# ---------------------------------------------------------------------------
+# Wikipedia cache entries on a page being rewritten
+# ---------------------------------------------------------------------------
+
+def test_preprocess_documents_carries_the_state_onto_the_term_copies(index_path):
+    """A Wikipedia page indexed the standard way has to keep reporting source
+    `wikipedia`, so the per-token copies need its state."""
+    document = Document(title="Bananas", url="https://example.com/bananas", extract="fruit",
+                        state=DocumentState.FROM_WIKI)
+
+    page_documents = preprocess_documents([document], index_path)
+
+    copies = [copy for copies in page_documents.values() for copy in copies]
+    assert copies
+    assert {copy.state for copy in copies} == {DocumentState.FROM_WIKI}
+
+
+def test_index_pages_drops_expired_cache_entries_from_a_page_it_rewrites(index_path):
+    """Pages truncate their tail, so cache entries would otherwise pile up on whatever page
+    they landed on and never leave. index_pages is where a page gets rewritten anyway."""
+    cache_term = wiki_cache_term("bananas")
+    stale = Document(title="Stale", url="https://stale.test", extract="", term=cache_term,
+                     state=DocumentState.FROM_WIKI,
+                     last_crawled=int(time.time()) - settings.WIKI_CACHE_TTL_SECONDS - 1)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        page = index.get_key_page_index(cache_term)
+    index_pages(index_path, {page: [stale]})
+    with TinyIndex(Document, index_path, 'r') as index:
+        assert [d.url for d in index.get_page(page)] == [stale.url]
+
+    # Any later write to that page clears it out.
+    index_pages(index_path, {page: [Document(title="New", url="https://new.test",
+                                             extract="", term=cache_term,
+                                             state=DocumentState.FROM_WIKI,
+                                             last_crawled=int(time.time()))]})
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        assert [d.url for d in index.get_page(page)] == ["https://new.test"]

--- a/test/test_rank.py
+++ b/test/test_rank.py
@@ -70,8 +70,8 @@ def _reset_wiki_circuit():
 
 
 def _get_wiki_results_with_session(session):
-    with patch.object(rank, "request_cache") as mock_request_cache:
-        mock_request_cache.return_value.__enter__.return_value = session
+    with patch("mwmbl.tinysearchengine.rank.requests.Session") as mock_session:
+        mock_session.return_value.__enter__.return_value = session
         return get_wiki_results("query", 5)
 
 
@@ -109,10 +109,10 @@ def test_wiki_query_text_containing_429_is_not_mistaken_for_rate_limit():
 def test_open_wiki_circuit_short_circuits_without_calling_wikipedia():
     rank._trip_wiki_circuit()
 
-    with patch.object(rank, "request_cache") as mock_request_cache:
+    with patch("mwmbl.tinysearchengine.rank.requests.Session") as mock_session:
         results = get_wiki_results("query", 5)
 
-    mock_request_cache.assert_not_called()
+    mock_session.assert_not_called()
     assert results == []
 
 

--- a/test/test_wiki_cache.py
+++ b/test/test_wiki_cache.py
@@ -1,0 +1,625 @@
+"""Wikipedia results cached in the index instead of in a filesystem HTTP cache.
+
+Three things are under test: the query never reaches the index in readable form, a query's
+results come back from the index instead of from Wikipedia, and a Wikipedia page we have
+not seen before becomes an ordinary index entry rather than a query-specific one.
+"""
+import time
+from random import Random
+from string import ascii_letters
+from unittest.mock import MagicMock, patch
+
+import fakeredis
+import pytest
+from django.test import override_settings
+
+from mwmbl import background
+from mwmbl.format import format_result, format_result_v2
+from mwmbl.indexer import wiki_cache
+from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.indexer.blacklist_snapshot import SnapshotBlacklist
+from mwmbl.indexer.index import tokenize_document
+from mwmbl.indexer.index_batches import index_pages, preprocess_documents
+from mwmbl.indexer.wiki_cache import (
+    WIKI_CACHE_TERM_PREFIX, drain_wiki_queue, drop_expired_wiki_cache, enqueue_wiki_results,
+    get_cached_wiki_results, unseen_wiki_urls, wiki_cache_term, wiki_terms_for_documents,
+)
+from mwmbl.tinysearchengine import rank
+from mwmbl.tinysearchengine.indexer import Document, DocumentState, PAGE_SIZE, TinyIndex
+from mwmbl.tinysearchengine.rank import (
+    HeuristicAndWikiRanker, HeuristicRanker, get_wiki_intro_extracts, score_result,
+)
+
+NUM_PAGES = 64
+
+# A result that contains its query words, so it can take real query terms.
+PYTHON = Document(title="Python (programming language)",
+                  url="https://en.wikipedia.org/wiki/Python_(programming_language)",
+                  extract="Python is a high-level programming language.",
+                  score=3.0, state=DocumentState.FROM_WIKI)
+# A spelling-corrected result: Wikipedia returned it for "pithon", which appears nowhere
+# in it, so it may only ever be reachable through the query hash.
+CORRECTED = Document(title="Monty Python", url="https://en.wikipedia.org/wiki/Monty_Python",
+                     extract="A British comedy troupe.",
+                     score=2.0, state=DocumentState.FROM_WIKI)
+
+
+@pytest.fixture
+def index_path(tmp_path):
+    path = str(tmp_path / "wiki.tinysearch")
+    TinyIndex.create(item_factory=Document, index_path=path, num_pages=NUM_PAGES, page_size=PAGE_SIZE)
+    return path
+
+
+@pytest.fixture
+def redis_client():
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+def write_queue_to_index(index_path, redis_client, limit=1000):
+    """Do what the background task does: drain the queue and write it into the index."""
+    documents = drain_wiki_queue(limit, redis_client)
+    page_documents = {}
+    with TinyIndex(Document, index_path, 'r') as index:
+        for document in documents:
+            page_documents.setdefault(index.get_key_page_index(document.term), []).append(document)
+    for documents_for_page in page_documents.values():
+        documents_for_page.sort(key=lambda document: -(document.score or 0.0))
+    index_pages(index_path, page_documents)
+    return documents
+
+
+def terms_written(query, documents):
+    return {document.term for document in wiki_terms_for_documents(query, documents)}
+
+
+# ---------------------------------------------------------------------------
+# The cache term
+# ---------------------------------------------------------------------------
+
+def test_cache_term_is_stable_and_normalised():
+    assert wiki_cache_term("Python") == wiki_cache_term(" python ") == wiki_cache_term("python")
+    assert wiki_cache_term("python").startswith(WIKI_CACHE_TERM_PREFIX)
+
+
+def test_cache_term_does_not_contain_the_query():
+    term = wiki_cache_term("bananas")
+
+    assert "banana" not in term
+    assert wiki_cache_term("bananas") != wiki_cache_term("apples")
+
+
+def test_cache_term_is_keyed_so_it_cannot_be_recomputed_without_the_secret():
+    """A bare digest of a one-word query is brute-forceable from a wordlist; keyed on
+    SECRET_KEY the term->query mapping is not reproducible without the key."""
+    with override_settings(SECRET_KEY="one"):
+        first = wiki_cache_term("bananas")
+    with override_settings(SECRET_KEY="two"):
+        second = wiki_cache_term("bananas")
+
+    assert first != second
+
+
+# ---------------------------------------------------------------------------
+# The anonymisation gate
+# ---------------------------------------------------------------------------
+
+def test_a_one_word_query_present_in_the_document_takes_a_real_term():
+    terms = terms_written("python", [PYTHON])
+
+    assert terms == {"python", wiki_cache_term("python")}
+
+
+def test_a_two_word_query_takes_both_unigrams_and_the_bigram():
+    terms = terms_written("python programming", [PYTHON])
+
+    assert terms == {"python", "programming", "python programming",
+                     wiki_cache_term("python programming")}
+
+
+def test_a_document_missing_a_query_word_only_gets_the_hash():
+    """Wikipedia spelling-corrects and partial-matches, so a returned document need not
+    contain the query at all. Filing it under a word it does not contain would put a
+    user's query into the index."""
+    terms = terms_written("pithon", [CORRECTED])
+
+    assert terms == {wiki_cache_term("pithon")}
+
+
+def test_a_two_word_query_matching_only_one_word_only_gets_the_hash():
+    terms = terms_written("python bananas", [PYTHON])
+
+    assert terms == {wiki_cache_term("python bananas")}
+
+
+@override_settings(WIKI_CACHE_MAX_ORGANIC_TERM_TOKENS=2)
+def test_a_three_word_query_only_gets_the_hash_even_when_every_word_matches():
+    query = "python is programming"
+    assert set(query.split()) <= wiki_cache.document_token_set(PYTHON)
+
+    assert terms_written(query, [PYTHON]) == {wiki_cache_term(query)}
+
+
+def test_a_mixed_result_set_gates_per_document():
+    terms = terms_written("python", [PYTHON, CORRECTED])
+
+    # Both are cached; only the one containing "python" is reachable by that word.
+    assert terms == {"python", wiki_cache_term("python")}
+    cached = [d for d in wiki_terms_for_documents("python", [PYTHON, CORRECTED])
+              if d.term == wiki_cache_term("python")]
+    assert {d.url for d in cached} == {PYTHON.url, CORRECTED.url}
+
+
+def test_documents_without_a_title_or_url_are_not_stored():
+    assert wiki_terms_for_documents("python", [Document(title="", url="", extract="x")]) == []
+
+
+# ---------------------------------------------------------------------------
+# Round trip through the queue and the index
+# ---------------------------------------------------------------------------
+
+def test_results_come_back_from_the_index(index_path, redis_client):
+    enqueue_wiki_results("python", [PYTHON, CORRECTED], redis_client)
+    write_queue_to_index(index_path, redis_client)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        cached = get_cached_wiki_results(index, "python")
+
+    assert [d.url for d in cached] == [PYTHON.url, CORRECTED.url]   # descending score
+    assert all(d.state == DocumentState.FROM_WIKI for d in cached)
+    assert [d.score for d in cached] == [3.0, 2.0]
+
+
+def test_the_queue_never_holds_the_query(redis_client):
+    enqueue_wiki_results("bananas", [CORRECTED], redis_client)
+
+    queued = redis_client.smembers(wiki_cache.WIKI_CACHE_QUEUE_KEY)
+
+    assert queued
+    assert not any("banana" in payload for payload in queued)
+
+
+def test_a_qualifying_result_is_retrievable_by_its_own_word(index_path, redis_client):
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+    write_queue_to_index(index_path, redis_client)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        urls = {d.url for d in index.retrieve("python")}
+
+    assert urls == {PYTHON.url}
+
+
+def test_a_corrected_result_is_not_retrievable_by_the_query_word(index_path, redis_client):
+    enqueue_wiki_results("pithon", [CORRECTED], redis_client)
+    write_queue_to_index(index_path, redis_client)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        assert index.retrieve("pithon") == []
+        assert {d.url for d in get_cached_wiki_results(index, "pithon")} == {CORRECTED.url}
+
+
+def test_hash_term_order_survives_an_arbitrary_queue_order(index_path, redis_client):
+    """The queue is a SET drained with SPOP, and under the hash term the write path scores
+    every document against a term none of them match, so nothing but the score orders
+    them."""
+    # Enqueued worst-score-first, and SPOP will reorder them again anyway.
+    enqueue_wiki_results("pithon", [CORRECTED, PYTHON], redis_client)
+    write_queue_to_index(index_path, redis_client)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        cached = get_cached_wiki_results(index, "pithon")
+
+    assert [d.score for d in cached] == [3.0, 2.0]
+
+
+def test_enqueueing_the_same_results_twice_adds_nothing(redis_client):
+    first = enqueue_wiki_results("python", [PYTHON], redis_client)
+    second = enqueue_wiki_results("python", [PYTHON], redis_client)
+
+    assert first > 0
+    assert second == 0
+
+
+def test_enqueueing_survives_a_broken_redis():
+    """Nothing here may affect a search response; a lost entry costs one re-fetch."""
+    broken = MagicMock()
+    broken.scard.side_effect = RuntimeError("redis is down")
+
+    assert enqueue_wiki_results("python", [PYTHON], broken) == 0
+
+
+@override_settings(WIKI_CACHE_ENABLED=False)
+def test_the_kill_switch_stops_reads_and_writes(index_path, redis_client):
+    assert enqueue_wiki_results("python", [PYTHON], redis_client) == 0
+    with TinyIndex(Document, index_path, 'r') as index:
+        assert get_cached_wiki_results(index, "python") == []
+
+
+# ---------------------------------------------------------------------------
+# Freshness
+# ---------------------------------------------------------------------------
+
+def test_a_stale_entry_is_not_a_cache_hit(index_path, redis_client):
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+    write_queue_to_index(index_path, redis_client)
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        stale = int(time.time()) + 2 * 10 * 7 * 24 * 60 * 60
+        assert get_cached_wiki_results(index, "python") != []
+        assert get_cached_wiki_results(index, "python", now=stale) == []
+
+
+def test_stale_cache_entries_are_dropped_from_a_page_being_rewritten():
+    now = int(time.time())
+    fresh = Document(title="a", url="https://a.test", extract="", term=wiki_cache_term("a"),
+                     state=DocumentState.FROM_WIKI, last_crawled=now)
+    stale = Document(title="b", url="https://b.test", extract="", term=wiki_cache_term("b"),
+                     state=DocumentState.FROM_WIKI, last_crawled=now - 10 * 7 * 24 * 60 * 60 - 1)
+    # Filed under its own token rather than a hash: index content, not cache, so it stays
+    # however old it is.
+    organic = Document(title="c", url="https://c.test", extract="", term="c",
+                       state=DocumentState.FROM_WIKI, last_crawled=1)
+
+    kept = drop_expired_wiki_cache([fresh, stale, organic], now=now)
+
+    assert [d.url for d in kept] == [fresh.url, organic.url]
+
+
+# ---------------------------------------------------------------------------
+# The read path
+# ---------------------------------------------------------------------------
+
+class TermIndex:
+    """An index that answers per term, unlike the fake in test_rank_blacklist."""
+
+    def __init__(self, documents_by_term=None):
+        self.documents_by_term = documents_by_term or {}
+
+    def retrieve(self, key):
+        return list(self.documents_by_term.get(key, []))
+
+
+class TrackingRanker(HeuristicRanker):
+    def __init__(self, documents_by_term=None):
+        completer = MagicMock()
+        completer.complete.return_value = []
+        super().__init__(TermIndex(documents_by_term), completer)
+        self.external_search_calls = []
+
+    def external_search(self, q):
+        self.external_search_calls.append(q)
+        return [PYTHON]
+
+
+def cached_page(query, documents):
+    term = wiki_cache_term(query)
+    return {term: [Document(title=d.title, url=d.url, extract=d.extract, score=d.score,
+                            term=term, state=DocumentState.FROM_WIKI,
+                            last_crawled=int(time.time()))
+                   for d in documents]}
+
+
+def test_a_cache_hit_does_not_call_wikipedia(redis_client):
+    ranker = TrackingRanker(cached_page("python", [PYTHON]))
+
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        results = ranker.search("python", [])
+
+    assert ranker.external_search_calls == []
+    assert PYTHON.url in [r.url for r in results]
+
+
+def test_a_cache_miss_calls_wikipedia_and_queues_the_results(redis_client):
+    ranker = TrackingRanker()
+
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        ranker.search("python", [])
+
+    assert ranker.external_search_calls == ["python"]
+    assert redis_client.scard(wiki_cache.WIKI_CACHE_QUEUE_KEY) > 0
+
+
+def test_autocomplete_neither_fetches_nor_caches(redis_client):
+    ranker = TrackingRanker(cached_page("python", [PYTHON]))
+
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        ranker.complete("python")
+
+    assert ranker.external_search_calls == []
+    assert redis_client.scard(wiki_cache.WIKI_CACHE_QUEUE_KEY) == 0
+
+
+def test_a_cached_result_is_ranked_rather_than_pinned_as_curated(redis_client):
+    """A one-word query stores its results under the curation term with a non-None state.
+    Treating those as curated would put them above everything, ranking skipped."""
+    better = Document(title="python", url="https://short.test", extract="python python",
+                      score=1.0, term="python")
+    documents = cached_page("python", [PYTHON])
+    documents["python"] = [PYTHON, better]
+
+    ranker = TrackingRanker(documents)
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        results = ranker.search("python", [])
+
+    scored = [(score_result(["python"], d, True), d.url) for d in (PYTHON, better)]
+    expected_first = max(scored)[1]
+    assert results[0].url == expected_first
+
+
+def test_an_approved_wiki_result_is_still_curated(redis_client):
+    approved = Document(title="Python", url="https://en.wikipedia.org/wiki/Python",
+                        extract="", score=0.0, term="python",
+                        state=DocumentState.FROM_WIKI_APPROVED)
+    better = Document(title="python", url="https://short.test", extract="python python",
+                      score=1.0, term="python")
+
+    ranker = TrackingRanker({"python": [better, approved]})
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        results = ranker.search("python", [])
+
+    assert results[0].url == approved.url
+
+
+def test_a_query_that_looks_like_a_cache_term_reads_nothing(redis_client):
+    term = wiki_cache_term("secret query")
+    ranker = TrackingRanker({term: [Document(title="Leaked", url="https://leaked.test",
+                                             extract="", term=term,
+                                             state=DocumentState.FROM_WIKI,
+                                             last_crawled=int(time.time()))]})
+
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client):
+        results = ranker.search(term, [])
+        raw = ranker.get_raw_results(term)
+
+    assert "https://leaked.test" not in [r.url for r in results]
+    assert raw == []
+
+
+# ---------------------------------------------------------------------------
+# The standard indexing path
+# ---------------------------------------------------------------------------
+
+def test_a_new_url_is_indexed_under_its_own_tokens(index_path):
+    """The point of the general path: the page is findable by words from the article
+    itself, not only by the query that happened to surface it."""
+    index_pages(index_path, preprocess_documents([PYTHON], index_path))
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        assert {d.url for d in index.retrieve("high-level")} == {PYTHON.url}
+
+
+def test_the_general_path_keeps_the_wikipedia_source(index_path):
+    index_pages(index_path, preprocess_documents([PYTHON], index_path))
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        stored = index.retrieve("high-level")
+
+    assert [d.state for d in stored] == [DocumentState.FROM_WIKI]
+    assert format_result(stored[0], "python")['source'] == "wikipedia"
+    assert format_result_v2(stored[0], 1, "python")['engine'] == "wikipedia"
+
+
+def test_a_url_is_only_returned_as_unseen_once(redis_client):
+    first = unseen_wiki_urls([PYTHON, CORRECTED], 10, redis_client)
+    second = unseen_wiki_urls([PYTHON, CORRECTED], 10, redis_client)
+
+    assert {d.url for d in first} == {PYTHON.url, CORRECTED.url}
+    assert second == []
+
+
+def test_urls_beyond_the_limit_are_left_for_the_next_run(redis_client):
+    """They must not be recorded as seen: that would mark them done and never index them."""
+    first = unseen_wiki_urls([PYTHON, CORRECTED], 1, redis_client)
+    second = unseen_wiki_urls([PYTHON, CORRECTED], 1, redis_client)
+
+    assert len(first) == len(second) == 1
+    assert {d.url for d in first + second} == {PYTHON.url, CORRECTED.url}
+
+
+def test_a_weakly_matching_wiki_document_scores_zero_like_an_organic_one():
+    """FROM_WIKI is not curation, so it gets no exemption from the minimum-term-match
+    rule - at query time or in sort_documents' write-time page ordering."""
+    terms = ["python", "bananas", "oranges", "apples"]
+    organic = Document(title=PYTHON.title, url=PYTHON.url, extract=PYTHON.extract)
+
+    assert score_result(terms, PYTHON, True) == score_result(terms, organic, True) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Page competition
+# ---------------------------------------------------------------------------
+
+def test_a_cache_entry_survives_a_full_page_and_costs_the_deepest_results(index_path):
+    """sort_documents interleaves terms by rank position, so a new term's documents sit in
+    the first rounds and what falls off the end is the tail of the longest term."""
+    cache_term = wiki_cache_term("python")
+    with TinyIndex(Document, index_path, 'r') as index:
+        page = index.get_key_page_index(cache_term)
+        # A term that shares the cache term's page, so the two really do compete.
+        crowded = next(f"crowded{i}" for i in range(10000)
+                       if index.get_key_page_index(f"crowded{i}") == page)
+
+    # Incompressible extracts: repeated filler zstd-compresses away and the page never
+    # fills, which is the whole point of the test.
+    crowd = [Document(title=f"Crowd {i}", url=f"https://crowd.test/{i}",
+                      extract="".join(Random(i).choices(ascii_letters, k=200)),
+                      score=1.0, term=crowded)
+             for i in range(200)]
+    index_pages(index_path, {page: crowd})
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        before = index.get_page(page)
+    assert 0 < len(before) < len(crowd), "expected the page to be full"
+
+    cached = [Document(title=PYTHON.title, url=PYTHON.url, extract=PYTHON.extract,
+                       score=PYTHON.score, term=cache_term,
+                       state=DocumentState.FROM_WIKI, last_crawled=int(time.time()))]
+    index_pages(index_path, {page: cached})
+
+    with TinyIndex(Document, index_path, 'r') as index:
+        after = index.get_page(page)
+
+    assert PYTHON.url in [d.url for d in after], "the cache entry must survive a full page"
+    surviving_crowd = [d for d in after if d.term == crowded]
+    assert len(surviving_crowd) < len(before), "and it costs the deepest existing results"
+
+
+# ---------------------------------------------------------------------------
+# The intro extract
+# ---------------------------------------------------------------------------
+
+WIKI_EXTRACTS_RESPONSE = {
+    "query": {"pages": {
+        "23862": {"title": "Python (programming language)",
+                  "extract": "Python is a high-level, general-purpose programming language."},
+        "18942": {"title": "Monty Python", "extract": ""},
+    }},
+}
+
+
+def test_intro_extracts_are_keyed_by_title():
+    session = MagicMock()
+    session.get.return_value.json.return_value = WIKI_EXTRACTS_RESPONSE
+
+    with patch("mwmbl.tinysearchengine.rank.requests.Session") as mock_session:
+        mock_session.return_value.__enter__.return_value = session
+        extracts = get_wiki_intro_extracts(["Python (programming language)", "Monty Python"])
+
+    # An empty extract is no better than the snippet, so it is not returned.
+    assert extracts == {"Python (programming language)":
+                        "Python is a high-level, general-purpose programming language."}
+
+
+def test_intro_extracts_do_not_call_wikipedia_with_the_circuit_open():
+    rank._trip_wiki_circuit()
+    try:
+        with patch("mwmbl.tinysearchengine.rank.requests.Session") as mock_session:
+            assert get_wiki_intro_extracts(["Python"]) == {}
+        mock_session.assert_not_called()
+    finally:
+        rank._wiki_blocked_until = 0.0
+
+
+def test_the_intro_replaces_the_query_chosen_snippet():
+    """The snippet Wikipedia returns is the passage that matched the query. Keeping it as
+    the permanent extract would put a query-shaped artefact in the index - and
+    tokenize_document tokenizes the extract, so it would also decide which pages the
+    document is filed under."""
+    intro = "Python is a high-level, general-purpose programming language."
+    with patch.object(background, "get_wiki_intro_extracts",
+                      return_value={PYTHON.title: intro}):
+        documents = background._with_intro_extracts([PYTHON, CORRECTED])
+
+    by_url = {d.url: d for d in documents}
+    assert by_url[PYTHON.url].extract == intro
+    assert by_url[CORRECTED.url].extract == CORRECTED.extract   # nothing fetched, snippet kept
+    assert by_url[PYTHON.url].state == DocumentState.FROM_WIKI
+    # The query term has no business travelling with a document filed under its own tokens.
+    assert all(document.term is None for document in documents)
+
+
+# ---------------------------------------------------------------------------
+# The background task, end to end
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def wiki_index(tmp_path, redis_client):
+    """Point the background task at a temporary index and a fake Redis."""
+    TinyIndex.create(item_factory=Document, index_path=str(tmp_path / "index.tinysearch"),
+                     num_pages=NUM_PAGES, page_size=PAGE_SIZE)
+    blacklist = SnapshotBlacklist(built_in_rules=StaticBlacklistProvider(set()),
+                                  redis_client=fakeredis.FakeRedis())
+    with override_settings(DATA_PATH=str(tmp_path), INDEX_NAME="index.tinysearch"), \
+            patch.object(wiki_cache, "get_redis", return_value=redis_client), \
+            patch("mwmbl.indexer.index_batches.get_snapshot_blacklist", return_value=blacklist), \
+            patch.object(background, "get_wiki_intro_extracts", return_value={}):
+        yield str(tmp_path / "index.tinysearch")
+
+
+def test_the_task_writes_the_cache_entry_and_the_query_term(wiki_index, redis_client):
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+
+    background.index_wiki_results_from_queue.now()
+
+    with TinyIndex(Document, wiki_index, 'r') as index:
+        assert {d.url for d in get_cached_wiki_results(index, "python")} == {PYTHON.url}
+        # The query term too, because the gate passed.
+        assert {d.url for d in index.retrieve("python")} == {PYTHON.url}
+
+
+def test_the_task_indexes_the_page_under_its_own_tokens(wiki_index, redis_client):
+    """The general path files the document under ~57 of its own terms. A term copy landing
+    on the same page as one of them costs that one copy - combine_documents dedupes by URL
+    across a whole page - so this asserts on the bulk rather than on one chosen token. With
+    64 test pages that is nearly every page; with prod's 102.4M it is a rounding error."""
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+
+    background.index_wiki_results_from_queue.now()
+
+    tokens = tokenize_document(PYTHON.url, PYTHON.title, PYTHON.extract, PYTHON.score).tokens
+    with TinyIndex(Document, wiki_index, 'r') as index:
+        found = [token for token in tokens
+                 if PYTHON.url in {d.url for d in index.retrieve(token)}]
+
+    assert len(found) >= len(tokens) - 2, f"only {len(found)} of {len(tokens)} terms kept"
+
+
+def test_the_task_does_nothing_with_an_empty_queue(wiki_index):
+    background.index_wiki_results_from_queue.now()
+
+    with TinyIndex(Document, wiki_index, 'r') as index:
+        assert index.get_page(0) == []
+
+
+def test_the_task_only_generally_indexes_a_url_once(wiki_index, redis_client):
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+    background.index_wiki_results_from_queue.now()
+
+    with patch.object(background.index_batches, "index_documents") as mock_index_documents:
+        enqueue_wiki_results("pithon", [PYTHON], redis_client)
+        background.index_wiki_results_from_queue.now()
+
+    mock_index_documents.assert_not_called()
+
+
+@override_settings(WIKI_CACHE_GENERAL_INDEX=False)
+def test_the_general_index_kill_switch_leaves_the_cache_working(wiki_index, redis_client):
+    enqueue_wiki_results("python", [PYTHON], redis_client)
+
+    background.index_wiki_results_from_queue.now()
+
+    with TinyIndex(Document, wiki_index, 'r') as index:
+        assert {d.url for d in get_cached_wiki_results(index, "python")} == {PYTHON.url}
+        assert index.retrieve("high-level") == []
+
+
+def test_a_ranker_that_reads_a_remote_index_does_not_use_the_cache(redis_client):
+    """HeuristicAndWikiRanker fetches Wikipedia itself and reads a remote index, where a
+    cache lookup is an HTTP round trip that /raw refuses to serve. It must not queue
+    anything either - nothing drains that queue on an evaluation run."""
+    class RemoteReadingRanker(TrackingRanker):
+        cache_wiki_results = False
+
+    ranker = RemoteReadingRanker(cached_page("python", [PYTHON]))
+    with patch.object(wiki_cache, "get_redis", return_value=redis_client), \
+            patch.object(wiki_cache, "get_cached_wiki_results") as mock_cache_read:
+        ranker.search("python", [])
+
+    mock_cache_read.assert_not_called()
+    assert redis_client.scard(wiki_cache.WIKI_CACHE_QUEUE_KEY) == 0
+    assert ranker.external_search_calls == ["python"]
+
+
+def test_the_eval_ranker_has_the_cache_turned_off():
+    assert HeuristicAndWikiRanker.cache_wiki_results is False
+    assert HeuristicRanker.cache_wiki_results is True
+
+
+def test_an_entry_without_a_term_is_discarded_rather_than_crashing_the_task(redis_client):
+    """There is no page to file a termless document under, and the background task would
+    raise on get_key_page_index."""
+    redis_client.sadd(wiki_cache.WIKI_CACHE_QUEUE_KEY,
+                      '{"extract": "", "score": null, "term": null, '
+                      '"title": "T", "url": "https://x.test"}')
+
+    assert drain_wiki_queue(10, redis_client) == []


### PR DESCRIPTION
## Why

`get_wiki_results()` cached through `mwmbl.utils.request_cache` — a requests-cache **filesystem** session with a 10-week expiry:

```python
with request_cache(timedelta(weeks=10)) as session:      # rank.py:488
```

That writes **one JSON file per response** into `REQUEST_CACHE_PATH`, which in prod is `/app/storage/request_cache` — the same volume as the 400 GB index. There is no LRU, no size cap, and nothing ever calls `delete(expired=True)`, so it grows without bound; the local dev copy is **91,000 files / 4.5 GB**. `indexer/blacklist_providers.py:148` already documents the failure mode: fill that volume and every `request_cache` user breaks, *including `get_wiki_results()` on the live search path*.

It also wrote the **raw user query** to disk. The cache key is a hash, but the stored JSON holds the whole request, so `srsearch=<query>` sat on the volume for ten weeks.

The index is a fixed-size preallocated file, so caching in it costs **no additional disk at all**.

## How

A result set has up to three destinations, in increasing generality:

| | Term written | Reachable by |
|---|---|---|
| **Cache entry** (always) | `#wiki-<16 hex>` — HMAC-SHA256 of the normalised query, keyed on `SECRET_KEY` | only by re-hashing the same query |
| **Organic entry** (gated) | each query unigram, plus the bigram for a two-word query | anyone's matching query, as `source: wikipedia` |
| **General indexing** (unseen URLs) | the document's own `tokenize_document` tokens | anyone's query matching the *article* |

The gate is what keeps the organic entry anonymous: a document takes a real query term only if the query is one or two words **and** the document contains all of them, so the term→document link is derivable from the document itself. Wikipedia spelling-corrects and partial-matches, so a returned document need not contain the query words at all — those stay hash-only.

HMAC rather than a bare digest because a plain hash of a one- or two-word query is trivially brute-forced from a wordlist. Being straight about the residual: a hashed entry still holds the *articles* returned, so a dump reveals the topic of some past query even though the text is gone. That is strictly less than the disk cache gave away.

Freshness reuses `last_crawled` (10-week TTL, matching the old `expire_after`), so there is no schema change. Expired hash entries are dropped from any page `index_pages` rewrites anyway, which keeps the cache from piling up on pages it landed on.

Writes go through a Redis queue drained by a background task, exactly as the blacklist purge does: an index page write is a read-modify-write, and doing it from every gunicorn worker on a large fraction of searches would have them fighting over the same 4 KB pages. It also keeps the query text inside the search worker — the queue only ever holds document-derived terms and the opaque hash.

## Two pre-existing behaviours this surfaced

- `get_results` treated **any** non-`None` state under the curation term as curated. A one-word query stores its results under exactly that term, so they would have been pinned above everything with ranking skipped. Now `FROM_WIKI` is excluded; `FROM_WIKI_APPROVED` is real curation and stays.
- `score_result` exempted any non-`None` state from the minimum-term-match rule. `FROM_WIKI` is crawled-equivalent content, not curation, so it no longer gets that exemption — at query time or in `sort_documents`' write-time page ordering.

## Page competition

`sort_documents` interleaves terms by rank position, so a new term's documents sit in the first rounds and what falls off the truncated tail is the deepest positions of the longest terms. A hash entry therefore **survives** a full page and costs ~3 documents from the deep tail. It cannot be inverted — a cache entry that loses its documents is not a cache — so the only lever is storing fewer results per query (prod already fetches 3).

`scripts/index_page_occupancy.py` measures this. **On the dev index every page is over 90% full** (35.6 docs, 4038/4096 bytes), so anything stored evicts about as much as it adds. Prod has 102.4M pages over 400 GB and may differ; please run it there before raising `WIKI_CACHE_GENERAL_BATCH_SIZE`, since the general path costs ~57 page-writes per new URL against ~4 for the cache path.

## Verified

End to end against a real index with a real Wikipedia fetch:

1. Live search → 3 results, `source: wikipedia`
2. `request_cache` file count **unchanged** (91001 → 91001)
3. Background task drains the queue; `/raw` shows the qualifying documents with `state: 4`
4. Repeat search with `get_wiki_results` patched to **raise** → same 3 URLs, served from the index
5. Unrelated query `complexity` finds `Kolmogorov_complexity` — general indexing works
6. Cache term contains no query text

Plus 43 new tests in `test/test_wiki_cache.py` covering the term hashing, the gate (including spelling-corrected and partially-matching results), the queue round trip, TTL expiry, the read path, the general-index novelty check, and page competition. Full suite: **530 passed**.

## Notes for review

- **Eval regression:** `HeuristicAndWikiRanker` reads a `RemoteIndex`, where a cache lookup is an HTTP round trip to `/raw` (which now refuses cache terms), so it opts out via `Ranker.cache_wiki_results`. Consequence: `rankeval/ltr/dataset.py` and `scripts/llm_relabel_pass2_collect.py` lose their disk-cached Wikipedia calls and re-fetch per run, protected by `WIKI_RETRY` and the circuit breaker.
- **No negative caching.** A query Wikipedia returns nothing for writes no entry and re-fetches. A sentinel document would fix it but would leak into `/raw` and every candidate list.
- **Cold window.** Between a fetch and the next drain (~60s) repeats of a query re-fetch.
- `devdata/request_cache` (4.5 GB) and `/app/storage/request_cache` can be deleted after rollout — worth checking nothing else has started using the directory first.
- `WIKI_CACHE_ENABLED=false` restores today's behaviour; `WIKI_CACHE_GENERAL_INDEX=false` keeps the cache but skips the general path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)