### PR TITLE
Wikipedia results in the index (off by default), and make index page writes safe

### DIFF
--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -6,7 +6,7 @@ from collections import defaultdict, Counter
 from datetime import datetime
 from functools import reduce
 from logging import getLogger
-from typing import Collection, Iterable, Optional
+from typing import Callable, Collection, Iterable, Optional
 from urllib.parse import unquote
 
 from mwmbl.crawler.batch import HashedBatch, Item
@@ -115,10 +115,14 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
         for page, documents in page_documents.items():
-            existing_documents = indexer.get_page(page)
-            combined_documents = combine_documents(existing_documents, documents, mark_synced, ranker)
-            logger.info(f"Storing {len(combined_documents)} documents for page {page}, originally {len(existing_documents)}")
-            indexer.store_in_page(page, combined_documents)
+            # Read-merge-write under an exclusive lock on this page. Without it a writer can
+            # read a page another writer is halfway through storing, get an empty page back,
+            # and store its own documents over everything that was there - see locked_page.
+            with indexer.locked_page(page):
+                existing_documents = indexer.get_page(page)
+                combined_documents = combine_documents(existing_documents, documents, mark_synced, ranker)
+                logger.info(f"Storing {len(combined_documents)} documents for page {page}, originally {len(existing_documents)}")
+                indexer.store_in_page(page, combined_documents)
 
             term_new_doc_counts.update(document.term for document in combined_documents
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
@@ -133,7 +137,12 @@ def _document_token_set(doc: Document) -> set[str]:
             | set(tokenize(doc.extract)))
 
 
-def index_results_against_query(documents: list[Document], query: str, index_path: str) -> int:
+def index_results_against_query(documents: list[Document], query: str, index_path: str,
+                                max_term_tokens: Optional[int] = None,
+                                require_existing_term: bool = False,
+                                term_exists: Optional[Callable[[str], bool]] = None,
+                                state: Optional[DocumentState] = None,
+                                keep_score: bool = False) -> int:
     """Index each document against the query unigrams/bigrams it matches.
 
     A query term matches a document when all of the term's words are present in
@@ -141,6 +150,28 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     order). Matching docs are stored against that term via index_pages(), which
     applies the normal combine/prioritise path. Returns the number of distinct
     URLs newly added to the index.
+
+    The containment rule is what makes this safe to run on user queries: a document
+    only takes a term whose words it already contains, so the term -> document link is
+    derivable from the document itself and says nothing about the query that produced
+    it. `max_term_tokens` caps how many words a stored term may have (so a long query is
+    never written as one phrase), and `require_existing_term` restricts writes to terms
+    the index already holds documents for, so nothing is stored that the corpus did not
+    already contain - by default asking the index being written to, or `term_exists` when
+    the corpus the caller means is larger than that (the evaluation's overlay index).
+    All of these default to off, which is the behaviour Super Search has always had;
+    mwmbl.tinysearchengine.wiki_index_cache passes them from settings.
+
+    `keep_score` carries the incoming document's score onto the stored copies. It is off
+    by default because a Super Search document's score is not comparable across sources,
+    but a Wikipedia result's score *is* its rank in Wikipedia's own results - and the LTR
+    model reads `score` as a feature, so dropping it makes every copy served from the
+    index look worse to the ranker than the identical result fetched live.
+
+    `state` is stamped on the stored copies. Wikipedia results keep FROM_WIKI so they are
+    recognisable later - as the source shown to the user, and as the thing the
+    from_wiki_only gate counts. It is never taken from the incoming document, whose
+    `term` is the raw user query; every stored copy is rebuilt with a derived term.
 
     The count is computed in the read pass, before combine/store, so a candidate
     later dropped by URL/title dedup or by the full-page trim is still counted;
@@ -154,12 +185,31 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     query_terms: dict[str, frozenset[str]] = {t: frozenset((t,)) for t in tokens}
     for bigram in get_bigrams(len(tokens), tokens):
         query_terms[bigram] = frozenset(bigram.split())
+    if max_term_tokens is not None:
+        query_terms = {term: words for term, words in query_terms.items()
+                       if len(words) <= max_term_tokens}
+    if not query_terms:
+        return 0
 
     # Read pass: build per-page candidates and track which (term, url) are new.
     page_documents: dict[int, list[Document]] = defaultdict(list)
     new_urls: set[str] = set()
     with TinyIndex(Document, index_path, 'r') as indexer:
         existing_keys: dict[int, set[tuple]] = {}
+
+        def keys_for_page(page: int) -> set[tuple]:
+            if page not in existing_keys:
+                existing_keys[page] = {(d.term, d.url) for d in indexer.get_page(page)}
+            return existing_keys[page]
+
+        if require_existing_term:
+            def in_this_index(term: str) -> bool:
+                page = indexer.get_key_page_index(term)
+                return any(t == term for t, _ in keys_for_page(page))
+
+            check = term_exists if term_exists is not None else in_this_index
+            query_terms = {term: words for term, words in query_terms.items() if check(term)}
+
         for doc in documents:
             if not (doc.url and doc.title):
                 continue
@@ -170,11 +220,10 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
                 page = indexer.get_key_page_index(term)
                 page_documents[page].append(Document(
                     doc.title, doc.url, doc.extract,
-                    term=term, last_crawled=doc.last_crawled,
+                    score=doc.score if keep_score else None,
+                    term=term, state=state, last_crawled=doc.last_crawled,
                 ))
-                if page not in existing_keys:
-                    existing_keys[page] = {(d.term, d.url) for d in indexer.get_page(page)}
-                if (term, doc.url) not in existing_keys[page]:
+                if (term, doc.url) not in keys_for_page(page):
                     new_urls.add(doc.url)
 
     if page_documents:

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -134,12 +134,47 @@ def _document_token_set(doc: Document) -> set[str]:
             | set(tokenize(doc.extract)))
 
 
+SCORE_TERMS_CHOICES = ("none", "all", "specific", "exact")
+
+
+def _takes_score(score_terms: str, tokens: list[str]) -> Callable[[frozenset[str]], bool]:
+    """Which of a query's terms a stored copy is allowed to carry its score under.
+
+    A Wikipedia result's score is the rank Wikipedia gave it *for the whole query*, and
+    nothing in the index records what that query was. Filing it under a bare unigram
+    therefore claims a ranking the word never earned on its own: `connections hint
+    september 14` writes rank 3 under `connections`, and the next person searching
+    `connections` gets that number fed to the model as a feature.
+
+      none      no stored copy carries a score. What Super Search has always done - its
+                documents' scores are not comparable across sources.
+      all       every term carries it.
+      specific  bigrams only, unless the query is a single token - in which case the
+                unigram *is* the query and the score is honestly its own.
+      exact     only a term equal to the whole query, so the score is never read for any
+                query but the one that produced it. Stores nothing for a 3+ token query.
+    """
+    if score_terms == "none":
+        return lambda words: False
+    if score_terms == "all":
+        return lambda words: True
+    if score_terms == "specific":
+        if len(tokens) == 1:
+            return lambda words: True
+        return lambda words: len(words) > 1
+    if score_terms == "exact":
+        whole_query = frozenset(tokens)
+        return lambda words: words == whole_query
+    raise ValueError(f"Unknown score_terms {score_terms!r}, expected one of {SCORE_TERMS_CHOICES}")
+
+
 def index_results_against_query(documents: list[Document], query: str, index_path: str,
                                 max_term_tokens: Optional[int] = None,
                                 require_existing_term: bool = False,
                                 term_exists: Optional[Callable[[str], bool]] = None,
                                 state: Optional[DocumentState] = None,
-                                keep_score: bool = False) -> int:
+                                score_terms: str = "none",
+                                score_ema_alpha: float = 1.0) -> int:
     """Index each document against the query unigrams/bigrams it matches.
 
     A query term matches a document when all of the term's words are present in
@@ -159,11 +194,18 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     All of these default to off, which is the behaviour Super Search has always had;
     mwmbl.tinysearchengine.wiki_index_cache passes them from settings.
 
-    `keep_score` carries the incoming document's score onto the stored copies. It is off
-    by default because a Super Search document's score is not comparable across sources,
-    but a Wikipedia result's score *is* its rank in Wikipedia's own results - and the LTR
-    model reads `score` as a feature, so dropping it makes every copy served from the
-    index look worse to the ranker than the identical result fetched live.
+    `score_terms` decides which stored copies carry the incoming document's score - see
+    _takes_score. The LTR model reads `score` as a feature, so dropping it entirely makes
+    a copy served from the index look worse to the ranker than the identical result
+    fetched live, while carrying it under every term lets one query's ranking leak into
+    another's.
+
+    `score_ema_alpha` blends a score being written over a previous one for the same
+    (term, url): `alpha * new + (1 - alpha) * previous`. 1.0, the default, overwrites.
+    Below 1.0 a term's score becomes an average of the evidence from every query that
+    filed the document there, rather than whatever the last one happened to say. Only
+    copies stored with this same `state` are blended with - a curated document on the
+    same page carries ~1.1e6 and a crawled one carries None.
 
     `state` is stamped on the stored copies. Wikipedia results keep FROM_WIKI so they are
     recognisable later - as the source shown to the user, and as the thing the
@@ -177,6 +219,7 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     tokens = tokenize(query)
     if not tokens or not documents:
         return 0
+    takes_score = _takes_score(score_terms, tokens)
 
     # term string -> the set of words that must all be present to match.
     query_terms: dict[str, frozenset[str]] = {t: frozenset((t,)) for t in tokens}
@@ -191,13 +234,28 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
     # Read pass: build per-page candidates and track which (term, url) are new.
     page_documents: dict[int, list[Document]] = defaultdict(list)
     new_urls: set[str] = set()
+    blending = score_ema_alpha < 1.0 and score_terms != "none"
+    num_blended = 0
     with TinyIndex(Document, index_path, 'r') as indexer:
         existing_keys: dict[int, set[tuple]] = {}
+        existing_scores: dict[int, dict[tuple, float]] = {}
+
+        def read_page(page: int) -> None:
+            """One read per page, feeding both the is-it-new check and the EMA."""
+            if page in existing_keys:
+                return
+            documents_on_page = indexer.get_page(page)
+            existing_keys[page] = {(d.term, d.url) for d in documents_on_page}
+            existing_scores[page] = {(d.term, d.url): d.score for d in documents_on_page
+                                     if d.state == state and d.score is not None} if blending else {}
 
         def keys_for_page(page: int) -> set[tuple]:
-            if page not in existing_keys:
-                existing_keys[page] = {(d.term, d.url) for d in indexer.get_page(page)}
+            read_page(page)
             return existing_keys[page]
+
+        def previous_score(page: int, key: tuple) -> Optional[float]:
+            read_page(page)
+            return existing_scores[page].get(key)
 
         if require_existing_term:
             def in_this_index(term: str) -> bool:
@@ -215,14 +273,22 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
                 if not (words <= doc_tokens):
                     continue
                 page = indexer.get_key_page_index(term)
+                key = (term, doc.url)
+                score = doc.score if takes_score(words) else None
+                if blending and score is not None:
+                    previous = previous_score(page, key)
+                    if previous is not None:
+                        score = score_ema_alpha * score + (1 - score_ema_alpha) * previous
+                        num_blended += 1
                 page_documents[page].append(Document(
                     doc.title, doc.url, doc.extract,
-                    score=doc.score if keep_score else None,
-                    term=term, state=state, last_crawled=doc.last_crawled,
+                    score=score, term=term, state=state, last_crawled=doc.last_crawled,
                 ))
-                if (term, doc.url) not in keys_for_page(page):
+                if key not in keys_for_page(page):
                     new_urls.add(doc.url)
 
+    if num_blended:
+        logger.info(f"Blended {num_blended} scores into existing stored copies")
     if page_documents:
         index_pages(index_path, page_documents)  # reuse the existing write path
     return len(new_urls)

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -115,15 +115,13 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
         for page, documents in page_documents.items():
-            # Read-merge-write under an exclusive lock on this page. Without it a writer can
-            # read a page another writer is halfway through storing, get an empty page back,
-            # and store its own documents over everything that was there - see locked_page.
-            with indexer.locked_page(page):
-                existing_documents = indexer.get_page(page)
-                combined_documents = combine_documents(existing_documents, documents, mark_synced, ranker)
-                logger.info(f"Storing {len(combined_documents)} documents for page {page}, originally {len(existing_documents)}")
-                indexer.store_in_page(page, combined_documents)
+            def merge(existing_documents, documents=documents, page=page):
+                combined = combine_documents(existing_documents, documents, mark_synced, ranker)
+                logger.info(f"Storing {len(combined)} documents for page {page}, "
+                            f"originally {len(existing_documents)}")
+                return combined
 
+            combined_documents = indexer.update_page(page, merge)
             term_new_doc_counts.update(document.term for document in combined_documents
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
     return term_new_doc_counts

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -114,15 +114,14 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     term_new_doc_counts = Counter()
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
-        for page, documents in page_documents.items():
-            def merge(existing_documents, documents=documents, page=page):
-                combined = combine_documents(existing_documents, documents, mark_synced, ranker)
-                logger.info(f"Storing {len(combined)} documents for page {page}, "
-                            f"originally {len(existing_documents)}")
-                return combined
+        for page_index, documents in page_documents.items():
+            with indexer.page(page_index) as page:
+                combined_documents = combine_documents(page.documents, documents, mark_synced, ranker)
+                num_stored = page.store(combined_documents)
+                logger.info(f"Storing {num_stored} of {len(combined_documents)} documents for "
+                            f"page {page_index}, originally {len(page.documents)}")
 
-            combined_documents = indexer.update_page(page, merge)
-            term_new_doc_counts.update(document.term for document in combined_documents
+            term_new_doc_counts.update(document.term for document in combined_documents[:num_stored]
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
     return term_new_doc_counts
 

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -79,18 +79,20 @@ def purge_documents(index: TinyIndex, documents: Iterable[Document],
     # pages, so counting each removal would report an order of magnitude too many.
     removed_urls_by_domain: dict[str, set[str]] = defaultdict(set)
     for page_index, urls in pages_to_urls.items():
-        page = index.get_page(page_index)
-        kept = [d for d in page if d.url not in urls]
-        if len(kept) == len(page):
-            continue
+        def drop_blacklisted(page, urls=urls):
+            kept = [d for d in page if d.url not in urls]
+            if len(kept) == len(page):
+                return None  # nothing to remove here, so leave the page alone
 
-        for document in page:
-            if document.url in urls:
-                try:
-                    removed_urls_by_domain[get_domain(document.url)].add(document.url)
-                except ValueError:
-                    removed_urls_by_domain[document.url].add(document.url)
-        index.store_in_page(page_index, kept)
+            for document in page:
+                if document.url in urls:
+                    try:
+                        removed_urls_by_domain[get_domain(document.url)].add(document.url)
+                    except ValueError:
+                        removed_urls_by_domain[document.url].add(document.url)
+            return kept
+
+        index.update_page(page_index, drop_blacklisted)
 
     removed_by_domain = {domain: len(urls) for domain, urls in removed_urls_by_domain.items()}
     if removed_by_domain:

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -79,20 +79,19 @@ def purge_documents(index: TinyIndex, documents: Iterable[Document],
     # pages, so counting each removal would report an order of magnitude too many.
     removed_urls_by_domain: dict[str, set[str]] = defaultdict(set)
     for page_index, urls in pages_to_urls.items():
-        def drop_blacklisted(page, urls=urls):
-            kept = [d for d in page if d.url not in urls]
-            if len(kept) == len(page):
-                return None  # nothing to remove here, so leave the page alone
+        with index.page(page_index) as page:
+            kept = [d for d in page.documents if d.url not in urls]
+            if len(kept) == len(page.documents):
+                # Nothing to remove here, so leave the page alone rather than rewriting it.
+                continue
 
-            for document in page:
+            for document in page.documents:
                 if document.url in urls:
                     try:
                         removed_urls_by_domain[get_domain(document.url)].add(document.url)
                     except ValueError:
                         removed_urls_by_domain[document.url].add(document.url)
-            return kept
-
-        index.update_page(page_index, drop_blacklisted)
+            page.store(kept)
 
     removed_by_domain = {domain: len(urls) for domain, urls in removed_urls_by_domain.items()}
     if removed_by_domain:

--- a/mwmbl/rankeval/README.md
+++ b/mwmbl/rankeval/README.md
@@ -79,3 +79,19 @@ DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
     uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index \
       --arm-set scores --fraction 0.3
 ```
+
+- **How often a gate fires, cheaply** —
+  `mwmbl/rankeval/evaluation/simulate_wiki_gate_firing.py` answers the counting
+  half of the same question in about a minute, with no network and no remote
+  index, over *every* query whose Wikipedia response `evaluate_wiki_index` has
+  already cached rather than a sample of a few hundred. It can, because the gate
+  counts only documents a previous call stored, so a local index holding exactly
+  what the run stored is a faithful simulation of its input. It reports firings
+  split into genuine repeats and first-seen queries riding on some other query's
+  documents — the split that decides whether a gate is caching or guessing. It
+  says nothing about NDCG; read it alongside `evaluate_wiki_index`, not instead.
+
+```bash
+DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
+    uv run python -m mwmbl.rankeval.evaluation.simulate_wiki_gate_firing
+```

--- a/mwmbl/rankeval/README.md
+++ b/mwmbl/rankeval/README.md
@@ -66,3 +66,16 @@ DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
   called at most once per distinct query ever — responses are cached in
   `devdata/wiki-index-eval-cache`, while the *count* of calls each policy would
   make is tracked exactly. Results in `WIKI_INDEX_CACHE_FINDINGS.md`.
+
+  `--arm-set scores` asks the other question: with Wikipedia called on *every*
+  query so nothing is skipped, does storing its results help or hurt the queries
+  that later retrieve them? The arms vary only which query term a stored result's
+  score is filed under (`none` / `all` / `specific` / `exact`) and whether
+  re-storing overwrites or averages, and the report is a paired per-query Δ on the
+  queries that actually retrieved another query's stored documents.
+
+```bash
+DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
+    uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index \
+      --arm-set scores --fraction 0.3
+```

--- a/mwmbl/rankeval/README.md
+++ b/mwmbl/rankeval/README.md
@@ -45,3 +45,24 @@ uv run python -m mwmbl.rankeval.evaluation.evaluate_remote
 
 (A `RankingModel` wrapper around the Super Search pipeline, for comparing Super
 Search v2 against standard search, is added separately.)
+
+- **Wikipedia results from the index** —
+  `mwmbl/rankeval/evaluation/evaluate_wiki_index.py` measures what it costs in
+  NDCG to stop calling the Wikipedia search API on every query: results a call
+  returns are written into the index under the query's unigrams and bigrams, and
+  a later query that the index already answers with enough Wikipedia results
+  skips the call. It sweeps the gate definition and threshold as arms over one
+  shared query sample, and reports NDCG, calls avoided, and NDCG **on the subset
+  where the gate fired** — the number the feature is decided on.
+
+```bash
+DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
+    uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index --fraction 0.1
+```
+
+  Reads go through an `OverlayIndex`: the remote production index unioned with a
+  fresh local `TinyIndex` that everything written during the run goes into (the
+  local dev index is far too small for a gate to mean anything). Wikipedia is
+  called at most once per distinct query ever — responses are cached in
+  `devdata/wiki-index-eval-cache`, while the *count* of calls each policy would
+  make is tracked exactly. Results in `WIKI_INDEX_CACHE_FINDINGS.md`.

--- a/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
+++ b/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
@@ -17,6 +17,17 @@ DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
 596 queries, shuffled order, test split, over the **remote production index** unioned with
 a fresh local index holding everything the run stored.
 
+> **Every absolute NDCG below predates two evaluation fixes and is not comparable with
+> anything measured after them.** (1) `gold_scores_for` took a query's first ten rows, but
+> 1,135 of the 5,969 test queries were scraped on several dates and their rows sit
+> consecutively, so those queries' "top ten" mixed dates and a URL appearing in two scrapes
+> kept the *worse* rank's weight; the gold ranking is now the latest scrape only.
+> (2) The gate arms were decided on the *fired* subset - 9 queries at 596, 35 at 1,790 -
+> and compared as a difference of two independent means. The subset that answers whether
+> storing helps at all is the queries that retrieved another query's stored documents, and
+> it is now compared paired. Within-run comparisons in the tables below still hold; the
+> levels do not.
+
 ## Headline: storing is free, skipping is expensive
 
 | arm | NDCG@10 | Δ | wiki calls | stored URLs |
@@ -229,6 +240,112 @@ bottleneck, and distinct bigrams grow nearly linearly with volume. Gold-set fire
 decile is flat noise (0%, 2%, 0%, 2%, 0%, 2%, 2%, 0%, 0%, 5%). Repeat matching does grow
 and then saturates (22% -> 47% by decile), at a ceiling set by how repetitive the traffic
 is - a property of the traffic, not of the dataset size.
+
+## Storing on its own, with nothing skipped: where the score should be filed
+
+Every table above conflates two things, because a gate firing and a stored document being
+served were the same event. `--arm-set scores` separates them: Wikipedia is called on
+**every** query and the results are stored, so no call is ever avoided and the only thing
+that varies is what a stored document looks like to the ranker when a *different* query
+retrieves it.
+
+The subset it is read on is new too. `fired` was 9 queries at 596 and 35 at 1,790. The
+population that actually matters is the queries whose candidate pool held documents an
+earlier, different query stored - **957 of 1,790**. The overlay's local half holds only
+what the run stored and storing happens after retrieval, so on a repeat-free gold set a
+local-half hit *is* a cross-query hit; no provenance bookkeeping is needed. Every arm is
+compared **paired**, per query, against `live-wiki`.
+
+`score_terms` decides which of a query's terms a stored copy carries the Wikipedia rank
+under: `all` (every term), `specific` (bigrams only, unless the query is one token),
+`exact` (only a term equal to the whole query), `none`.
+
+1,790 queries, test split, paired Δ NDCG against `live-wiki`:
+
+| arm | Δ affected (n=957) | Δ 1-token (n=18) | Δ 2+ token (n=939) | carried@10 |
+|---|---|---|---|---|
+| stored-score-none | −0.0012 ± 0.0017 | +0.0573 ± 0.0555 | −0.0023 ± 0.0014 | 0.17 |
+| stored-score-all | −0.0002 ± 0.0020 | +0.1128 ± 0.0761 | −0.0023 ± 0.0014 | 0.24 |
+| stored-score-specific | −0.0004 ± 0.0016 | +0.0573 ± 0.0555 | −0.0015 ± 0.0013 | 0.19 |
+| **stored-score-exact** | **+0.0010 ± 0.0011** | +0.0573 ± 0.0555 | **−0.0001 ± 0.0005** | 0.17 |
+
+**1. Storing is not what cost the −0.19.** With nothing skipped, the worst arm is −0.0012
+on the subset it acts on. The damage every gate paid was the *skipping*, and this is the
+first measurement that separates the two rather than inferring it.
+
+**2. The multi-token column is monotone in how narrowly the score is attributed.**
+all/none −0.0023 -> specific −0.0015 -> exact −0.0001. The direction is the hypothesis:
+a score filed under a bare unigram is the rank Wikipedia gave a document for a *whole*
+query, and the next query using that word reads it as if it were the word's own. But every
+one of these is within about 1.5 SEM of zero, so the ordering is a direction, not a
+result. What is not marginal is the **variance**: exact's error bar is a third of the
+others' (±0.0005 vs ±0.0014). Attributing the score to the originating query alone stops
+stored documents perturbing other queries' rankings at all - which is what its carried@10
+of 0.17, level with storing no score, says directly.
+
+**3. Removing the score is worse than mis-attributing it.** `none` is the *worst* arm on
+the affected subset (−0.0012 vs `all`'s −0.0002). This is the `WIKI_INDEX_KEEP_SCORE`
+finding again from the other side: a stored copy with no score is handicapped in a feature
+the model reads, against the identical result fetched live.
+
+**4. One-token queries are helped, if by anything.** All four arms are positive there
+(+0.057, +0.113 for `all`), which is a longer query's stored documents answering a shorter
+one - `connections` <- `connections hint september 14`. n=18 and the error bars are larger
+than the effects, so this is a lead, not a finding.
+
+**5. The exponential moving average had almost nothing to average.** Blending a score
+being written over the previous one for the same `(term, url)` (`WIKI_INDEX_SCORE_EMA_ALPHA`)
+produced results identical to plain `specific` at both 0.5 and 0.25, to four decimal
+places in every column. Counting the write events over the same 1,790 queries says why:
+
+| score_terms | scored writes | writes with a previous score to blend |
+|---|---|---|
+| all | 10,749 | 269 (2.5%) |
+| specific | 3,524 | **46 (1.3%)** |
+| exact | 1,691 | **0** |
+
+The arms ran `specific`, so the EMA acted 46 times in the whole run - 0.03 per query.
+It is **untested, not disproved**: a gold set with no repeated queries barely ever files
+the same document under the same term twice. Under `exact` it can never fire at all by
+construction, since the term is the query. Measuring it needs the repeat-weighted stream,
+where re-storing is the norm rather than the exception.
+
+### At repeat-stream density, `specific` and `all` come apart
+
+The gold set is sparse: 596 queries store 1,530 URLs and most terms are written once. A
+Zipf-weighted stream of 3,000 positions over the same 596 queries stores far more per
+term, which is the direction production goes. Every arm calls Wikipedia every time, so
+again nothing is skipped; the Δ is paired position by position (every arm replays the same
+seed, so position *i* is the same query in all of them).
+
+| arm | NDCG on repeats | Δ paired on repeats |
+|---|---|---|
+| live-wiki | 0.2372 ± 0.0073 | — |
+| stored-score-all | 0.2352 ± 0.0072 | **−0.0020 ± 0.0006** |
+| stored-score-specific | 0.2393 ± 0.0073 | +0.0021 ± 0.0025 |
+| stored-score-exact | 0.2393 ± 0.0073 | +0.0021 ± 0.0025 |
+| stored-score-specific-ema0_5 | 0.2393 ± 0.0073 | +0.0021 ± 0.0025 |
+
+`all` is negative at 3.3 SEM - small, but the clearest signal in this whole document that
+storing *can* hurt, and it appears only once the index is dense. `specific` is positive
+though within its own error bar. The two do not overlap: the gap between them is about
+0.004, six times `all`'s SEM. Note the shape of the error bars - `all` moves a lot of
+queries a little way down (tight SEM), `specific` moves few queries further.
+
+This also revises the earlier "storing is not free once the index is dense" figure of
+−0.0210 for `indexed-nogate`, which is the same score policy as `all`. Paired, and with the
+gold-set fix, the same effect measures −0.0020.
+
+### The EMA is a no-op in every configuration measured, for two different reasons
+
+On the gold set it has nothing to blend (46 chances in 1,790 queries under `specific`, 0
+under `exact`). On the repeat stream, where re-storing is the norm, it has plenty of
+chances and still changes nothing - because a repeated query re-stores the *identical*
+Wikipedia rank, and blending 3.0 with 3.0 is 3.0. The EMA can only bite where two
+**different** queries file the same (term, url) with **different** ranks, and under
+`exact` that combination cannot exist by construction. In production a third case exists
+that this harness cannot see - Wikipedia's own ranking drifting over weeks - but a single
+run has no time axis, so nothing here speaks to it.
 
 ## Recommendation
 

--- a/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
+++ b/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
@@ -174,6 +174,62 @@ valid — which is why every table above reports Δ against a baseline run at th
 - **The real repeat rate.** The Zipf stream is synthetic. Production query-frequency data
   would replace it and turn the ratio above into an actual expected saving.
 
+## Confirmation at 1790 queries: the zero did not replicate
+
+The zero-loss result above rested on 9 fired queries out of 596. Re-run at three times the
+sample, same harness, same seed:
+
+| arm | NDCG@10 | Δ | fired | Δ on fired | wiki@10 | calls |
+|---|---|---|---|---|---|---|
+| live-wiki | 0.3026 ± 0.0100 | — | — | — | 1.24 | 1790/1790 |
+| indexed-nogate | 0.3021 ± 0.0100 | −0.0005 | — | — | 1.31 | 1790/1790 |
+| indexed-from_wiki_only-t1 | 0.2806 ± 0.0098 | −0.0220 | 182 | −0.2163 | 1.24 | 1608/1790 |
+| indexed-term_coverage-t1 | 0.2972 ± 0.0099 | −0.0054 | 35 | **−0.1927** | 1.30 | 1755/1790 |
+
+`term_coverage = 1.0` went from +0.0000 to −0.0054 overall, and on the 35 queries it fired
+on it loses −0.1927 - in line with every other gate. **There is no gate that avoids calls
+without paying on the queries it fires on.** The overall figure stays small only because it
+fires on 2% of queries; "small because it rarely acts" is not "free".
+
+### Storing is not free once the index is dense
+
+`indexed-nogate` makes every API call and still loses 0.0210 on the repeat stream. It is
+not the gate - it is the storing. Wikipedia's share of the top 10 goes from 1.24 to 1.31,
+displacing non-wiki gold results.
+
+| arm | Δ on repeats | wiki@10 |
+|---|---|---|
+| indexed-nogate (calls every time) | −0.0210 | 1.31 |
+| indexed-term_coverage-t1 | −0.0314 | 1.30 |
+
+The effect is invisible on the gold set (−0.0005) and appears on the repeat stream. The
+difference is index **density**: 2,000 positions over 596 queries stores far more per term.
+Production density only increases. (Not paired-tested; treat as a strong signal, not a
+settled number.) The earlier claim that storing is free was true of a sparse index only.
+
+## What the gate is actually doing
+
+Tracing which earlier query stored the documents that let a later query skip its call
+(no network; replayed from the cached responses):
+
+- On the repeat-weighted stream, of 797 firings **794 were the same query asked again and
+  3 were a different query.** The rule is an exact-query cache implemented via terms.
+- On the gold set, where nothing repeats, it fires on 7/596 = 1.2%. Six of the seven are
+  single-word queries whose word was stored by a longer query containing it
+  (`connections` <- `connections hint september 14`, `jobs` <- `shunter jobs near me`).
+  The only multi-word case, `rachel reeves`, worked because `rachel reeves news` had stored
+  the bigram.
+- It catches **794 of 1,597 repeat positions - 49.7%**. A repeated query still needs *every*
+  term covered, and the stored documents often do not contain all of them. Misses by query
+  length: 2-token 436, 3-token 232, 4-token 80. The bigram is what fails, and 2-token
+  queries are the most common length in the gold set.
+
+Cross-query matching does not scale: requiring all unigrams *and* bigrams makes bigrams the
+bottleneck, and distinct bigrams grow nearly linearly with volume. Gold-set fire rate by
+decile is flat noise (0%, 2%, 0%, 2%, 0%, 2%, 2%, 0%, 0%, 5%). Repeat matching does grow
+and then saturates (22% -> 47% by decile), at a ceiling set by how repetitive the traffic
+is - a property of the traffic, not of the dataset size.
+
 ## Recommendation
 
 The proposal splits into two halves with different verdicts, and the gate splits again.
@@ -189,17 +245,17 @@ Wikipedia is needed. Queries where the crawled index looks richest in Wikipedia 
 are queries where live Wikipedia does especially well (live-wiki scores 0.65 on the
 t3-fired subset versus 0.30 overall).
 
-**3. `from_wiki_only` is the one to pursue.** Counting only documents a previous call
-stored makes it an approximate exact-query cache rather than an inference, and it behaves
-like one: ~50% of calls avoided on repeat-weighted traffic for −0.0117 NDCG on repeats,
-with the cost essentially flat as the savings grow.
+**3. An exact-query cache is the target, not a count or a coverage rule.** Every gate
+degraded as the sample grew, each looking best at the size where it fired least. What has
+held across every run is the diagnosis: the useful signal is "I have this query's own
+stored results", and every rule here is an awkward proxy for it. A query-keyed cache
+catches all 1,597 repeats rather than 794, cannot fire on the wrong query, and - because a
+hash-keyed entry never enters the candidate pool for other queries - sidesteps the density
+problem in the section above. That is the approach on branch `wiki-results-in-index`
+(`b39e9f8`).
 
-It is still only *approximate* — it fires on term overlap too, and on the gold set those
-24 firings cost −0.2872 on the fired subset. The exact version keys on the query itself and
-so cannot fire on overlap at all: that is the query-hash cache term on branch
-`wiki-results-in-index` (`b39e9f8`), which by construction cannot produce those losses.
+Suggested next step: build the exact-query cache and measure it head-to-head against
+`term_coverage = 1.0` on the same repeat-weighted stream. The prediction from these numbers
+is roughly double the savings with no ranking risk.
 
-Suggested next step: evaluate the exact-query cache against `from_wiki_only` on the
-repeat-weighted stream. The prediction from these numbers is that it captures the same
-~50% saving with the residual −0.0117 removed. If that holds, ship the exact cache and
-drop the count-based gate entirely.
+Do not enable `WIKI_INDEX_CACHE_ENABLED` on the strength of the 596-query numbers.

--- a/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
+++ b/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
@@ -347,6 +347,88 @@ Wikipedia rank, and blending 3.0 with 3.0 is 3.0. The EMA can only bite where tw
 that this harness cannot see - Wikipedia's own ranking drifting over weeks - but a single
 run has no time axis, so nothing here speaks to it.
 
+## Gating on bigram coverage: the denominator is not the point, the score policy is
+
+Every gate above counts coverage over the query's unigrams *and* bigrams. The proposal
+tested here narrows the denominator to bigrams alone, on the reasoning that a bigram is
+what identifies the query rather than the words in it.
+
+Measured with `mwmbl/rankeval/evaluation/simulate_wiki_gate_firing.py`, which replays a
+repeat-weighted stream over every query whose Wikipedia response is already on disk and
+counts firings only. It needs no remote index and no model, because the gate counts only
+documents a previous call stored - so a local index holding exactly what the run stored is
+a faithful simulation of its input. 2,347 cached queries, 3,000 positions, 2,149 repeats,
+threshold 1.0:
+
+| denominator / scores | fired | on repeats | on first-seen | repeats caught |
+|---|---|---|---|---|
+| terms / all (today's default) | 690 | 672 | 18 | 31.3% |
+| terms / specific | 227 | 227 | 0 | 10.6% |
+| bigrams / all | 690 | 672 | 18 | 31.3% |
+| **bigrams / specific** | **677** | **672** | **5** | **31.3%** |
+
+**1. The denominator change on its own is a no-op, and provably so.** Rows 1 and 3 are
+identical in every cell. A document only takes a term whose words it all contains
+(`words <= doc_tokens`), so a copy filed under the bigram `"a b"` is filed under `"a"` and
+`"b"` in the same write, and every unigram of a query appears in one of its consecutive
+bigrams. "Every bigram covered" and "every term covered" are the same condition. Pinned by
+`test_the_two_denominators_agree_when_every_term_is_scored`.
+
+**2. What it enables is `specific` scoring, which cannot be gated on without it.** Row 2
+is the combination that ships today if `WIKI_INDEX_SCORE_TERMS=specific` is set with the
+default gate: `specific` leaves unigram copies unscored, `term_coverage` reads an unscored
+term as uncovered, and full coverage becomes unreachable for every multi-token query. The
+gate does not error - it just stops firing on 96% of traffic, and every survivor is a
+one-token query. Pinned by
+`test_term_coverage_cannot_fire_for_a_multi_token_query_under_specific_scoring`.
+
+**3. Together they keep every repeat and drop 72% of the wrong-query firings.** Repeat
+catch is unchanged at 672/672. First-seen firings fall 18 -> 5, and the 13 that disappear
+are all the same shape:
+
+```
+eliminated:  1-token 'aircraft' 'amazon' 'argos' 'betfair' 'bundesliga' 'bus' ...
+surviving:   2-token 'angelina jolie' 'council tax' 'post office' 'premier league'
+             3-token 'champions league fixtures'
+```
+
+That is exactly the case `_takes_score` was written for - `connections` answered from
+`connections hint september 14` - now blocked at the gate as well as at the score. The
+survivors are the mild version: a bigram query answered by a longer query that contains
+it, where Wikipedia's ranking for `angelina jolie news` is unlikely to be far from
+`angelina jolie`.
+
+**What this does not measure is NDCG.** Firing counts are not cost; what a firing costs
+depends on the whole candidate pool. `build_coverage_arms` in `evaluate_wiki_index` runs
+the same 2x2 through the full stack for that. The prediction from the numbers above is
+that `bigrams/specific` matches `terms/all` on savings and loses less, but that is a
+prediction.
+
+**Threshold stays at 1.0.** Below it the gate fires on a query whose bigrams are only
+partly covered - `rachel reeves budget news` answered from whatever stored `rachel reeves`
+- which is the partial-match case every gate in this document has paid around -0.19 for.
+`DEFAULT_VALUE_THRESHOLDS` sweeps 0.5 and 0.75 to confirm that, not because either is a
+candidate.
+
+### What the privacy rule actually delivers
+
+Worth stating plainly, because the module docstring claims more than the code does.
+
+- **61% of queries are already stored whole.** 15.0% of test queries are one token and
+  46.2% are two, and `WIKI_INDEX_MAX_TERM_TOKENS = 2` files bigrams - so for a two-token
+  query the entire query is an index term stamped `FROM_WIKI`. Neither this proposal nor
+  today's code changes that.
+- **A 3+ token query is reconstructable from its bigram chain.** All consecutive bigrams
+  are filed against the same URL in one write, so `"a b"` + `"b c"` + `"c d"` recovers
+  `"a b c d"`. Containment is unordered set membership, so bigram *adjacency* is not
+  derivable from the document - it is query-derived. Filing non-overlapping bigrams
+  (`"a b"`, `"c d"`) would break the chain at the cost of a smaller denominator, and is
+  untested.
+- **The score leaks nothing further.** Every stored copy already carries
+  `state=FROM_WIKI`, which marks it as query-derived whether or not it has a score. So
+  `specific` is privacy-neutral at worst, and narrows the set of terms carrying
+  query-derived numbers at best.
+
 ## Recommendation
 
 The proposal splits into two halves with different verdicts, and the gate splits again.
@@ -362,7 +444,12 @@ Wikipedia is needed. Queries where the crawled index looks richest in Wikipedia 
 are queries where live Wikipedia does especially well (live-wiki scores 0.65 on the
 t3-fired subset versus 0.30 overall).
 
-**3. An exact-query cache is the target, not a count or a coverage rule.** Every gate
+**3. Pair `bigram_coverage` with `score_terms="specific"`, or neither.** They are one
+change: the denominator alone is a no-op, and `specific` cannot be gated on without it.
+Together they hold savings flat and cut wrong-query firings by 72%. Never ship `specific`
+with `term_coverage` - that silently disables the gate for all multi-token queries.
+
+**4. An exact-query cache is still the target, not a count or a coverage rule.** Every gate
 degraded as the sample grew, each looking best at the size where it fired least. What has
 held across every run is the diagnosis: the useful signal is "I have this query's own
 stored results", and every rule here is an awkward proxy for it. A query-keyed cache

--- a/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
+++ b/mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md
@@ -1,0 +1,205 @@
+# Wikipedia results from the index instead of the API
+
+Measuring the proposal: after a call to the Wikipedia search endpoint, index the results
+against the query's unigrams and bigrams; on later queries, skip the call when the index
+already returned enough Wikipedia results. Goals were fewer API calls, faster results, and
+deleting the filesystem HTTP cache (91,000 files / 4.5 GB on the dev box, unbounded, on the
+same volume as the index, and holding the raw user query in plaintext for ten weeks).
+
+Harness: `mwmbl/rankeval/evaluation/evaluate_wiki_index.py`. Command:
+
+```bash
+DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
+  uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index \
+    --fraction 0.1 --overlay-pages 65536 --zipf 3000
+```
+
+596 queries, shuffled order, test split, over the **remote production index** unioned with
+a fresh local index holding everything the run stored.
+
+## Headline: storing is free, skipping is expensive
+
+| arm | NDCG@10 | Δ | wiki calls | stored URLs |
+|---|---|---|---|---|
+| no-wiki | 0.0998 ± 0.0113 | −0.2002 | 0/596 | 0 |
+| **live-wiki** (today) | **0.3000 ± 0.0172** | — | 596/596 | 0 |
+| indexed-nogate | 0.3000 ± 0.0172 | +0.0000 | 596/596 | 1530 |
+| indexed-raw_candidates-t1 | 0.1162 ± 0.0122 | −0.1838 | 50/596 | 89 |
+| indexed-raw_candidates-t2 | 0.1216 ± 0.0124 | −0.1784 | 97/596 | 205 |
+| indexed-raw_candidates-t3 | 0.1333 ± 0.0129 | −0.1667 | 148/596 | 342 |
+| indexed-ranked_top_n-t1 | 0.1932 ± 0.0148 | −0.1067 | 403/596 | 991 |
+| indexed-ranked_top_n-t2 | 0.2406 ± 0.0161 | −0.0593 | 503/596 | 1270 |
+| indexed-ranked_top_n-t3 | 0.2703 ± 0.0167 | −0.0297 | 555/596 | 1421 |
+| indexed-from_wiki_only-t1 | 0.2884 ± 0.0170 | −0.0116 | 572/596 | 1466 |
+| indexed-from_wiki_only-t2 | 0.2966 ± 0.0172 | −0.0033 | 589/596 | 1515 |
+| indexed-from_wiki_only-t3 | 0.3000 ± 0.0172 | +0.0000 | 591/596 | 1521 |
+| indexed-unigrams-only | 0.2406 ± 0.0161 | −0.0593 | 503/596 | 1270 |
+| indexed-safe | 0.2406 ± 0.0161 | −0.0593 | 503/596 | 1270 |
+| never-call | 0.0998 ± 0.0113 | −0.2002 | 0/596 | 0 |
+
+Sanity invariants hold exactly, which is the evidence the harness is wired up correctly:
+`no-wiki` == `never-call`, and `live-wiki` == `indexed-nogate`.
+
+**1. Wikipedia is worth a lot.** Live results are +0.20 NDCG over not calling at all
+(0.0998 → 0.3000) — two thirds of the ranking's total score. Anything that loses them is
+expensive, which is why the gate has so little room.
+
+**2. Writing results into the index costs nothing.** `indexed-nogate` stores 1,530 URLs and
+scores *identically* to `live-wiki`, to four decimal places. The stored copies never
+displace a better result. So the half of the proposal that retires the disk cache is free.
+
+**3. Every gate that saves a material number of calls loses NDCG, and there is no knee in
+the curve.** `ranked_top_n` at threshold 3 is the least-bad useful setting and still loses
+−0.0297 (about 1.7 SEM) while avoiding only 41/596 = 6.9% of calls. Push it to a
+worthwhile saving and the loss grows roughly linearly:
+
+| gate | calls avoided | ΔNDCG |
+|---|---|---|
+| ranked_top_n-t3 | 6.9% | −0.0297 |
+| ranked_top_n-t2 | 15.6% | −0.0593 |
+| ranked_top_n-t1 | 32.4% | −0.1067 |
+| raw_candidates-t1 | 91.6% | −0.1838 |
+
+**4. `raw_candidates` is the worst of the three, as expected.** It counts unranked
+candidates, so a broad query pulls in crawled Wikipedia pages that would never have made
+the top 10, and the gate fires on 546/596 queries — nearly the `never-call` floor.
+
+**5. The damage is concentrated exactly where the feature acts.** On the subset where each
+gate fired, against `live-wiki` on those same queries:
+
+| arm | fired | NDCG (arm) | NDCG (live-wiki) | Δ |
+|---|---|---|---|---|
+| indexed-ranked_top_n-t1 | 193/596 | 0.1715 ± 0.0256 | 0.5011 ± 0.0329 | −0.3296 |
+| indexed-ranked_top_n-t2 | 93/596 | 0.2215 ± 0.0415 | 0.6017 ± 0.0463 | −0.3802 |
+| indexed-ranked_top_n-t3 | 41/596 | 0.2195 ± 0.0654 | 0.6512 ± 0.0724 | −0.4317 |
+| indexed-raw_candidates-t1 | 546/596 | 0.0998 ± 0.0119 | 0.3005 ± 0.0180 | −0.2006 |
+
+Note the direction: the *higher* the threshold, the worse the fired-subset loss. The gate
+is anti-correlated with the truth. Queries where the index looks richest in Wikipedia
+content are queries where live Wikipedia does *especially* well (live-wiki scores 0.65 on
+the t3-fired subset versus 0.30 overall) — so "the index already has wiki results" is
+close to the opposite of the signal we want.
+
+**6. The privacy restrictions are free — at this scale, for the wrong reason.**
+`indexed-unigrams-only` (bigrams never stored) and `indexed-safe`
+(`WIKI_INDEX_REQUIRE_EXISTING_TERM`) are byte-identical to plain `ranked_top_n-t2`: same
+NDCG, same 503 calls, same 1,270 stored URLs. That is not evidence they are harmless — it
+is evidence that **what we store barely drives the gate at all**. `from_wiki_only`, which
+counts only documents a previous call stored, fires on just 24/596 queries at threshold 1.
+The other gates are firing on Wikipedia pages that were already in the crawled index.
+
+**7. ~6% of fetches can never become a hit.** Wikipedia spell-corrects and partial-matches,
+so 34/596 results sets contained none of the query's words and the containment rule stored
+nothing for them.
+
+## The repeat-weighted stream: the case the gold set cannot show
+
+The gold set has **no repeated queries** — 596 unique queries, each asked once. So every
+gate firing in the table above is a *term-overlap* firing: the index answered with
+Wikipedia pages that merely look related. Production traffic is mostly repeats, and a
+repeat is a completely different case: the index holds the very URLs the API returned last
+time, so serving them is a cache hit, not an inference.
+
+Replaying the same queries as a Zipf-weighted stream of 3,000 positions and scoring each
+one, split on whether the query had been seen before:
+
+| arm | calls | NDCG on repeats | NDCG first-seen | Δ vs live on repeats |
+|---|---|---|---|---|
+| live-wiki | 3000/3000 | 0.2190 ± 0.0070 | 0.3004 ± 0.0193 | — |
+| indexed-ranked_top_n-t2 | 1551/3000 (48.3% avoided) | 0.1884 ± 0.0066 | 0.2379 ± 0.0180 | −0.0306 |
+| indexed-from_wiki_only-t1 | 1488/3000 (50.4% avoided) | 0.2073 ± 0.0069 | 0.2876 ± 0.0190 | −0.0117 |
+
+The Zipf weighting is a modelling assumption, so the absolute 50% is not a measurement of
+production. What is informative is the **loss per call avoided**, and it separates the
+gates sharply:
+
+- `ranked_top_n-t2` avoided 15.6% of calls for −0.0593 on the gold set, but 48.3% for
+  −0.0306 on repeats. Most of its firings on real traffic would be repeats, which are
+  cheap; its term-overlap firings are what cost.
+- `from_wiki_only-t1` avoided 4% of calls for −0.0116 on the gold set, and **50.4% for
+  −0.0117 on repeats**. Its cost barely moves as the savings go from 4% to 50%, because
+  the extra firings are all genuine repeats.
+
+That is the whole result in one line: **counting the query's own stored results scales;
+counting related Wikipedia content does not.**
+
+## Storage fidelity: part of the measured loss was a bug, not the idea
+
+A live Wikipedia result carries `score = 3.0/2.0/1.0` — its rank in Wikipedia's own
+results — and `LTRRanker.order_results` feeds `score` straight to the model as a feature.
+`index_results_against_query` did not copy it, so every stored copy scored `None` -> `0.0`.
+A result served from the index was therefore handicapped, in a feature the ranker uses,
+against the *identical* result fetched live. Fixed by `WIKI_INDEX_KEEP_SCORE`.
+
+Same harness, `from_wiki_only` at threshold 1, repeat-weighted stream:
+
+| arm | calls avoided | NDCG on repeats | Δ vs live on repeats |
+|---|---|---|---|
+| live-wiki | 0% | 0.2202 ± 0.0070 | — |
+| indexed-noscore (before) | 50.4% | 0.2085 ± 0.0069 | −0.0117 |
+| **indexed-from_wiki_only-t1 (after)** | **54.6%** | **0.2144 ± 0.0069** | **−0.0058** |
+
+Both directions improved at once: the loss halved *and* more calls were avoided, because
+stored copies now reach the top 10 often enough for the gate to recognise them. On the gold
+set the fired-subset loss also improved, −0.2872 -> −0.2154.
+
+This matters for how the rest of this document should be read. The gate arms were partly
+measuring a storage defect rather than the policy. Three fidelity gaps remain untested and
+all push the same way:
+
+- **3 results per call.** `num_wiki_results=3`, so a cache entry holds three results where
+  live Wikipedia offers many more. Nothing here tested fetching and storing more.
+- **The query-chosen snippet.** The stored `extract` is the snippet Wikipedia picked
+  *because it matched that query* — arbitrary as permanent index content, and it is what
+  `_document_token_set` tokenises, so it also decides what the document can be filed under.
+  `b39e9f8` refetches the query-independent intro instead.
+- **Filed only under query terms.** Wikipedia pages are never indexed under their *own*
+  tokens the way a crawled page is, so a page one person's query surfaced is not findable
+  by anyone else's words.
+
+Methodology note: `live-wiki` scored 0.3000 in the main run and 0.3016 here. The remote
+production index is live and changes between runs, so only *within-run* comparisons are
+valid — which is why every table above reports Δ against a baseline run at the same time.
+
+## What this does *not* measure
+
+- **Latency.** The harness's wall clock is meaningless here: with `RemoteIndex` each query
+  makes one HTTP call per term to api.mwmbl.org, and the wiki fetch is disk-cached. Derive
+  any latency claim from calls avoided × separately measured live Wikipedia call latency.
+- **Eviction.** The overlay index starts empty. Production pages are >90% full and
+  `_write_page` silently truncates an oversized page's tail, so there each stored document
+  evicts about as much as it adds. Measure page occupancy on the production index before
+  storing anything at volume.
+- **Staleness.** A single run has no time axis, so it says nothing about a TTL.
+- **The real repeat rate.** The Zipf stream is synthetic. Production query-frequency data
+  would replace it and turn the ratio above into an actual expected saving.
+
+## Recommendation
+
+The proposal splits into two halves with different verdicts, and the gate splits again.
+
+**1. Take the storage half — unconditionally.** Writing Wikipedia results into the index is
+free in NDCG (finding 2: identical to four decimal places), and it is what lets the
+filesystem HTTP cache — unbounded, on the index's volume, holding raw queries in
+plaintext — be deleted. Worth doing on its own merits.
+
+**2. Reject the `raw_candidates` and `ranked_top_n` gates.** Neither preserves NDCG at any
+useful saving, and finding 5 says why: their signal is *anti-correlated* with when
+Wikipedia is needed. Queries where the crawled index looks richest in Wikipedia content
+are queries where live Wikipedia does especially well (live-wiki scores 0.65 on the
+t3-fired subset versus 0.30 overall).
+
+**3. `from_wiki_only` is the one to pursue.** Counting only documents a previous call
+stored makes it an approximate exact-query cache rather than an inference, and it behaves
+like one: ~50% of calls avoided on repeat-weighted traffic for −0.0117 NDCG on repeats,
+with the cost essentially flat as the savings grow.
+
+It is still only *approximate* — it fires on term overlap too, and on the gold set those
+24 firings cost −0.2872 on the fired subset. The exact version keys on the query itself and
+so cannot fire on overlap at all: that is the query-hash cache term on branch
+`wiki-results-in-index` (`b39e9f8`), which by construction cannot produce those losses.
+
+Suggested next step: evaluate the exact-query cache against `from_wiki_only` on the
+repeat-weighted stream. The prediction from these numbers is that it captures the same
+~50% saving with the residual −0.0117 removed. If that holds, ship the exact cache and
+drop the count-based gate entirely.

--- a/mwmbl/rankeval/evaluation/evaluate.py
+++ b/mwmbl/rankeval/evaluation/evaluate.py
@@ -29,6 +29,34 @@ class RankingModel(ABC):
         pass
 
 
+def query_ndcg(predicted_urls: list[str], gold_scores: dict[str, float]) -> float:
+    """NDCG@10 of a predicted ranking against gold, matching ``evaluate`` below.
+
+    ``gold_scores`` maps each gold URL to its click-proportion relevance weight. Lives
+    here so the harnesses that run several arms over a shared query sample - and so need
+    per-query scores rather than ``evaluate``'s aggregate - score identically to it.
+    """
+    top_urls = predicted_urls[:NUM_RESULTS_FOR_EVAL]
+    y_true = [gold_scores.get(url, 0.0) for url in top_urls] + [0.0] * (10 - len(top_urls))
+    y_predicted = list(range(NUM_RESULTS_FOR_EVAL, 0, -1))
+    return ndcg_score([y_true], [y_predicted])
+
+
+def gold_scores_for(rankings) -> dict[str, float]:
+    """The gold URL -> click-weight map for one query's rows of the rankings dataset."""
+    top_ranked = rankings[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
+    top_ranked["score"] = CLICK_PROPORTIONS[:len(top_ranked)]
+    return top_ranked.set_index("url")["score"].to_dict()
+
+
+def mean_sem(values: list[float], places: int = 4) -> str:
+    if not values:
+        return "n/a"
+    if len(values) == 1:
+        return f"{np.mean(values):.{places}f}"
+    return f"{np.mean(values):.{places}f} ± {sem(values):.{places}f}"
+
+
 def evaluate(ranking_model: RankingModel, fraction: float = 1.0, use_test=False):
     # TODO:
     #  - output feature importances from XGBoost
@@ -57,9 +85,7 @@ def evaluate(ranking_model: RankingModel, fraction: float = 1.0, use_test=False)
         if query not in random_queries:
             continue
 
-        top_ranked = rankings[['url']].iloc[:NUM_RESULTS_FOR_EVAL]
-        top_ranked['score'] = CLICK_PROPORTIONS[:len(top_ranked)]
-        scores = top_ranked.set_index('url')['score'].to_dict()
+        scores = gold_scores_for(rankings)
         print(f"Query: '{query}'", scores)
 
         start_time = time.perf_counter()

--- a/mwmbl/rankeval/evaluation/evaluate.py
+++ b/mwmbl/rankeval/evaluation/evaluate.py
@@ -42,9 +42,28 @@ def query_ndcg(predicted_urls: list[str], gold_scores: dict[str, float]) -> floa
     return ndcg_score([y_true], [y_predicted])
 
 
+def latest_ranking(rankings):
+    """The most recent scrape of one query's results, in rank order.
+
+    The rankings dataset holds several scrapes of the same query taken on different
+    dates - 1,135 of the 5,969 test queries, up to 16 dates each - and their rows sit
+    consecutively under the one query. Taking the first ten rows therefore mixes dates:
+    the ten are not one ranking, and a URL that appears in two scrapes appears twice at
+    two different ranks. Keeping only the latest date makes the gold set what it is meant
+    to be - one ranking per query.
+    """
+    latest = rankings["date_retrieved"].max()
+    return rankings[rankings["date_retrieved"] == latest].sort_values("rank")
+
+
 def gold_scores_for(rankings) -> dict[str, float]:
-    """The gold URL -> click-weight map for one query's rows of the rankings dataset."""
-    top_ranked = rankings[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
+    """The gold URL -> click-weight map for one query's rows of the rankings dataset.
+
+    Duplicate URLs are dropped keeping the best rank, because the map is keyed by URL:
+    left in, the *worse* rank's weight is the one that would survive.
+    """
+    ranking = latest_ranking(rankings).drop_duplicates(subset="url", keep="first")
+    top_ranked = ranking[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
     top_ranked["score"] = CLICK_PROPORTIONS[:len(top_ranked)]
     return top_ranked.set_index("url")["score"].to_dict()
 

--- a/mwmbl/rankeval/evaluation/evaluate_fallback.py
+++ b/mwmbl/rankeval/evaluation/evaluate_fallback.py
@@ -45,15 +45,13 @@ from argparse import ArgumentParser
 import django
 import numpy as np
 import pandas as pd
-from scipy.stats import sem
-from sklearn.metrics import ndcg_score
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mwmbl.settings_dev")
 django.setup()
 
 import mwmbl.rankeval.evaluation.evaluate_super_search as ss_module  # noqa: E402
 from mwmbl.rankeval.evaluation.evaluate import (  # noqa: E402
-    CLICK_PROPORTIONS, NUM_RESULTS_FOR_EVAL, RankingModel)
+    RankingModel, gold_scores_for, mean_sem as _mean_sem, query_ndcg)
 from mwmbl.rankeval.evaluation.evaluate_ranker import DummyCompleter, MwmblRankingModel  # noqa: E402
 from mwmbl.rankeval.evaluation.evaluate_super_search import SuperSearchRankingModel  # noqa: E402
 from mwmbl.rankeval.evaluation.remote_index import RemoteIndex  # noqa: E402
@@ -96,23 +94,6 @@ class FallbackRankingModel(RankingModel):
         if len(primary_results) <= self.threshold:
             return self.fallback.predict(query)
         return primary_results
-
-
-def query_ndcg(predicted_urls: list[str], gold_scores: dict[str, float]) -> float:
-    """NDCG@10 of a predicted ranking against gold, matching ``evaluate.evaluate``.
-
-    ``gold_scores`` maps each gold URL to its click-proportion relevance weight.
-    """
-    top_urls = predicted_urls[:NUM_RESULTS_FOR_EVAL]
-    y_true = [gold_scores.get(url, 0.0) for url in top_urls] + [0.0] * (10 - len(top_urls))
-    y_predicted = list(range(NUM_RESULTS_FOR_EVAL, 0, -1))
-    return ndcg_score([y_true], [y_predicted])
-
-
-def _mean_sem(values: list[float]) -> str:
-    if not values:
-        return "    n/a"
-    return f"{np.mean(values):.4f} ± {sem(values):.4f}" if len(values) > 1 else f"{np.mean(values):.4f}"
 
 
 def run():
@@ -166,9 +147,7 @@ def run():
     for query, rankings in dataset.groupby("query"):
         if query not in sampled:
             continue
-        top_ranked = rankings[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
-        top_ranked["score"] = CLICK_PROPORTIONS[:len(top_ranked)]
-        gold_scores = top_ranked.set_index("url")["score"].to_dict()
+        gold_scores = gold_scores_for(rankings)
 
         std_results = standard.predict(query)
         standard_count[query] = len(std_results)

--- a/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
+++ b/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
@@ -255,6 +255,7 @@ DEFAULT_VALUE_THRESHOLDS = {
     "min_max_ltr": [0.0002, 0.0005, 0.001, 0.002, 0.005],
     "max_max_ltr": [0.001, 0.0025, 0.005, 0.01, 0.02],
     "term_coverage": [0.25, 0.5, 0.75, 1.0],
+    "bigram_coverage": [0.5, 0.75, 1.0],
     "mean_max_stored": [0.75, 1.5, 2.25, 3.0],
 }
 
@@ -288,7 +289,38 @@ def build_arms(gates: list[str], thresholds: list[float],
         Arm("indexed-safe", require_existing_term=True),
         Arm("never-call", gate="always"),
     ]
+    arms += build_coverage_arms()
     return arms
+
+
+def build_coverage_arms() -> list[Arm]:
+    """The 2x2 of coverage denominator against score policy.
+
+    The sweep above runs every gate at the default score_terms="all", where the two
+    denominators are provably the same condition (see query_bigrams) - so the gate on its
+    own measures nothing and has to be paired with the score policy explicitly. Offline
+    replay of a 3,000-position repeat-weighted stream over 2,347 cached queries gives the
+    firing counts; what these arms add is what those firings cost in NDCG.
+
+        denominator / scores      fired   repeats   first-seen
+        terms       / all           690       672           18
+        terms       / specific      227       227            0   <- gate dies
+        bigrams     / all           690       672           18   <- identical to row 1
+        bigrams     / specific      677       672            5   <- same savings, fewer
+                                                                    wrong-query firings
+
+    Threshold is pinned at 1.0. Anything lower fires when only some of a query's bigrams
+    are covered, which is the partial-match case every gate in this harness has paid
+    around -0.19 for; the sweep in DEFAULT_VALUE_THRESHOLDS is there to confirm that, not
+    because a lower setting is a candidate.
+    """
+    return [
+        Arm("indexed-bigram_coverage-all-t1", gate="bigram_coverage", threshold=1.0),
+        Arm("indexed-bigram_coverage-specific-t1", gate="bigram_coverage", threshold=1.0,
+            score_terms="specific"),
+        Arm("indexed-term_coverage-specific-t1", gate="term_coverage", threshold=1.0,
+            score_terms="specific"),
+    ]
 
 
 def build_score_arms() -> list[Arm]:
@@ -428,7 +460,7 @@ def report_zipf(records_by_arm: dict, baseline_name: str = "live-wiki"):
     def paired_over(records, predicate):
         return [r["ndcg"] - b["ndcg"] for r, b in zip(records, baseline) if predicate(r)]
 
-    print(f"\n{'arm':<30} {'calls':>13} {'NDCG on repeats':>20} "
+    print(f"\n{'arm':<36} {'calls':>13} {'NDCG on repeats':>20} "
           f"{'NDCG first-seen':>20} {'Δ paired on repeats':>22}")
     print("-" * 110)
     for name, records in records_by_arm.items():
@@ -439,7 +471,7 @@ def report_zipf(records_by_arm: dict, baseline_name: str = "live-wiki"):
             delta = "n/a"
         else:
             delta = mean_sem(paired_over(records, lambda r: r["repeat"]))
-        print(f"{name:<30} {calls:>5}/{len(records):<7} {mean_sem(repeats):>20} "
+        print(f"{name:<36} {calls:>5}/{len(records):<7} {mean_sem(repeats):>20} "
               f"{mean_sem(first):>20} {delta:>22}")
 
 
@@ -479,14 +511,14 @@ def report_affected(results: list[ArmResult], reference_name: str,
           f"({len(affected)}/{len(reference.order)}, from {reference_name}):")
     print(f"  {len(short)} one-token, {len(longer)} multi-token. Paired NDCG against "
           f"{baseline_name} on the same queries.")
-    print(f"\n{'arm':<30} {'Δ paired (affected)':>24} {'Δ 1-token':>24} "
+    print(f"\n{'arm':<36} {'Δ paired (affected)':>24} {'Δ 1-token':>24} "
           f"{'Δ 2+ token':>24} {'carried@10':>11}")
     print("-" * 118)
     for result in results:
         if result.arm.name == baseline_name:
             continue
         carried_top = np.mean([result.carried_in_top[q] for q in affected])
-        print(f"{result.arm.name:<30} "
+        print(f"{result.arm.name:<36} "
               f"{mean_sem(paired_deltas(result, baseline, affected)):>24} "
               f"{mean_sem(paired_deltas(result, baseline, short)):>24} "
               f"{mean_sem(paired_deltas(result, baseline, longer)):>24} "
@@ -496,7 +528,7 @@ def report_affected(results: list[ArmResult], reference_name: str,
     for result in results:
         if result.arm.name == baseline_name:
             continue
-        print(f"  {result.arm.name:<30} "
+        print(f"  {result.arm.name:<36} "
               f"{mean_sem(paired_deltas(result, baseline, reference.order)):>24}")
 
 
@@ -514,14 +546,14 @@ def report(results: list[ArmResult], header: str = "",
         print(f"\n{header}")
 
     print(f"\n{'=' * 132}")
-    print(f"{'arm':<30} {'NDCG@10':>18} {'ΔNDCG':>9} {'proportion':>18} "
+    print(f"{'arm':<36} {'NDCG@10':>18} {'ΔNDCG':>9} {'proportion':>18} "
           f"{'wiki@10':>7} {'calls':>12} {'stored':>8} {'affected':>9} {'carried@10':>11}")
     print(f"{'-' * 132}")
     for result in results:
         ndcg = list(result.ndcg.values())
         delta = (f"{np.mean(ndcg) - np.mean(list(baseline.ndcg.values())):+.4f}"
                  if baseline else "n/a")
-        print(f"{result.arm.name:<30} {mean_sem(ndcg):>18} {delta:>9} "
+        print(f"{result.arm.name:<36} {mean_sem(ndcg):>18} {delta:>9} "
               f"{mean_sem(list(result.proportion.values())):>18} "
               f"{np.mean(list(result.wiki_in_top.values())):>7.2f} "
               f"{result.calls:>5}/{n:<6} {sum(result.stored.values()):>8} "
@@ -530,24 +562,24 @@ def report(results: list[ArmResult], header: str = "",
     print(f"{'=' * 132}")
 
     print("\nSteady state (second half of the stream, index already warm):")
-    print(f"{'arm':<30} {'NDCG@10':>18} {'calls avoided':>15}")
+    print(f"{'arm':<36} {'NDCG@10':>18} {'calls avoided':>15}")
     for result in results:
         tail = result.order[len(result.order) // 2:]
         avoided = sum(1 for q in tail if not result.called_wiki[q])
-        print(f"{result.arm.name:<30} {mean_sem(_second_half(result, result.ndcg)):>18} "
+        print(f"{result.arm.name:<36} {mean_sem(_second_half(result, result.ndcg)):>18} "
               f"{avoided:>6}/{len(tail):<8}")
 
     if baseline is None:
         return
     print("\nOn the queries where the gate fired - the subset the feature is decided on:")
-    print(f"{'arm':<30} {'fired':>13} {'NDCG (arm)':>18} {'NDCG (live-wiki)':>18} {'Δ':>9}")
+    print(f"{'arm':<36} {'fired':>13} {'NDCG (arm)':>18} {'NDCG (live-wiki)':>18} {'Δ':>9}")
     for result in results:
         fired = result.fired
         if not fired or result.arm.name == baseline_name or not result.arm.include_wiki:
             continue
         arm_ndcg = [result.ndcg[q] for q in fired]
         base_ndcg = [baseline.ndcg[q] for q in fired]
-        print(f"{result.arm.name:<30} {len(fired):>5}/{n:<7} {mean_sem(arm_ndcg):>18} "
+        print(f"{result.arm.name:<36} {len(fired):>5}/{n:<7} {mean_sem(arm_ndcg):>18} "
               f"{mean_sem(base_ndcg):>18} {np.mean(arm_ndcg) - np.mean(base_ndcg):>+9.4f}")
 
     stored_nothing = [r for r in results if r.arm.cache_enabled and r.arm.include_wiki]
@@ -558,14 +590,14 @@ def report(results: list[ArmResult], header: str = "",
             fetched = [q for q, called in result.called_wiki.items() if called]
             empty = [q for q in fetched if result.stored[q] == 0]
             if fetched:
-                print(f"  {result.arm.name:<30} {len(empty):>5}/{len(fetched):<6} "
+                print(f"  {result.arm.name:<36} {len(empty):>5}/{len(fetched):<6} "
                       f"({100 * len(empty) / len(fetched):.1f}% of fetches)")
 
     print("\nNOTE: wall-clock timings from this harness are not production latency - the "
           "remote\nindex makes one HTTP call per query term and the wiki fetch is disk-cached. "
           "Mean\nper-query predict time, for reference only:")
     for result in results:
-        print(f"  {result.arm.name:<30} {np.mean(list(result.duration.values())):.3f}s")
+        print(f"  {result.arm.name:<36} {np.mean(list(result.duration.values())):.3f}s")
 
 
 def run():
@@ -581,8 +613,12 @@ def run():
                              "every time and vary only which term carries a stored "
                              "result's score, to measure the ranking effect on other "
                              "queries in isolation.")
+    # bigram_coverage is left out of the default sweep because build_coverage_arms
+    # already runs it at the only threshold worth running, paired with both score
+    # policies. Pass it explicitly to sweep its thresholds.
     parser.add_argument("--gates", nargs="+",
-                        default=list(COUNTING_GATES) + list(VALUE_GATES),
+                        default=[g for g in list(COUNTING_GATES) + list(VALUE_GATES)
+                                 if g != "bigram_coverage"],
                         help="Gate definitions to sweep.")
     parser.add_argument("--thresholds", type=float, nargs="+", default=[1, 2, 3],
                         help="Counting gates: wiki results needed to skip the call.")

--- a/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
+++ b/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
@@ -24,6 +24,24 @@ Two pieces make a realistic measurement possible:
     SUPER_SEARCH_EVAL_FINDINGS.md finding #6 records silently losing 36% of wiki results.
     We *count* the calls; we do not *make* them repeatedly.
 
+Two questions, two arm sets (``--arm-set``):
+
+``gates``
+    The original one: which rule for skipping the API call preserves NDCG. Every firing
+    is both "a call was skipped" and "stored documents were served", so the two effects
+    are inseparable.
+
+``scores``
+    Wikipedia is called on *every* query and the results are stored, so nothing is ever
+    skipped and the only thing that varies is what a stored document looks like to the
+    ranker when a *different* query retrieves it. This is the "does storing help in
+    general" question, and it is reported on the **affected subset**: the queries whose
+    candidate pool held documents an earlier, different query stored. The overlay's local
+    half contains only what the run stored and storing happens after retrieval, so on a
+    gold set with no repeats a local-half hit *is* a cross-query hit - see
+    ``OverlayIndex.retrieve``. That subset is hundreds of queries where the gates' fired
+    subsets were 9 and 35, and it is compared paired, per query, against ``live-wiki``.
+
 Three limits on what the numbers mean, none of them incidental:
 
   * **The gold set has no repeat queries** - 5,969 unique queries in the test split, each
@@ -77,6 +95,7 @@ from mwmbl.tinysearchengine.mmr_rank import MMRRanker  # noqa: E402
 from mwmbl.tinysearchengine.rank import get_wiki_results  # noqa: E402
 from mwmbl.tinysearchengine.wiki_index_cache import (  # noqa: E402
     COUNTING_GATES, VALUE_GATES, store_wiki_results)
+from mwmbl.tokenizer import tokenize  # noqa: E402
 
 
 # Roughly 6k queries * ~3 storable terms each is well under 20k distinct terms, so 64k
@@ -156,9 +175,18 @@ class OverlayIndex:
         # immediately - the same arrangement production relies on (see search_setup).
         self.local = TinyIndex(item_factory=Document, index_path=str(local_path))
         self.local.__enter__()
+        # Set to a fresh set() before a query to collect the stored (term, url) pairs that
+        # query retrieved. Everything in the local half was stored by an *earlier* query -
+        # external_search, which does the storing, runs after retrieval, and the gold set
+        # has no repeats - so a non-empty trace is exactly "this query saw another query's
+        # stored documents", with no provenance bookkeeping needed.
+        self.trace: set[tuple[str, str]] | None = None
 
     def retrieve(self, term: str) -> list[Document]:
-        return self.remote.retrieve(term) + self.local.retrieve(term)
+        local = self.local.retrieve(term)
+        if self.trace is not None:
+            self.trace.update((document.term, document.url) for document in local)
+        return self.remote.retrieve(term) + local
 
     def has_term(self, term: str) -> bool:
         """Whether the corpus - both halves - already holds documents under this term."""
@@ -179,7 +207,8 @@ class Arm:
     threshold: int = 2
     require_existing_term: bool = False
     max_term_tokens: int = 2
-    keep_score: bool = True
+    score_terms: str = "all"
+    score_ema_alpha: float = 1.0
 
 
 @dataclass
@@ -190,6 +219,8 @@ class ArmResult:
     wiki_in_top: dict = field(default_factory=dict)
     called_wiki: dict = field(default_factory=dict)
     stored: dict = field(default_factory=dict)
+    carried: dict = field(default_factory=dict)
+    carried_in_top: dict = field(default_factory=dict)
     duration: dict = field(default_factory=dict)
     order: list = field(default_factory=list)
 
@@ -201,6 +232,17 @@ class ArmResult:
     def fired(self) -> list:
         """Queries where the gate suppressed a call it would otherwise have made."""
         return [q for q, called in self.called_wiki.items() if not called]
+
+    @property
+    def affected(self) -> list:
+        """Queries whose candidate pool held documents an earlier, different query stored.
+
+        The population this feature is supposed to help. Unlike `fired` it exists with the
+        gate off, and it is a term-overlap event rather than a repeated query - so it is
+        the subset that answers whether storing Wikipedia results makes the index better
+        in general rather than only caching.
+        """
+        return [q for q, count in self.carried.items() if count]
 
 
 # The per-term gates live on wildly different scales, so one shared sweep cannot serve
@@ -242,11 +284,38 @@ def build_arms(gates: list[str], thresholds: list[float],
                  for t in sweep]
     arms += [
         Arm("indexed-unigrams-only", max_term_tokens=1),
-        Arm("indexed-noscore", gate="from_wiki_only", threshold=1, keep_score=False),
+        Arm("indexed-noscore", gate="from_wiki_only", threshold=1, score_terms="none"),
         Arm("indexed-safe", require_existing_term=True),
         Arm("never-call", gate="always"),
     ]
     return arms
+
+
+def build_score_arms() -> list[Arm]:
+    """Arms that isolate the *ranking* effect of stored results from the caching effect.
+
+    Every one runs gate="never": Wikipedia is called on every query and the results are
+    stored, so no call is ever skipped and the only thing that varies is what a stored
+    document looks like to the ranker when some *other* query retrieves it. That is the
+    question the gate sweep could never answer, because a gate firing and a stored
+    document being served were the same event.
+
+    live-wiki stores nothing at all and is the baseline. The rest differ only in which
+    term carries the Wikipedia rank, and whether re-storing overwrites or averages - so
+    they all store the same (term, url) pairs and the affected subset is identical across
+    them, which keeps the comparison paired.
+    """
+    return [
+        Arm("live-wiki", cache_enabled=False),
+        Arm("stored-score-none", gate="never", score_terms="none"),
+        Arm("stored-score-all", gate="never", score_terms="all"),
+        Arm("stored-score-specific", gate="never", score_terms="specific"),
+        Arm("stored-score-exact", gate="never", score_terms="exact"),
+        Arm("stored-score-specific-ema0_5", gate="never", score_terms="specific",
+            score_ema_alpha=0.5),
+        Arm("stored-score-specific-ema0_25", gate="never", score_terms="specific",
+            score_ema_alpha=0.25),
+    ]
 
 
 def build_stack(arm: Arm, overlay: Path, overlay_pages: int, model):
@@ -269,7 +338,8 @@ def arm_settings(arm: Arm):
         WIKI_INDEX_GATE_THRESHOLD=arm.threshold,
         WIKI_INDEX_REQUIRE_EXISTING_TERM=arm.require_existing_term,
         WIKI_INDEX_MAX_TERM_TOKENS=arm.max_term_tokens,
-        WIKI_INDEX_KEEP_SCORE=arm.keep_score,
+        WIKI_INDEX_SCORE_TERMS=arm.score_terms,
+        WIKI_INDEX_SCORE_EMA_ALPHA=arm.score_ema_alpha,
     )
 
 
@@ -282,16 +352,20 @@ def run_arm(arm: Arm, queries: list[str], gold: dict, overlay_pages: int,
         with arm_settings(arm):
             for i, query in enumerate(queries):
                 calls_before, stored_before = fetcher.calls, store.urls_stored
+                index.trace = set()
                 start = time.perf_counter()
                 urls = ranking_model.predict(query)
                 result.duration[query] = time.perf_counter() - start
 
                 top = urls[:NUM_RESULTS_FOR_EVAL]
+                carried_urls = {url for _, url in index.trace}
                 result.ndcg[query] = query_ndcg(urls, gold[query])
                 result.proportion[query] = len(set(top) & gold[query].keys()) / NUM_RESULTS_FOR_EVAL
                 result.wiki_in_top[query] = sum(1 for url in top if "en.wikipedia.org" in url)
                 result.called_wiki[query] = fetcher.calls > calls_before
                 result.stored[query] = store.urls_stored - stored_before
+                result.carried[query] = len(index.trace)
+                result.carried_in_top[query] = sum(1 for url in top if url in carried_urls)
 
                 if (i + 1) % 100 == 0:
                     print(f"  {arm.name}: {i + 1}/{len(queries)} queries, "
@@ -344,14 +418,19 @@ def run_zipf(arm: Arm, queries: list[str], gold: dict, stream_length: int,
 
 
 def report_zipf(records_by_arm: dict, baseline_name: str = "live-wiki"):
+    """Every arm replays the same stream from the same seed, so position i is the same
+    query in all of them and the Δ can be paired the way report_affected's is."""
     baseline = records_by_arm.get(baseline_name)
 
     def mean_over(records, predicate):
         return [r["ndcg"] for r in records if predicate(r)]
 
+    def paired_over(records, predicate):
+        return [r["ndcg"] - b["ndcg"] for r, b in zip(records, baseline) if predicate(r)]
+
     print(f"\n{'arm':<30} {'calls':>13} {'NDCG on repeats':>20} "
-          f"{'NDCG first-seen':>20} {'Δ vs live on repeats':>21}")
-    print("-" * 104)
+          f"{'NDCG first-seen':>20} {'Δ paired on repeats':>22}")
+    print("-" * 110)
     for name, records in records_by_arm.items():
         calls = sum(1 for r in records if r["called"])
         repeats = mean_over(records, lambda r: r["repeat"])
@@ -359,10 +438,66 @@ def report_zipf(records_by_arm: dict, baseline_name: str = "live-wiki"):
         if baseline is None or name == baseline_name:
             delta = "n/a"
         else:
-            base_repeats = mean_over(baseline, lambda r: r["repeat"])
-            delta = f"{np.mean(repeats) - np.mean(base_repeats):+.4f}"
+            delta = mean_sem(paired_over(records, lambda r: r["repeat"]))
         print(f"{name:<30} {calls:>5}/{len(records):<7} {mean_sem(repeats):>20} "
-              f"{mean_sem(first):>20} {delta:>21}")
+              f"{mean_sem(first):>20} {delta:>22}")
+
+
+def paired_deltas(result: ArmResult, baseline: ArmResult, queries: list) -> list[float]:
+    """Per-query NDCG differences against the baseline on the same queries.
+
+    Paired, unlike the difference of two independent means the main table prints: both
+    arms answered the identical query against the identical remote index, so the query's
+    own difficulty cancels and the error bar shrinks to the variance of the *effect*.
+    That matters here because the interesting subsets are small.
+    """
+    return [result.ndcg[query] - baseline.ndcg[query] for query in queries]
+
+
+def report_affected(results: list[ArmResult], reference_name: str,
+                    baseline_name: str = "live-wiki"):
+    """What happens to a query that retrieves a document some other query stored.
+
+    The subset is taken from one reference arm and applied to all of them: the score arms
+    store the same (term, url) pairs and differ only in the score written, so they share a
+    subset, and using one keeps every arm scored on identical queries. The baseline stores
+    nothing, so it has no subset of its own - it is what the subset is measured against.
+    """
+    baseline = next((r for r in results if r.arm.name == baseline_name), None)
+    reference = next((r for r in results if r.arm.name == reference_name), None)
+    if baseline is None or reference is None:
+        return
+
+    affected = [q for q in reference.order if reference.carried[q]]
+    if not affected:
+        print(f"\nNo query retrieved another query's stored documents in {reference_name}.")
+        return
+
+    short = [q for q in affected if len(tokenize(q)) == 1]
+    longer = [q for q in affected if len(tokenize(q)) > 1]
+    print(f"\nQueries that retrieved documents an earlier, different query stored "
+          f"({len(affected)}/{len(reference.order)}, from {reference_name}):")
+    print(f"  {len(short)} one-token, {len(longer)} multi-token. Paired NDCG against "
+          f"{baseline_name} on the same queries.")
+    print(f"\n{'arm':<30} {'Δ paired (affected)':>24} {'Δ 1-token':>24} "
+          f"{'Δ 2+ token':>24} {'carried@10':>11}")
+    print("-" * 118)
+    for result in results:
+        if result.arm.name == baseline_name:
+            continue
+        carried_top = np.mean([result.carried_in_top[q] for q in affected])
+        print(f"{result.arm.name:<30} "
+              f"{mean_sem(paired_deltas(result, baseline, affected)):>24} "
+              f"{mean_sem(paired_deltas(result, baseline, short)):>24} "
+              f"{mean_sem(paired_deltas(result, baseline, longer)):>24} "
+              f"{carried_top:>11.2f}")
+
+    print(f"\nPaired Δ over all {len(reference.order)} queries, for comparison:")
+    for result in results:
+        if result.arm.name == baseline_name:
+            continue
+        print(f"  {result.arm.name:<30} "
+              f"{mean_sem(paired_deltas(result, baseline, reference.order)):>24}")
 
 
 def _second_half(result: ArmResult, values: dict) -> list:
@@ -378,10 +513,10 @@ def report(results: list[ArmResult], header: str = "",
     if header:
         print(f"\n{header}")
 
-    print(f"\n{'=' * 118}")
+    print(f"\n{'=' * 132}")
     print(f"{'arm':<30} {'NDCG@10':>18} {'ΔNDCG':>9} {'proportion':>18} "
-          f"{'wiki@10':>7} {'calls':>12} {'stored':>8}")
-    print(f"{'-' * 118}")
+          f"{'wiki@10':>7} {'calls':>12} {'stored':>8} {'affected':>9} {'carried@10':>11}")
+    print(f"{'-' * 132}")
     for result in results:
         ndcg = list(result.ndcg.values())
         delta = (f"{np.mean(ndcg) - np.mean(list(baseline.ndcg.values())):+.4f}"
@@ -389,8 +524,10 @@ def report(results: list[ArmResult], header: str = "",
         print(f"{result.arm.name:<30} {mean_sem(ndcg):>18} {delta:>9} "
               f"{mean_sem(list(result.proportion.values())):>18} "
               f"{np.mean(list(result.wiki_in_top.values())):>7.2f} "
-              f"{result.calls:>5}/{n:<6} {sum(result.stored.values()):>8}")
-    print(f"{'=' * 118}")
+              f"{result.calls:>5}/{n:<6} {sum(result.stored.values()):>8} "
+              f"{len(result.affected):>9} "
+              f"{np.mean(list(result.carried_in_top.values())):>11.2f}")
+    print(f"{'=' * 132}")
 
     print("\nSteady state (second half of the stream, index already warm):")
     print(f"{'arm':<30} {'NDCG@10':>18} {'calls avoided':>15}")
@@ -438,7 +575,12 @@ def run():
     parser.add_argument("--train", action="store_true",
                         help="Evaluate on the train split instead of test.")
     parser.add_argument("--arms", nargs="+", default=None,
-                        help="Only run these arms by name (default: the standard set).")
+                        help="Only run these arms by name (default: the whole set).")
+    parser.add_argument("--arm-set", choices=["gates", "scores"], default="gates",
+                        help="gates: sweep the skip-the-call rules. scores: call Wikipedia "
+                             "every time and vary only which term carries a stored "
+                             "result's score, to measure the ranking effect on other "
+                             "queries in isolation.")
     parser.add_argument("--gates", nargs="+",
                         default=list(COUNTING_GATES) + list(VALUE_GATES),
                         help="Gate definitions to sweep.")
@@ -494,7 +636,10 @@ def run():
         np.random.default_rng(42).shuffle(queries)
     print(f"Num queries {len(queries)} ({args.order} order)")
 
-    arms = build_arms(args.gates, args.thresholds, args.value_thresholds)
+    if args.arm_set == "scores":
+        arms = build_score_arms()
+    else:
+        arms = build_arms(args.gates, args.thresholds, args.value_thresholds)
     if args.arms:
         by_name = {arm.name: arm for arm in arms}
         unknown = [name for name in args.arms if name not in by_name]
@@ -516,6 +661,11 @@ def run():
         report(results, header=f"{len(queries)} queries, {args.order} order, "
                               f"{'train' if args.train else 'test'} split, "
                               f"fraction={args.fraction}, overlay_pages={args.overlay_pages}")
+
+        reference = next((r.arm.name for r in results
+                          if r.arm.cache_enabled and r.arm.include_wiki), None)
+        if reference is not None:
+            report_affected(results, reference_name=reference)
 
         if args.zipf:
             print(f"\nRepeat-weighted stream: {args.zipf} positions, Zipf over the same "

--- a/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
+++ b/mwmbl/rankeval/evaluation/evaluate_wiki_index.py
@@ -1,0 +1,538 @@
+"""Evaluate serving Wikipedia results from our own index instead of the API.
+
+Today every search makes one live call to the Wikipedia search endpoint, cached by a
+filesystem HTTP cache that grows without bound and writes the raw user query to disk. The
+proposal under test: index the results a call returns against the query's unigrams and
+bigrams, and on later queries skip the call when the index already returned enough
+Wikipedia results. Goals are fewer calls, faster results, and deleting the disk cache. The
+question this harness answers is what that costs in NDCG.
+
+Two pieces make a realistic measurement possible:
+
+``OverlayIndex``
+    The local dev index (11 MB, NUM_PAGES=2560) returns <= 3 results for almost every
+    query, so a gate evaluated against it would fire on nothing and mean nothing. The
+    realistic index is the production one, reachable only read-only over HTTP. So reads
+    come from ``RemoteIndex`` *unioned with* a fresh local ``TinyIndex`` that everything
+    written during the run goes into. Both are duck-typed against ``retrieve()``, which is
+    all ``Ranker`` uses.
+
+``CountingWikiFetcher``
+    Counts the calls the policy *would* make - the headline cost metric, and exact - while
+    serving the response from a joblib cache, so Wikipedia is hit at most once per distinct
+    query ever, reruns are free and reproducible, and we never trip the rate limiter that
+    SUPER_SEARCH_EVAL_FINDINGS.md finding #6 records silently losing 36% of wiki results.
+    We *count* the calls; we do not *make* them repeatedly.
+
+Three limits on what the numbers mean, none of them incidental:
+
+  * **The gold set has no repeat queries** - 5,969 unique queries in the test split, each
+    appearing once. Every hit here comes from term overlap between *different* queries,
+    never from a repeat, so the measured call-avoidance rate is a **lower bound** on the
+    production saving. ``--zipf`` replays the same queries as a repeat-weighted stream to
+    bracket the real number (call counts only; no NDCG).
+  * **Do not quote the wall clock.** With ``RemoteIndex``, ``get_results`` makes one HTTP
+    call per term ∪ bigram ∪ completion to api.mwmbl.org, absorbed by a never-expiring
+    filesystem cache, and the wiki fetch is joblib-cached. Derive the latency claim from
+    the call-avoidance rate times a separately measured live Wikipedia call latency.
+  * **Eviction is not measured.** The overlay starts empty, so nothing it stores displaces
+    anything. Production pages are >90% full and ``_write_page`` silently truncates the
+    tail of an oversized page, so there every stored document evicts about as much as it
+    adds. Measure page occupancy on the production index before rollout.
+
+Usage::
+
+    DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \\
+        uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index --fraction 0.02
+"""
+import logging
+import os
+import shutil
+import time
+from argparse import ArgumentParser
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import django
+import numpy as np
+import pandas as pd
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mwmbl.settings_dev")
+django.setup()
+
+from django.test import override_settings  # noqa: E402
+from joblib import Memory  # noqa: E402
+
+from mwmbl.rankeval.evaluation.evaluate import (  # noqa: E402
+    NUM_RESULTS_FOR_EVAL, gold_scores_for, mean_sem, query_ndcg)
+from mwmbl.rankeval.evaluation.evaluate_ranker import DummyCompleter, MwmblRankingModel  # noqa: E402
+from mwmbl.rankeval.evaluation.remote_index import RemoteIndex  # noqa: E402
+from mwmbl.rankeval.paths import (  # noqa: E402
+    DATA_DIR, RANKINGS_DATASET_TEST_PATH, RANKINGS_DATASET_TRAIN_PATH, RUST_MODEL_PATH)
+from mwmbl.tinysearchengine.indexer import (  # noqa: E402
+    PAGE_SIZE, Document, DocumentState, TinyIndex)
+from mwmbl.tinysearchengine.ltr import RustXGBPipeline  # noqa: E402
+from mwmbl.tinysearchengine.ltr_rank import LTRRanker  # noqa: E402
+from mwmbl.tinysearchengine.mmr_rank import MMRRanker  # noqa: E402
+from mwmbl.tinysearchengine.rank import get_wiki_results  # noqa: E402
+from mwmbl.tinysearchengine.wiki_index_cache import (  # noqa: E402
+    COUNTING_GATES, VALUE_GATES, store_wiki_results)
+
+
+# Roughly 6k queries * ~3 storable terms each is well under 20k distinct terms, so 64k
+# pages keeps collisions rare enough that the silent page-full truncation in _write_page
+# does not confound the measurement. 256 MB on disk, recreated per arm.
+DEFAULT_OVERLAY_PAGES = 65536
+
+memory = Memory(location=str(DATA_DIR / "wiki-index-eval-cache"), verbose=0)
+
+
+@memory.cache
+def _fetch_wiki(query: str, num_results: int) -> list[dict]:
+    """One real call to the Wikipedia search API, cached forever on disk.
+
+    Cached as plain dicts rather than Documents so the cache survives changes to the
+    Document class. Note the ``term``: get_wiki_results stamps each result with the *raw*
+    query, and we keep that here deliberately, so the write path is exercised with the
+    same input production would give it.
+    """
+    return [{"title": d.title, "url": d.url, "extract": d.extract, "score": d.score,
+             "term": d.term}
+            for d in get_wiki_results(query, num_results)]
+
+
+class CountingWikiFetcher:
+    """Drop-in for get_wiki_results that counts the calls a policy makes."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, query: str, num_results: int) -> list[Document]:
+        self.calls += 1
+        return [Document(d["title"], d["url"], d["extract"], d["score"], d["term"],
+                         state=DocumentState.FROM_WIKI)
+                for d in _fetch_wiki(query, num_results)]
+
+
+class CountingWikiStore:
+    """Drop-in for store_wiki_results that counts what actually got written.
+
+    Also answers the WIKI_INDEX_REQUIRE_EXISTING_TERM question against the *overlay*.
+    Left to itself store_wiki_results would ask the index it writes to, which here is
+    only the local half and starts empty - so no term would ever exist and the strict
+    arm would degenerate into storing nothing at all.
+    """
+
+    def __init__(self, index: 'OverlayIndex'):
+        self.index = index
+        self.urls_stored = 0
+
+    def __call__(self, query: str, documents: list[Document], index_path) -> int:
+        stored = store_wiki_results(query, documents, index_path,
+                                    term_exists=self.index.has_term)
+        self.urls_stored += stored
+        return stored
+
+
+class OverlayIndex:
+    """Reads from a remote index unioned with a local writable one; writes go local.
+
+    The remote production index is the only realistic thing to evaluate a gate against,
+    and it is read-only over HTTP. Everything this run stores goes into a fresh local
+    TinyIndex, and retrieve() returns both - which is what the production index would
+    look like once it had been accumulating results.
+    """
+
+    def __init__(self, local_path: Path, num_pages: int, remote: RemoteIndex = None):
+        self.local_path = local_path
+        self.remote = remote if remote is not None else RemoteIndex()
+        if local_path.exists():
+            local_path.unlink()
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        TinyIndex.create(item_factory=Document, index_path=str(local_path),
+                         num_pages=num_pages, page_size=PAGE_SIZE)
+        # Held open read-only for the arm's lifetime. Writers (index_pages) open their own
+        # 'w' handle on the same file; both mmap MAP_SHARED, so writes are visible here
+        # immediately - the same arrangement production relies on (see search_setup).
+        self.local = TinyIndex(item_factory=Document, index_path=str(local_path))
+        self.local.__enter__()
+
+    def retrieve(self, term: str) -> list[Document]:
+        return self.remote.retrieve(term) + self.local.retrieve(term)
+
+    def has_term(self, term: str) -> bool:
+        """Whether the corpus - both halves - already holds documents under this term."""
+        return bool(self.retrieve(term))
+
+    def close(self):
+        self.local.__exit__(None, None, None)
+        self.local_path.unlink(missing_ok=True)
+
+
+@dataclass
+class Arm:
+    """One policy to evaluate. Defaults are the proposal at its recommended settings."""
+    name: str
+    include_wiki: bool = True
+    cache_enabled: bool = True
+    gate: str = "ranked_top_n"
+    threshold: int = 2
+    require_existing_term: bool = False
+    max_term_tokens: int = 2
+    keep_score: bool = True
+
+
+@dataclass
+class ArmResult:
+    arm: Arm
+    ndcg: dict = field(default_factory=dict)
+    proportion: dict = field(default_factory=dict)
+    wiki_in_top: dict = field(default_factory=dict)
+    called_wiki: dict = field(default_factory=dict)
+    stored: dict = field(default_factory=dict)
+    duration: dict = field(default_factory=dict)
+    order: list = field(default_factory=list)
+
+    @property
+    def calls(self) -> int:
+        return sum(self.called_wiki.values())
+
+    @property
+    def fired(self) -> list:
+        """Queries where the gate suppressed a call it would otherwise have made."""
+        return [q for q, called in self.called_wiki.items() if not called]
+
+
+# The per-term gates live on wildly different scales, so one shared sweep cannot serve
+# them. The LTR model's predictions on live Wikipedia results run 0 to ~0.04 with a
+# median near 0.003 (it filters at > 0.0 and the tail collapses toward zero), and
+# mean_max divides by every query term including the ones with nothing, so it sits lower
+# again. Coverage is a fraction, and the stored score is Wikipedia's rank, 3/2/1.
+DEFAULT_VALUE_THRESHOLDS = {
+    "mean_max_ltr": [0.0002, 0.0005, 0.001, 0.002, 0.005],
+    "min_max_ltr": [0.0002, 0.0005, 0.001, 0.002, 0.005],
+    "max_max_ltr": [0.001, 0.0025, 0.005, 0.01, 0.02],
+    "term_coverage": [0.25, 0.5, 0.75, 1.0],
+    "mean_max_stored": [0.75, 1.5, 2.25, 3.0],
+}
+
+
+def format_threshold(threshold: float) -> str:
+    return f"{threshold:g}".replace(".", "_")
+
+
+def build_arms(gates: list[str], thresholds: list[float],
+               value_thresholds: list[float]) -> list[Arm]:
+    """The standard arm set.
+
+    Counting gates take a document count, the per-term profile gates take a score or a
+    fraction, so the two families sweep over different threshold lists.
+    """
+    arms = [
+        Arm("no-wiki", include_wiki=False),
+        Arm("live-wiki", cache_enabled=False),
+        Arm("indexed-nogate", gate="never"),
+    ]
+    for gate in gates:
+        if gate not in VALUE_GATES:
+            sweep = thresholds
+        else:
+            sweep = value_thresholds or DEFAULT_VALUE_THRESHOLDS[gate]
+        arms += [Arm(f"indexed-{gate}-t{format_threshold(t)}", gate=gate, threshold=t)
+                 for t in sweep]
+    arms += [
+        Arm("indexed-unigrams-only", max_term_tokens=1),
+        Arm("indexed-noscore", gate="from_wiki_only", threshold=1, keep_score=False),
+        Arm("indexed-safe", require_existing_term=True),
+        Arm("never-call", gate="always"),
+    ]
+    return arms
+
+
+def build_stack(arm: Arm, overlay: Path, overlay_pages: int, model):
+    """The production stack (LTR + MMR) over a fresh overlay, instrumented for one arm."""
+    fetcher = CountingWikiFetcher()
+    index = OverlayIndex(overlay, overlay_pages)
+    store = CountingWikiStore(index)
+    ranker = MMRRanker(LTRRanker(
+        index, DummyCompleter(), model,
+        include_wiki=arm.include_wiki, num_wiki_results=3,
+        wiki_fetcher=fetcher, wiki_store=store, wiki_index_path=str(index.local_path),
+    ))
+    return index, fetcher, store, MwmblRankingModel(ranker)
+
+
+def arm_settings(arm: Arm):
+    return override_settings(
+        WIKI_INDEX_CACHE_ENABLED=arm.cache_enabled,
+        WIKI_INDEX_GATE=arm.gate,
+        WIKI_INDEX_GATE_THRESHOLD=arm.threshold,
+        WIKI_INDEX_REQUIRE_EXISTING_TERM=arm.require_existing_term,
+        WIKI_INDEX_MAX_TERM_TOKENS=arm.max_term_tokens,
+        WIKI_INDEX_KEEP_SCORE=arm.keep_score,
+    )
+
+
+def run_arm(arm: Arm, queries: list[str], gold: dict, overlay_pages: int,
+            model, scratch: Path) -> ArmResult:
+    index, fetcher, store, ranking_model = build_stack(
+        arm, scratch / f"overlay-{arm.name}.tinysearch", overlay_pages, model)
+    result = ArmResult(arm=arm, order=list(queries))
+    try:
+        with arm_settings(arm):
+            for i, query in enumerate(queries):
+                calls_before, stored_before = fetcher.calls, store.urls_stored
+                start = time.perf_counter()
+                urls = ranking_model.predict(query)
+                result.duration[query] = time.perf_counter() - start
+
+                top = urls[:NUM_RESULTS_FOR_EVAL]
+                result.ndcg[query] = query_ndcg(urls, gold[query])
+                result.proportion[query] = len(set(top) & gold[query].keys()) / NUM_RESULTS_FOR_EVAL
+                result.wiki_in_top[query] = sum(1 for url in top if "en.wikipedia.org" in url)
+                result.called_wiki[query] = fetcher.calls > calls_before
+                result.stored[query] = store.urls_stored - stored_before
+
+                if (i + 1) % 100 == 0:
+                    print(f"  {arm.name}: {i + 1}/{len(queries)} queries, "
+                          f"{fetcher.calls} wiki calls", flush=True)
+    finally:
+        index.close()
+    return result
+
+
+def run_zipf(arm: Arm, queries: list[str], gold: dict, stream_length: int,
+             overlay_pages: int, model, scratch: Path, seed: int = 42) -> list[dict]:
+    """Replay the queries as a repeat-weighted stream; one record per position.
+
+    This closes the blind spot in the main table. The gold set has no repeats, so *every*
+    gate firing measured there is a term-overlap firing: the index answered with Wikipedia
+    pages that merely look related. A repeat is a completely different case - the stored
+    documents are the very URLs the API returned last time - and production traffic is
+    mostly repeats. Scoring each position and splitting on whether the query has been seen
+    before separates the two, which is the difference between "caching" and "guessing".
+
+    The Zipf weighting is arbitrary (rank-1 exponent over an arbitrary query order), so
+    the absolute repeat rate is a modelling assumption, not a measurement. What the split
+    shows is the *shape*: what a hit costs when it is a real repeat versus when it is not.
+    """
+    rng = np.random.default_rng(seed)
+    weights = 1.0 / (np.arange(1, len(queries) + 1) ** 1.0)
+    weights /= weights.sum()
+    order = list(rng.choice(np.array(queries, dtype=object), stream_length,
+                            replace=True, p=weights))
+
+    index, fetcher, _, ranking_model = build_stack(
+        arm, scratch / f"overlay-zipf-{arm.name}.tinysearch", overlay_pages, model)
+    records = []
+    seen: set[str] = set()
+    try:
+        with arm_settings(arm):
+            for query in order:
+                calls_before = fetcher.calls
+                urls = ranking_model.predict(query)
+                records.append({
+                    "query": query,
+                    "repeat": query in seen,
+                    "called": fetcher.calls > calls_before,
+                    "ndcg": query_ndcg(urls, gold[query]),
+                })
+                seen.add(query)
+    finally:
+        index.close()
+    return records
+
+
+def report_zipf(records_by_arm: dict, baseline_name: str = "live-wiki"):
+    baseline = records_by_arm.get(baseline_name)
+
+    def mean_over(records, predicate):
+        return [r["ndcg"] for r in records if predicate(r)]
+
+    print(f"\n{'arm':<30} {'calls':>13} {'NDCG on repeats':>20} "
+          f"{'NDCG first-seen':>20} {'Δ vs live on repeats':>21}")
+    print("-" * 104)
+    for name, records in records_by_arm.items():
+        calls = sum(1 for r in records if r["called"])
+        repeats = mean_over(records, lambda r: r["repeat"])
+        first = mean_over(records, lambda r: not r["repeat"])
+        if baseline is None or name == baseline_name:
+            delta = "n/a"
+        else:
+            base_repeats = mean_over(baseline, lambda r: r["repeat"])
+            delta = f"{np.mean(repeats) - np.mean(base_repeats):+.4f}"
+        print(f"{name:<30} {calls:>5}/{len(records):<7} {mean_sem(repeats):>20} "
+              f"{mean_sem(first):>20} {delta:>21}")
+
+
+def _second_half(result: ArmResult, values: dict) -> list:
+    """Steady-state slice: the tail of the stream, after the index has warmed up."""
+    tail = result.order[len(result.order) // 2:]
+    return [values[q] for q in tail]
+
+
+def report(results: list[ArmResult], header: str = "",
+           baseline_name: str = "live-wiki"):
+    baseline = next((r for r in results if r.arm.name == baseline_name), None)
+    n = len(results[0].order)
+    if header:
+        print(f"\n{header}")
+
+    print(f"\n{'=' * 118}")
+    print(f"{'arm':<30} {'NDCG@10':>18} {'ΔNDCG':>9} {'proportion':>18} "
+          f"{'wiki@10':>7} {'calls':>12} {'stored':>8}")
+    print(f"{'-' * 118}")
+    for result in results:
+        ndcg = list(result.ndcg.values())
+        delta = (f"{np.mean(ndcg) - np.mean(list(baseline.ndcg.values())):+.4f}"
+                 if baseline else "n/a")
+        print(f"{result.arm.name:<30} {mean_sem(ndcg):>18} {delta:>9} "
+              f"{mean_sem(list(result.proportion.values())):>18} "
+              f"{np.mean(list(result.wiki_in_top.values())):>7.2f} "
+              f"{result.calls:>5}/{n:<6} {sum(result.stored.values()):>8}")
+    print(f"{'=' * 118}")
+
+    print("\nSteady state (second half of the stream, index already warm):")
+    print(f"{'arm':<30} {'NDCG@10':>18} {'calls avoided':>15}")
+    for result in results:
+        tail = result.order[len(result.order) // 2:]
+        avoided = sum(1 for q in tail if not result.called_wiki[q])
+        print(f"{result.arm.name:<30} {mean_sem(_second_half(result, result.ndcg)):>18} "
+              f"{avoided:>6}/{len(tail):<8}")
+
+    if baseline is None:
+        return
+    print("\nOn the queries where the gate fired - the subset the feature is decided on:")
+    print(f"{'arm':<30} {'fired':>13} {'NDCG (arm)':>18} {'NDCG (live-wiki)':>18} {'Δ':>9}")
+    for result in results:
+        fired = result.fired
+        if not fired or result.arm.name == baseline_name or not result.arm.include_wiki:
+            continue
+        arm_ndcg = [result.ndcg[q] for q in fired]
+        base_ndcg = [baseline.ndcg[q] for q in fired]
+        print(f"{result.arm.name:<30} {len(fired):>5}/{n:<7} {mean_sem(arm_ndcg):>18} "
+              f"{mean_sem(base_ndcg):>18} {np.mean(arm_ndcg) - np.mean(base_ndcg):>+9.4f}")
+
+    stored_nothing = [r for r in results if r.arm.cache_enabled and r.arm.include_wiki]
+    if stored_nothing:
+        print("\nFetches that stored nothing (Wikipedia's results did not contain the query's")
+        print("words, so nothing could be filed - these queries can never become hits):")
+        for result in stored_nothing:
+            fetched = [q for q, called in result.called_wiki.items() if called]
+            empty = [q for q in fetched if result.stored[q] == 0]
+            if fetched:
+                print(f"  {result.arm.name:<30} {len(empty):>5}/{len(fetched):<6} "
+                      f"({100 * len(empty) / len(fetched):.1f}% of fetches)")
+
+    print("\nNOTE: wall-clock timings from this harness are not production latency - the "
+          "remote\nindex makes one HTTP call per query term and the wiki fetch is disk-cached. "
+          "Mean\nper-query predict time, for reference only:")
+    for result in results:
+        print(f"  {result.arm.name:<30} {np.mean(list(result.duration.values())):.3f}s")
+
+
+def run():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--fraction", type=float, default=0.05,
+                        help="Fraction of gold queries to sample.")
+    parser.add_argument("--train", action="store_true",
+                        help="Evaluate on the train split instead of test.")
+    parser.add_argument("--arms", nargs="+", default=None,
+                        help="Only run these arms by name (default: the standard set).")
+    parser.add_argument("--gates", nargs="+",
+                        default=list(COUNTING_GATES) + list(VALUE_GATES),
+                        help="Gate definitions to sweep.")
+    parser.add_argument("--thresholds", type=float, nargs="+", default=[1, 2, 3],
+                        help="Counting gates: wiki results needed to skip the call.")
+    parser.add_argument("--value-thresholds", type=float, nargs="+", default=None,
+                        help="Per-term profile gates: score or fraction needed. "
+                             "Defaults to a per-gate sweep, since they are on very "
+                             "different scales.")
+    parser.add_argument("--order", choices=["shuffled", "alpha"], default="shuffled",
+                        help="Query order. Alphabetical clusters shared-prefix queries "
+                             "adjacently and inflates the hit rate; shuffled is the "
+                             "headline number.")
+    parser.add_argument("--overlay-pages", type=int, default=DEFAULT_OVERLAY_PAGES,
+                        help="Pages in the per-arm overlay index.")
+    parser.add_argument("--zipf", type=int, default=0,
+                        help="Also replay a repeat-weighted stream of this many queries "
+                             "and report call counts only (no NDCG).")
+    # Per-process by default: the run deletes its scratch directory when it finishes,
+    # so a second run sharing one would pull the overlay out from under the first.
+    parser.add_argument("--scratch", default=os.environ.get(
+        "WIKI_INDEX_EVAL_SCRATCH", f"/tmp/mwmbl-wiki-index-eval-{os.getpid()}"),
+        help="Where the per-arm overlay indexes are created.")
+    parser.add_argument("--clear-cache", action="store_true",
+                        help="Clear the cached Wikipedia responses before evaluating.")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Keep the per-query INFO logging from the ranker and indexer.")
+    args = parser.parse_args()
+
+    if not args.verbose:
+        # One line per retrieval and per stored page drowns the results table.
+        logging.getLogger("mwmbl").setLevel(logging.WARNING)
+
+    if args.clear_cache:
+        memory.clear(warn=False)
+
+    path = RANKINGS_DATASET_TRAIN_PATH if args.train else RANKINGS_DATASET_TEST_PATH
+    print("Evaluating against dataset", path)
+    dataset = pd.read_csv(path)
+
+    all_queries = dataset["query"].unique()
+    rng = np.random.default_rng(42)  # same seed/sampling as evaluate.evaluate
+    if args.fraction < 1.0:
+        sampled = set(rng.choice(all_queries, int(args.fraction * len(all_queries)),
+                                 replace=False))
+    else:
+        sampled = set(all_queries)
+
+    gold = {query: gold_scores_for(rankings)
+            for query, rankings in dataset.groupby("query") if query in sampled}
+    queries = sorted(gold)
+    if args.order == "shuffled":
+        np.random.default_rng(42).shuffle(queries)
+    print(f"Num queries {len(queries)} ({args.order} order)")
+
+    arms = build_arms(args.gates, args.thresholds, args.value_thresholds)
+    if args.arms:
+        by_name = {arm.name: arm for arm in arms}
+        unknown = [name for name in args.arms if name not in by_name]
+        if unknown:
+            raise SystemExit(f"Unknown arm(s) {unknown}. Available: {sorted(by_name)}")
+        arms = [by_name[name] for name in args.arms]
+
+    model = RustXGBPipeline.from_model_path(str(RUST_MODEL_PATH))
+    scratch = Path(args.scratch)
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    try:
+        for arm in arms:
+            print(f"\n--- {arm.name} (gate={arm.gate} threshold={arm.threshold} "
+                  f"cache={arm.cache_enabled} wiki={arm.include_wiki}) ---", flush=True)
+            results.append(run_arm(arm, queries, gold, args.overlay_pages, model, scratch))
+
+        report(results, header=f"{len(queries)} queries, {args.order} order, "
+                              f"{'train' if args.train else 'test'} split, "
+                              f"fraction={args.fraction}, overlay_pages={args.overlay_pages}")
+
+        if args.zipf:
+            print(f"\nRepeat-weighted stream: {args.zipf} positions, Zipf over the same "
+                  f"{len(queries)} queries.\nThe gold set has no repeats, so the table above "
+                  "measures only term-overlap hits.\nHere a hit can also be a genuine repeat, "
+                  "where the index holds the very URLs the\nAPI returned - which is what "
+                  "production traffic mostly consists of.")
+            records_by_arm = {}
+            for arm in arms:
+                if not arm.include_wiki:
+                    continue
+                records_by_arm[arm.name] = run_zipf(
+                    arm, queries, gold, args.zipf, args.overlay_pages, model, scratch)
+            report_zipf(records_by_arm)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/mwmbl/rankeval/evaluation/simulate_wiki_gate_firing.py
+++ b/mwmbl/rankeval/evaluation/simulate_wiki_gate_firing.py
@@ -1,0 +1,176 @@
+"""How often would a wiki-index gate fire, and on the right query?
+
+evaluate_wiki_index answers what a gate *costs*, and pays for the answer: every query is
+a full pass through the remote production index and the LTR model, so a run is limited to
+a sample of a few hundred to a couple of thousand queries. This asks the cheaper question -
+how often does a gate fire, and is the firing a genuine repeat or a different query
+riding on stored documents - over every query whose Wikipedia response is already on disk,
+in about a minute and with no network.
+
+That works because the gate only counts documents a previous call *stored*
+(``wiki_documents_by_term(stored_only=True)`` filters to WIKI_STATES), so the crawled half
+of production contributes nothing to it and a fresh local index holding exactly what this
+run stored is a faithful simulation of the gate's input. NDCG is not: what a firing costs
+depends on the whole candidate pool, so read this alongside evaluate_wiki_index, never
+instead of it.
+
+The split that matters is first-seen against repeat. A repeat firing serves the very URLs
+the API returned for this query last time; a first-seen firing serves some other query's
+documents, and every gate this harness has measured paid around -0.19 NDCG for those.
+
+```bash
+DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
+    uv run python -m mwmbl.rankeval.evaluation.simulate_wiki_gate_firing
+```
+"""
+import json
+import os
+import re
+import sys
+from argparse import ArgumentParser
+from collections import Counter
+from pathlib import Path
+
+import django
+import joblib
+import numpy as np
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mwmbl.settings_dev")
+django.setup()
+
+from mwmbl.indexer.index_batches import index_results_against_query  # noqa: E402
+from mwmbl.rankeval.paths import DATA_DIR  # noqa: E402
+from mwmbl.tinysearchengine.indexer import Document, DocumentState, TinyIndex  # noqa: E402
+from mwmbl.tinysearchengine.wiki_index_cache import (  # noqa: E402
+    DENOMINATORS, VALUE_GATES, have_enough_wiki_results, query_terms,
+)
+from mwmbl.tokenizer import tokenize  # noqa: E402
+
+
+# joblib keys a cached function's directory on the defining module and file path, and
+# evaluate_wiki_index is run as __main__, so the name depends on where the checkout lives.
+# Glob for it rather than reconstructing it.
+WIKI_RESPONSE_CACHE_ROOT = DATA_DIR / "wiki-index-eval-cache" / "joblib"
+
+
+def response_cache_dir() -> Path | None:
+    """evaluate_wiki_index._fetch_wiki's cache - responses that harness already paid for."""
+    return next(WIKI_RESPONSE_CACHE_ROOT.glob("*evaluate_wiki_index/_fetch_wiki"), None)
+
+# One arm is a (gate, score_terms) pair. The two are not independent: bigram_coverage and
+# term_coverage are the same condition under "all" (see query_bigrams), and term_coverage
+# cannot reach full coverage at all under "specific", so only the 2x2 says anything.
+ARMS = [
+    ("terms/all           (today's default)", "term_coverage", "all"),
+    ("terms/specific      (the gate dies)", "term_coverage", "specific"),
+    ("bigrams/all         (denominator alone)", "bigram_coverage", "all"),
+    ("bigrams/specific    (both halves)", "bigram_coverage", "specific"),
+]
+
+
+def cached_responses() -> dict[str, list[dict]]:
+    """Every query whose Wikipedia response evaluate_wiki_index has already fetched."""
+    cache = response_cache_dir()
+    if cache is None:
+        raise SystemExit(
+            f"No cached Wikipedia responses under {WIKI_RESPONSE_CACHE_ROOT}.\n"
+            "Run evaluate_wiki_index first - this reads the responses it cached.")
+    responses = {}
+    for call in sorted(cache.iterdir()):
+        metadata, output = call / "metadata.json", call / "output.pkl"
+        if not (metadata.exists() and output.exists()):
+            continue
+        query = json.loads(metadata.read_text())["input_args"]["query"]
+        responses[query[1:-1]] = joblib.load(output)  # the arg is repr()d
+    return responses
+
+
+def to_documents(rows: list[dict]) -> list[Document]:
+    return [Document(r["title"], r["url"], r["extract"], r["score"], r["term"],
+                     state=DocumentState.FROM_WIKI) for r in rows]
+
+
+def retrieve(index: TinyIndex, query: str) -> list[Document]:
+    return [document for term in query_terms(query) for document in index.retrieve(term)]
+
+
+def zipf_stream(queries: list[str], length: int, seed: int) -> list[str]:
+    """The same repeat-weighted replay evaluate_wiki_index.run_zipf uses."""
+    rng = np.random.default_rng(seed)
+    weights = 1.0 / np.arange(1, len(queries) + 1)
+    return list(rng.choice(np.array(queries, dtype=object), length, replace=True,
+                           p=weights / weights.sum()))
+
+
+def run_arm(name: str, gate: str, score_terms: str, stream: list[str],
+            responses: dict[str, list[dict]], threshold: float, pages: int,
+            scratch: Path) -> tuple[Counter, list[tuple[int, str]]]:
+    path = scratch / f"overlay-{re.sub('[^a-z0-9]+', '-', name.lower()).strip('-')}.tinysearch"
+    path.unlink(missing_ok=True)
+    with TinyIndex.create(Document, str(path), num_pages=pages, page_size=4096):
+        pass
+
+    counts, cross_query, seen = Counter(), [], set()
+    try:
+        with TinyIndex(Document, str(path), 'r') as index:
+            for query in stream:
+                fired = have_enough_wiki_results(query, retrieve(index, query),
+                                                 rank=None, gate=gate, threshold=threshold)
+                repeat = query in seen
+                seen.add(query)
+                counts["fired" if fired else "called", "repeat" if repeat else "first"] += 1
+                if fired and not repeat:
+                    cross_query.append((len(tokenize(query)), query))
+                if not fired:
+                    # A miss is what writes: same call, same write path, same settings.
+                    index_results_against_query(
+                        to_documents(responses[query]), query, str(path),
+                        max_term_tokens=2, state=DocumentState.FROM_WIKI,
+                        score_terms=score_terms)
+    finally:
+        path.unlink(missing_ok=True)
+    return counts, cross_query
+
+
+def run():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--stream", type=int, default=3000,
+                        help="Positions in the repeat-weighted replay.")
+    parser.add_argument("--threshold", type=float, default=1.0,
+                        help="Coverage needed to skip the call. Below 1.0 a gate fires on "
+                             "a partially covered query, which is the case that costs.")
+    parser.add_argument("--pages", type=int, default=65536,
+                        help="Pages in the simulated index. Enough that page-full "
+                             "truncation does not confound the count.")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--scratch", default=f"/tmp/mwmbl-wiki-gate-sim-{os.getpid()}")
+    args = parser.parse_args()
+
+    responses = cached_responses()
+    queries = sorted(responses)
+    stream = zipf_stream(queries, args.stream, args.seed)
+    repeats = sum(1 for i, query in enumerate(stream) if query in set(stream[:i]))
+    print(f"{len(queries)} cached queries; {len(stream)} positions, {repeats} repeats; "
+          f"threshold {args.threshold:g}\n")
+
+    scratch = Path(args.scratch)
+    scratch.mkdir(parents=True, exist_ok=True)
+    print(f"{'denominator / scores':40} {'fired':>6} {'repeat':>7} {'first-seen':>11} "
+          f"{'repeats caught':>15}")
+    for name, gate, score_terms in ARMS:
+        assert gate in VALUE_GATES and VALUE_GATES[gate][2] in DENOMINATORS
+        counts, cross_query = run_arm(name, gate, score_terms, stream, responses,
+                                      args.threshold, args.pages, scratch)
+        on_repeat, on_first = counts["fired", "repeat"], counts["fired", "first"]
+        print(f"{name:40} {on_repeat + on_first:6d} {on_repeat:7d} {on_first:11d} "
+              f"{on_repeat / repeats:14.1%}", flush=True)
+        if cross_query:
+            by_length = sorted(Counter(n for n, _ in cross_query).items())
+            print(f"{'':40} first-seen firings by query length: {by_length}")
+            for length, query in sorted(cross_query)[:5]:
+                print(f"{'':44} {length}-token {query!r}")
+    scratch.rmdir()
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -383,6 +383,10 @@ WIKI_INDEX_MAX_TERM_TOKENS = 2
 # Wikipedia gave a document for one whole query is what the model reads for every other
 # query sharing a word with it. See index_batches._takes_score for the options
 # (none / all / specific / exact).
+# "specific" only works with WIKI_INDEX_GATE="bigram_coverage". It leaves unigram copies
+# unscored, and term_coverage counts an unscored term as uncovered, so the two together
+# silently stop the gate firing for every multi-token query - measured at 690 firings ->
+# 227, all of them one-token queries.
 WIKI_INDEX_SCORE_TERMS = os.environ.get("WIKI_INDEX_SCORE_TERMS", "all")
 # Blend a score being written over the previous one for the same (term, url) rather than
 # overwriting it: alpha * new + (1 - alpha) * previous. 1.0 overwrites, which is what the

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -377,10 +377,17 @@ WIKI_INDEX_GATE_TOP_N = 10
 # itself; the token cap means the query as a whole is never a term.
 WIKI_INDEX_MAX_TERM_TOKENS = 2
 # A Wikipedia result's score is its rank in Wikipedia's own results, and the LTR model
-# reads score as a feature. Without this a result served from the index scores 0.0 where
-# the identical result fetched live scores 3/2/1, so the cached copy is handicapped
-# against the thing it is standing in for.
-WIKI_INDEX_KEEP_SCORE = os.environ.get("WIKI_INDEX_KEEP_SCORE", "true").lower() != "false"
+# reads score as a feature. Store no score and a result served from the index scores 0.0
+# where the identical result fetched live scores 3/2/1, so the stored copy is handicapped
+# against the thing it is standing in for. Store it under every term and the rank
+# Wikipedia gave a document for one whole query is what the model reads for every other
+# query sharing a word with it. See index_batches._takes_score for the options
+# (none / all / specific / exact).
+WIKI_INDEX_SCORE_TERMS = os.environ.get("WIKI_INDEX_SCORE_TERMS", "all")
+# Blend a score being written over the previous one for the same (term, url) rather than
+# overwriting it: alpha * new + (1 - alpha) * previous. 1.0 overwrites, which is what the
+# index has always done.
+WIKI_INDEX_SCORE_EMA_ALPHA = float(os.environ.get("WIKI_INDEX_SCORE_EMA_ALPHA", "1.0"))
 # Stricter still: only file a result under a term the index already has documents for, so
 # nothing is ever written that the corpus did not already contain.
 WIKI_INDEX_REQUIRE_EXISTING_TERM = os.environ.get(

--- a/mwmbl/settings_common.py
+++ b/mwmbl/settings_common.py
@@ -336,3 +336,52 @@ BLACKLIST_PURGE_BATCH_SIZE = 1000          # documents removed from the index pe
 # through submissions in batches, so the delay collapses a batch into one rebuild rather
 # than one per approval - see mwmbl.signals.
 BLACKLIST_SNAPSHOT_APPROVAL_DELAY_SECONDS = 600
+
+# Wikipedia results in the index, instead of the filesystem HTTP cache.
+#
+# get_wiki_results() used to cache through mwmbl.utils.request_cache, a requests-cache
+# *filesystem* session rooted at REQUEST_CACHE_PATH - the same volume as the index - with
+# no LRU, no size cap and nothing ever calling delete(expired=True), so it grew without
+# bound; and because the stored JSON holds the whole request, it wrote the raw user query
+# to disk for ten weeks. It also never removed the call: a miss was still a blocking HTTP
+# round trip on the search path.
+#
+# Instead, results found by a search are written into the index under the query's unigrams
+# and bigrams, and a later search skips the API call altogether when the index already
+# returned enough Wikipedia results. Off by default so this can be turned on per
+# environment; results and the reasoning are in rankeval/WIKI_INDEX_CACHE_FINDINGS.md.
+WIKI_INDEX_CACHE_ENABLED = os.environ.get("WIKI_INDEX_CACHE_ENABLED", "false").lower() == "true"
+
+# What "enough Wikipedia results already" means. See wiki_index_cache.GATES.
+#   from_wiki_only - only documents a previous API call stored, ranked, in the top N
+#   ranked_top_n   - rank the index-only candidates, count any wiki URL in the top N
+#   raw_candidates - count any wiki URL among the unranked index candidates
+#   term_coverage / mean_max_ltr / min_max_ltr / max_max_ltr / mean_max_stored
+#                  - reduce a per-term profile of how well the index covers each query term
+# The threshold is a float: a document count for the counting gates, a score or a fraction
+# for the rest.
+#
+# The default is the rule the evaluation picked: skip the call only when *every* one of the
+# query's unigrams and bigrams already has a stored Wikipedia result. Counting documents
+# cannot tell "three good wiki results" from "three wiki pages that mention this word", and
+# every count-based threshold lost NDCG; demanding full term coverage was the cheapest rule
+# with no measurable loss, at ~40% of calls avoided on repeat-weighted traffic. It also
+# needs no ranking and no model call, so the gate itself is nearly free.
+# See rankeval/WIKI_INDEX_CACHE_FINDINGS.md.
+WIKI_INDEX_GATE = os.environ.get("WIKI_INDEX_GATE", "term_coverage")
+WIKI_INDEX_GATE_THRESHOLD = float(os.environ.get("WIKI_INDEX_GATE_THRESHOLD", "1.0"))
+WIKI_INDEX_GATE_TOP_N = 10
+
+# Privacy limits on what a stored result may be filed under. A term is only written when
+# the document contains every one of its words, so the term is derivable from the document
+# itself; the token cap means the query as a whole is never a term.
+WIKI_INDEX_MAX_TERM_TOKENS = 2
+# A Wikipedia result's score is its rank in Wikipedia's own results, and the LTR model
+# reads score as a feature. Without this a result served from the index scores 0.0 where
+# the identical result fetched live scores 3/2/1, so the cached copy is handicapped
+# against the thing it is standing in for.
+WIKI_INDEX_KEEP_SCORE = os.environ.get("WIKI_INDEX_KEEP_SCORE", "true").lower() != "false"
+# Stricter still: only file a result under a term the index already has documents for, so
+# nothing is ever written that the corpus did not already contain.
+WIKI_INDEX_REQUIRE_EXISTING_TERM = os.environ.get(
+    "WIKI_INDEX_REQUIRE_EXISTING_TERM", "false").lower() == "true"

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -183,12 +183,13 @@ def _trim_items_to_page(compressor: ZstdCompressor, page_size: int, items:list[T
 
 
 def _get_page_data(page_size: int, items: list[T]):
+    """The padded page bytes, and how many of `items` actually fit on it."""
     compressor = ZstdCompressor()
     num_fitting, serialised_data = _trim_items_to_page(compressor, page_size, items)
 
     compressed_data = compressor.compress(json.dumps(items[:num_fitting]).encode('utf8'))
     assert len(compressed_data) <= page_size, "The data shouldn't get bigger"
-    return _pad_to_page_size(compressed_data, page_size)
+    return _pad_to_page_size(compressed_data, page_size), num_fitting
 
 
 def _pad_to_page_size(data: bytes, page_size: int):
@@ -198,6 +199,24 @@ def _pad_to_page_size(data: bytes, page_size: int):
     padding = b'\x00' * (page_size - page_length)
     page_data = data + padding
     return page_data
+
+
+class _OpenPage(Generic[T]):
+    """One page of the index, open for a read-modify-write. See TinyIndex.page."""
+
+    def __init__(self, index: 'TinyIndex[T]', page_index: int):
+        self._index = index
+        self._page_index = page_index
+        self.documents: List[T] = index.get_page(page_index)
+
+    def store(self, values: List[T]) -> int:
+        """Write these values to the page, returning how many of them actually fit.
+
+        A page holds a fixed number of bytes and the tail that does not fit is dropped, so
+        pass them best-first. It is store() rather than an assignment to `documents`
+        precisely because what you pass is not necessarily what ends up stored.
+        """
+        return self._index.store_in_page(self._page_index, values)
 
 
 class TinyIndex(Generic[T]):
@@ -237,7 +256,13 @@ class TinyIndex(Generic[T]):
     def retrieve(self, key: str) -> List[T]:
         index = self.get_key_page_index(key)
         logger.debug(f"Retrieving index {index}")
-        page = self.get_page(index)
+        try:
+            page = self.get_page(index)
+        except PageError:
+            # One unreadable page costs this query the results for one term, and the next
+            # read of it will very likely succeed. Writers do not swallow this.
+            logger.exception("Could not read index page %d", index)
+            return []
         return [item for item in page if item.term is None or item.term == key]
 
     def get_key_page_index(self, key) -> int:
@@ -257,7 +282,7 @@ class TinyIndex(Generic[T]):
         the wiki index cache writes from the request path, on a large fraction of searches
         and from every gunicorn worker, that stops being hypothetical.
 
-        Private: every read-modify-write on the index goes through update_page, so no
+        Private: every read-modify-write on the index goes through page(), so no
         caller has to know this exists. Readers deliberately do not take it - search would
         pay a syscall per retrieve on the hot path, and a torn read costs a reader only one
         query's results for one term, which the next read fixes.
@@ -315,56 +340,66 @@ class TinyIndex(Generic[T]):
         return items
 
     def _get_page_tuples(self, i):
+        """The raw tuples on page i. Raises PageError if the page will not decode.
+
+        It deliberately does not fall back to an empty page. A page that fails to
+        decompress is either corrupt or caught mid-write, and treating that as "no
+        documents here" is how a writer comes to merge onto nothing and store its result
+        over everything that was on the page. Readers that would rather have no results
+        than an error catch this - see retrieve.
+        """
         page_data = self.mmap[i * self.page_size + METADATA_SIZE:(i + 1) * self.page_size + METADATA_SIZE]
         decompressor = ZstdDecompressor()
         try:
             decompressed_data = decompressor.decompress(page_data)
         except ZstdError as e:
-            logger.exception(f"Error decompressing page {i}: {e}")
-            return []
+            raise PageError(f"Could not decompress page {i}: {e}") from e
         return json.loads(decompressed_data.decode('utf8'))
 
-    def store_in_page(self, page_index: int, values: list[T]):
-        """Overwrite a page. To change a page based on what it already holds, use
-        update_page instead, which does the read and the write under one lock."""
+    def store_in_page(self, page_index: int, values: list[T]) -> int:
+        """Overwrite a page, returning how many of `values` actually fit on it.
+
+        A page holds a fixed number of bytes and the tail that does not fit is dropped, so
+        pass the values best-first. To change a page based on what it already holds, use
+        page() instead, which does the read and the write under one lock."""
         value_tuples = [value.as_tuple() for value in values]
-        self._write_page(value_tuples, page_index)
+        return self._write_page(value_tuples, page_index)
 
-    def update_page(self, i: int, merge: Callable[[List[T]], Optional[List[T]]]) -> List[T]:
-        """Read page i, hand its contents to `merge`, and store what comes back.
-
-        Changing a page is read -> merge -> write, and the three have to be atomic together.
-        _write_page copies ~4 KB into the mmap; a reader catching it half-written gets a
-        ZstdError, which _get_page_tuples turns into an empty page - so a writer that reads
-        empty, merges and stores wipes out everything else on that page. Permanent loss in a
-        400 GB index, not a transient blip.
-
-        Locking lives here rather than in the callers because "hold a lock across your read
-        and your write" is the kind of rule that is quietly forgotten. There is one way to
-        change a page and it is already correct.
-
-        `merge` returning None means nothing needs writing, which avoids re-storing a page
-        that has not changed. Returns whatever was stored, or the page as it was found.
-        """
-        with self._locked_page(i):
-            existing = self.get_page(i)
-            merged = merge(existing)
-            if merged is None:
-                return existing
-            self.store_in_page(i, merged)
-            return merged
-
-    def _write_page(self, data, i: int):
+    def _write_page(self, data, i: int) -> int:
         """
         Serialise the data using JSON, compress it and store it at index i.
-        If the data is too big, it will store the first items in the list and discard the rest.
+        If the data is too big, it will store the first items in the list and discard the
+        rest; the number actually stored is returned.
         """
         if self.mode != 'w':
             raise UnsupportedOperation("The file is open in read mode, you cannot write")
 
-        page_data = _get_page_data(self.page_size, data)
+        page_data, num_stored = _get_page_data(self.page_size, data)
         logger.debug(f"Got page data of length {len(page_data)}")
         self.mmap[i * self.page_size + METADATA_SIZE:(i+1) * self.page_size + METADATA_SIZE] = page_data
+        return num_stored
+
+    @contextmanager
+    def page(self, i: int):
+        """Open page i for a read-modify-write, holding its lock throughout.
+
+        Changing a page is read -> merge -> write, and the three have to be atomic
+        together. _write_page copies ~4 KB into the mmap; a reader catching it half-written
+        gets a page that will not decompress, and a writer that took that for an empty page
+        would store its result over everything else there.
+
+        Locking lives here rather than in the callers because "hold a lock across your read
+        and your write" is the kind of rule that gets quietly forgotten. There is one way to
+        change a page and it is already correct::
+
+            with index.page(page_index) as page:
+                page.store(merge(page.documents))
+
+        Not calling store() writes nothing, which is what a caller that finds nothing to
+        change should do.
+        """
+        with self._locked_page(i):
+            yield _OpenPage(self, i)
 
     @staticmethod
     def create(item_factory: Callable[..., T], index_path: str, num_pages: int, page_size: int):
@@ -375,7 +410,7 @@ class TinyIndex(Generic[T]):
         metadata_bytes = metadata.to_bytes()
         metadata_padded = _pad_to_page_size(metadata_bytes, METADATA_SIZE)
 
-        page_bytes = _get_page_data(page_size, [])
+        page_bytes, _ = _get_page_data(page_size, [])
 
         with open(index_path, 'wb') as index_file:
             index_file.write(metadata_padded)

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -245,7 +245,7 @@ class TinyIndex(Generic[T]):
         return key_hash % self.num_pages
 
     @contextmanager
-    def locked_page(self, i: int):
+    def _locked_page(self, i: int):
         """Hold an exclusive lock on page i for a read-modify-write.
 
         Storing a page is read -> merge -> write, with no atomicity of its own. Two writers
@@ -257,9 +257,10 @@ class TinyIndex(Generic[T]):
         the wiki index cache writes from the request path, on a large fraction of searches
         and from every gunicorn worker, that stops being hypothetical.
 
-        Readers deliberately do not take this: search would pay a syscall per retrieve on
-        the hot path, and a torn read costs a reader only one query's results for one term,
-        which the next read fixes.
+        Private: every read-modify-write on the index goes through update_page, so no
+        caller has to know this exists. Readers deliberately do not take it - search would
+        pay a syscall per retrieve on the hot path, and a torn read costs a reader only one
+        query's results for one term, which the next read fixes.
 
         If the kernel or filesystem will not do this kind of lock, carry on without one and
         say so once. Every indexing path here - batch indexing, curation, POST
@@ -324,8 +325,34 @@ class TinyIndex(Generic[T]):
         return json.loads(decompressed_data.decode('utf8'))
 
     def store_in_page(self, page_index: int, values: list[T]):
+        """Overwrite a page. To change a page based on what it already holds, use
+        update_page instead, which does the read and the write under one lock."""
         value_tuples = [value.as_tuple() for value in values]
         self._write_page(value_tuples, page_index)
+
+    def update_page(self, i: int, merge: Callable[[List[T]], Optional[List[T]]]) -> List[T]:
+        """Read page i, hand its contents to `merge`, and store what comes back.
+
+        Changing a page is read -> merge -> write, and the three have to be atomic together.
+        _write_page copies ~4 KB into the mmap; a reader catching it half-written gets a
+        ZstdError, which _get_page_tuples turns into an empty page - so a writer that reads
+        empty, merges and stores wipes out everything else on that page. Permanent loss in a
+        400 GB index, not a transient blip.
+
+        Locking lives here rather than in the callers because "hold a lock across your read
+        and your write" is the kind of rule that is quietly forgotten. There is one way to
+        change a page and it is already correct.
+
+        `merge` returning None means nothing needs writing, which avoids re-storing a page
+        that has not changed. Returns whatever was stored, or the page as it was found.
+        """
+        with self._locked_page(i):
+            existing = self.get_page(i)
+            merged = merge(existing)
+            if merged is None:
+                return existing
+            self.store_in_page(i, merged)
+            return merged
 
     def _write_page(self, data, i: int):
         """

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -1,6 +1,7 @@
 import fcntl
 import json
 import os
+import struct
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict, field
 from enum import IntEnum
@@ -20,6 +21,27 @@ PAGE_SIZE = 4096
 
 
 logger = getLogger(__name__)
+
+
+# Open File Description locks (Linux 3.15+). Byte-range like POSIX record locks, but owned
+# by the open file description like flock - which is the property that matters here.
+# Ordinary fcntl/lockf record locks are owned by the *process* and are dropped as soon as
+# any fd on the file is closed, and index_results_against_query opens and closes a read
+# handle on the index on every store, so in a threaded worker a plain lockf would be
+# released out from under whoever held it. Verified: with lockf, closing an unrelated fd
+# lets another process take the "held" lock; with OFD locks it does not.
+F_OFD_SETLKW = 38
+# struct flock { short l_type; short l_whence; off_t l_start; off_t l_len; pid_t l_pid; }
+# Padded to the native 32 bytes so nothing past our buffer is read. l_pid must be 0 for OFD.
+_FLOCK_STRUCT = "hhqqi4x"
+
+# Set False the first time locking turns out to be unsupported here - see locked_page.
+_page_locking_supported = True
+
+
+def _set_page_lock(fileno: int, lock_type: int, start: int, length: int):
+    fcntl.fcntl(fileno, F_OFD_SETLKW,
+                struct.pack(_FLOCK_STRUCT, lock_type, os.SEEK_SET, start, length, 0))
 
 
 class DocumentState(IntEnum):
@@ -235,20 +257,42 @@ class TinyIndex(Generic[T]):
         the wiki index cache writes from the request path, on a large fraction of searches
         and from every gunicorn worker, that stops being hypothetical.
 
-        A POSIX record lock over just this page's bytes serialises writers of the same page
-        and nothing else. Readers deliberately do not take it: search would pay a syscall
-        per retrieve on the hot path, and a torn read costs a reader only one query's
-        results for one term, which the next read fixes.
+        Readers deliberately do not take this: search would pay a syscall per retrieve on
+        the hot path, and a torn read costs a reader only one query's results for one term,
+        which the next read fixes.
+
+        If the kernel or filesystem will not do this kind of lock, carry on without one and
+        say so once. Every indexing path here - batch indexing, curation, POST
+        /crawler/results, copy_index, purge - ran with no lock at all before this existed,
+        so turning an environment's lack of support into a hard failure of all of them
+        would be a much worse regression than the race it is guarding.
         """
+        global _page_locking_supported
         if self.mode != 'w':
             raise UnsupportedOperation("The file is open in read mode, you cannot lock a page")
+
         start = i * self.page_size + METADATA_SIZE
         fileno = self.index_file.fileno()
-        fcntl.lockf(fileno, fcntl.LOCK_EX, self.page_size, start, os.SEEK_SET)
+        locked = False
+        if _page_locking_supported:
+            try:
+                _set_page_lock(fileno, fcntl.F_WRLCK, start, self.page_size)
+                locked = True
+            except OSError as e:
+                _page_locking_supported = False
+                logger.warning(
+                    "Index page locking is not available here (%s); index writes will race "
+                    "as they did before it was added. Concurrent writers to one page can "
+                    "lose documents.", e)
         try:
             yield
         finally:
-            fcntl.lockf(fileno, fcntl.LOCK_UN, self.page_size, start, os.SEEK_SET)
+            if locked:
+                try:
+                    _set_page_lock(fileno, fcntl.F_UNLCK, start, self.page_size)
+                except OSError:
+                    # Dropped on close anyway; failing here would mask the caller's own error.
+                    logger.warning("Could not release the lock on index page %d", i)
 
     def get_page(self, i) -> list[T]:
         """

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -1,5 +1,7 @@
+import fcntl
 import json
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass, asdict, field
 from enum import IntEnum
 from io import UnsupportedOperation
@@ -219,6 +221,34 @@ class TinyIndex(Generic[T]):
     def get_key_page_index(self, key) -> int:
         key_hash = mmh3.hash(key, signed=False)
         return key_hash % self.num_pages
+
+    @contextmanager
+    def locked_page(self, i: int):
+        """Hold an exclusive lock on page i for a read-modify-write.
+
+        Storing a page is read -> merge -> write, with no atomicity of its own. Two writers
+        on the same page lose one writer's documents, which for a cache is tolerable. The
+        serious case is a *torn* read: _write_page copies ~4 KB into the mmap, and a reader
+        that catches it half-written gets a ZstdError, which _get_page_tuples turns into an
+        empty page. A writer that reads empty then merges and stores wipes out everything
+        else on that page - permanent loss in a 400 GB index, not a transient blip. Since
+        the wiki index cache writes from the request path, on a large fraction of searches
+        and from every gunicorn worker, that stops being hypothetical.
+
+        A POSIX record lock over just this page's bytes serialises writers of the same page
+        and nothing else. Readers deliberately do not take it: search would pay a syscall
+        per retrieve on the hot path, and a torn read costs a reader only one query's
+        results for one term, which the next read fixes.
+        """
+        if self.mode != 'w':
+            raise UnsupportedOperation("The file is open in read mode, you cannot lock a page")
+        start = i * self.page_size + METADATA_SIZE
+        fileno = self.index_file.fileno()
+        fcntl.lockf(fileno, fcntl.LOCK_EX, self.page_size, start, os.SEEK_SET)
+        try:
+            yield
+        finally:
+            fcntl.lockf(fileno, fcntl.LOCK_UN, self.page_size, start, os.SEEK_SET)
 
     def get_page(self, i) -> list[T]:
         """

--- a/mwmbl/tinysearchengine/ltr_rank.py
+++ b/mwmbl/tinysearchengine/ltr_rank.py
@@ -5,12 +5,15 @@ LTRRanker accepts any model with a sklearn-compatible predict(DataFrame) interfa
 including both the Python sklearn pipeline and the Rust RustXGBPipeline.
 """
 import numpy as np
+from django.conf import settings
 from pandas import DataFrame
 from sklearn.base import BaseEstimator
 
 from mwmbl.tinysearchengine.completer import Completer
 from mwmbl.tinysearchengine.indexer import Document, TinyIndex
 from mwmbl.tinysearchengine.rank import Ranker, get_wiki_results
+from mwmbl.tinysearchengine.wiki_index_cache import have_enough_wiki_results, store_wiki_results
+from mwmbl.tokenizer import tokenize
 
 
 class LTRRanker(Ranker):
@@ -38,6 +41,13 @@ class LTRRanker(Ranker):
         Whether to include Wikipedia results via external search.
     num_wiki_results : int
         Maximum number of Wikipedia results to include.
+    wiki_fetcher : callable(query, num_results) -> list[Document]
+        How Wikipedia is queried. Injectable so an evaluation can count and cache the
+        calls a policy makes without actually making them repeatedly.
+    wiki_store : callable(query, documents, index_path) -> int
+        How fetched results are written back into the index.
+    wiki_index_path : str or None
+        Index to write results into. None means the configured one.
     """
 
     def __init__(
@@ -47,11 +57,17 @@ class LTRRanker(Ranker):
         model,
         include_wiki: bool = True,
         num_wiki_results: int = 5,
+        wiki_fetcher=None,
+        wiki_store=None,
+        wiki_index_path=None,
     ):
         super().__init__(tiny_index, completer)
         self.model = model
         self.include_wiki = include_wiki
         self.num_wiki_results = num_wiki_results
+        self.wiki_fetcher = wiki_fetcher if wiki_fetcher is not None else get_wiki_results
+        self.wiki_store = wiki_store if wiki_store is not None else store_wiki_results
+        self.wiki_index_path = wiki_index_path
 
     def order_results(self, terms: list[str], results: list[Document], is_complete: bool) -> list[Document]:
         if len(results) == 0:
@@ -78,10 +94,32 @@ class LTRRanker(Ranker):
         indices = np.argsort(filtered_predictions)[::-1]
         return filtered_pages[indices].tolist()
 
-    def external_search(self, query: str) -> list[Document]:
-        if self.include_wiki:
-            return get_wiki_results(query, self.num_wiki_results)
-        return []
+    def external_search(self, query: str, index_results: list[Document]) -> list[Document]:
+        """Wikipedia results, fetched live only when the index has not already got them.
+
+        With WIKI_INDEX_CACHE_ENABLED off this is the historical behaviour: one API call
+        per search. With it on, a fetch also writes its results into the index under the
+        query terms they are allowed to take, so a later matching query is answered from
+        the index and makes no call at all - see mwmbl.tinysearchengine.wiki_index_cache.
+        """
+        if not self.include_wiki:
+            return []
+
+        if not settings.WIKI_INDEX_CACHE_ENABLED:
+            return self.wiki_fetcher(query, self.num_wiki_results)
+
+        def rank(documents: list[Document]) -> list[Document]:
+            return self.order_results(tokenize(query), documents, query.endswith(' '))
+
+        def score(documents: list[Document]) -> list[float]:
+            return score_documents(self.model, query, documents)
+
+        if have_enough_wiki_results(query, index_results, rank, score):
+            return []
+
+        results = self.wiki_fetcher(query, self.num_wiki_results)
+        self.wiki_store(query, results, self.wiki_index_path)
+        return results
 
 
 def score_documents(model, query: str, documents: list[Document]) -> list[float]:

--- a/mwmbl/tinysearchengine/rank.py
+++ b/mwmbl/tinysearchengine/rank.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import numpy as np
+import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter, Retry
 from requests.exceptions import RetryError
@@ -51,7 +52,11 @@ def score_result(terms: list[str], result: Document, is_complete: bool):
     match_score = (4 * features['match_score_title'] + features['match_score_extract'] + 2 * features[
         'match_score_domain'] + 2 * features['match_score_domain_tokenized'] + features['match_score_path'])
 
-    if features[f'match_terms'] <= len(terms) / 2 and result.state is None:
+    # A curated document is exempt from the minimum-term-match rule: a curator put it
+    # there deliberately. FROM_WIKI is not curation - it is crawled-equivalent content
+    # that the wiki index cache stores like any other document - so it gets no exemption,
+    # either at query time or in sort_documents' write-time page ordering.
+    if features[f'match_terms'] <= len(terms) / 2 and result.state in (None, DocumentState.FROM_WIKI):
         return 0.0
 
     if match_score > MATCH_SCORE_THRESHOLD:
@@ -325,7 +330,12 @@ class Ranker:
         # Check for curation
         curation_term = " ".join(terms)
         curation_items = self.tiny_index.retrieve(curation_term)
-        curated_items = [d for d in curation_items if d.state is not None
+        # FROM_WIKI is the one non-None state nobody curated: it is stamped on Wikipedia
+        # results the wiki index cache stores automatically, which for a one- or two-word
+        # query land under exactly this term. Treating those as curated would pin them above
+        # everything and skip ranking entirely. FROM_WIKI_APPROVED is real curation and stays.
+        curated_items = [d for d in curation_items
+                         if d.state is not None and d.state != DocumentState.FROM_WIKI
                          and d.term == curation_term]
 
         bigrams = set(get_bigrams(len(terms), terms))
@@ -349,7 +359,7 @@ class Ranker:
             if items is not None:
                 pages += items
 
-        external_search_items = self.external_search(q) if use_external_search else []
+        external_search_items = self.external_search(q, pages) if use_external_search else []
         candidates = pages + additional_results + external_search_items
         candidates, curated_items = self._remove_blacklisted(candidates, curated_items, index_items=pages)
 
@@ -385,7 +395,9 @@ class Ranker:
         return ([d for d in candidates if d.url not in blacklisted_urls],
                 [d for d in curated_items if d.url not in blacklisted_urls])
 
-    def external_search(self, q: str):
+    def external_search(self, q: str, index_results: list[Document]) -> list[Document]:
+        """Results from outside the index. `index_results` is what the index just returned,
+        so an implementation can decide whether it needs to go outside at all."""
         return []
 
     def get_raw_results(self, query: str):
@@ -421,6 +433,7 @@ class HeuristicRanker(Ranker):
         return filtered_results
 
 
+WIKI_USER_AGENT = 'Mwmbl/0.1.0 (https://mwmbl.org; daoud@mwmbl.org)'
 WIKI_SEARCH_API_URL = "https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={query}&format=json"
 WIKI_URL_FORMAT = "https://en.wikipedia.org/wiki/{title}"
 
@@ -428,7 +441,7 @@ WIKI_URL_FORMAT = "https://en.wikipedia.org/wiki/{title}"
 # calls — e.g. an evaluation run that queries it once per gold query. Retry with
 # backoff, honouring any Retry-After, so a transient 429 doesn't silently drop a
 # query's wiki results. Live search never bursts, so this adds no latency in
-# normal operation. Successful responses are cached for weeks (see request_cache).
+# normal operation. On where responses are cached, see wiki_session below.
 WIKI_RETRY = Retry(total=4, backoff_factor=0.5, status_forcelist=(429, 502, 503, 504),
                    allowed_methods=frozenset({"GET"}), respect_retry_after_header=True)
 
@@ -476,16 +489,30 @@ def clean_html(s: str):
     return html.unescape(HTML_TAG_REGEX.sub('', s))
 
 
+def wiki_session():
+    """The HTTP session Wikipedia is queried through.
+
+    Responses used to be cached by mwmbl.utils.request_cache, a *filesystem* cache on the
+    same volume as the index, with no LRU and nothing ever deleting expired entries, which
+    also wrote the raw user query to disk inside the stored request URL. The index cache
+    replaces it - see mwmbl.tinysearchengine.wiki_index_cache - but only once it is on:
+    with neither cache, every single search would call Wikipedia. So flipping
+    WIKI_INDEX_CACHE_ENABLED is what retires the disk cache, and until then nothing about
+    today's behaviour changes.
+    """
+    if settings.WIKI_INDEX_CACHE_ENABLED:
+        return requests.Session()
+    return request_cache(timedelta(weeks=10))
+
+
 def get_wiki_results(s: str, max_wiki_results: int) -> list[Document]:
     if _wiki_circuit_open():
         return []
 
     escaped_query = urllib.parse.quote(s, safe='')
-    headers = {
-        'User-Agent': 'Mwmbl/0.1.0 (https://mwmbl.org; daoud@mwmbl.org) requests-cache'
-    }
+    headers = {'User-Agent': WIKI_USER_AGENT}
     try:
-        with request_cache(timedelta(weeks=10)) as session:
+        with wiki_session() as session:
             session.mount("https://en.wikipedia.org", HTTPAdapter(max_retries=WIKI_RETRY))
             response = session.get(WIKI_SEARCH_API_URL.format(query=escaped_query), headers=headers, timeout=5)
             wiki_response = response.json()
@@ -530,6 +557,8 @@ class HeuristicAndWikiRanker(HeuristicRanker):
         self.return_none_if_no_mwmbl_results = return_none_if_no_mwmbl_results
         self.max_wiki_results = max_wiki_results
 
+    # Fetches Wikipedia here rather than through external_search(), and every caller in the
+    # tree hands it a RemoteIndex, so the wiki index cache is both unusable and unreachable.
     def search(self, s: str, additional_results: list[Document]) -> list[Document]:
         s_shortened = s[:MAX_QUERY_CHARS]
 

--- a/mwmbl/tinysearchengine/wiki_index_cache.py
+++ b/mwmbl/tinysearchengine/wiki_index_cache.py
@@ -35,7 +35,7 @@ The write happens in the request, not in a background task. Two reasons that is 
     so they are already warm.
   * Correctness. An index page write is a read-modify-write, and an unlocked writer that
     catches another mid-store reads an empty page and stores over everything on it. That is
-    now serialised inside TinyIndex.update_page, which every read-modify-write goes
+    now serialised inside TinyIndex.page(), which every read-modify-write goes
     through, so no caller has to know locking exists.
 """
 from logging import getLogger

--- a/mwmbl/tinysearchengine/wiki_index_cache.py
+++ b/mwmbl/tinysearchengine/wiki_index_cache.py
@@ -1,0 +1,247 @@
+"""Wikipedia results served from our own index, instead of from an HTTP cache on disk.
+
+get_wiki_results() used to cache through mwmbl.utils.request_cache, a requests-cache
+*filesystem* session rooted at REQUEST_CACHE_PATH - the same volume as the index - with a
+ten-week expiry, no LRU, no size cap and nothing ever calling delete(expired=True). It grew
+without bound (the dev copy reached 91,000 files / 4.5 GB), it wrote the raw user query to
+disk inside the stored request URL, and it did not remove the call: a miss was still a
+blocking HTTP round trip on the search path.
+
+Instead: after a call to the Wikipedia search endpoint, the results are written into the
+index under the query's unigrams and bigrams, exactly as Super Search already writes its
+own results. A later search that the index answers with enough Wikipedia results skips the
+API call altogether.
+
+Privacy - what may be written under a query-derived term:
+
+  * a document only takes a term whose words it *all contains*
+    (index_results_against_query's containment rule), so the term -> document link is
+    derivable from the document itself and says nothing about the query that produced it;
+  * terms are at most WIKI_INDEX_MAX_TERM_TOKENS words, so the query as a whole is never
+    stored as one phrase;
+  * optionally (WIKI_INDEX_REQUIRE_EXISTING_TERM) only terms the index already holds
+    documents for, so nothing is written that the corpus did not already contain.
+
+Note that get_wiki_results() stamps each Document's `term` with the *raw, untokenized
+query*. That value must never reach the index. store_wiki_results() goes through
+index_results_against_query(), which rebuilds every Document with a derived term, and
+test_wiki_index_cache asserts it - the failure would be silent.
+
+The write happens in the request, not in a background task. Two reasons that is safe:
+
+  * Cost. Storing costs about 1.2 ms per query term - 1.3 ms for a one-word query, ~10 ms
+    for a five-word one - and it only runs on a miss, where we have just paid 100-500 ms
+    for the Wikipedia call itself. The pages it writes are the ones retrieval just read,
+    so they are already warm.
+  * Correctness. An index page write is a read-modify-write, and an unlocked writer that
+    catches another mid-store reads an empty page and stores over everything on it. That is
+    now serialised by a POSIX record lock over the page's bytes - see TinyIndex.locked_page.
+"""
+from logging import getLogger
+from pathlib import Path
+
+from django.conf import settings
+
+from mwmbl.indexer.index_batches import index_results_against_query
+from mwmbl.tinysearchengine.indexer import Document, DocumentState
+from mwmbl.tokenizer import get_bigrams, tokenize
+
+logger = getLogger(__name__)
+
+
+WIKI_DOMAIN = "en.wikipedia.org"
+WIKI_STATES = frozenset({DocumentState.FROM_WIKI, DocumentState.FROM_WIKI_APPROVED})
+
+
+def is_wiki_document(document: Document) -> bool:
+    return bool(document.url) and WIKI_DOMAIN in document.url
+
+
+def count_wiki_results(documents: list[Document]) -> int:
+    return sum(1 for document in documents if is_wiki_document(document))
+
+
+def count_stored_wiki_results(documents: list[Document]) -> int:
+    """Only documents a previous API call put in the index, not organically crawled ones."""
+    return sum(1 for document in documents
+               if is_wiki_document(document) and document.state in WIKI_STATES)
+
+
+def query_terms(query: str) -> list[str]:
+    """The unigrams and bigrams a query's results are filed under - the gate's denominator."""
+    tokens = tokenize(query)
+    return tokens + get_bigrams(len(tokens), tokens)
+
+
+def wiki_documents_by_term(query: str, index_results: list[Document],
+                           stored_only: bool = True) -> dict[str, list[Document]]:
+    """Each query term mapped to the Wikipedia documents the index returned under it.
+
+    Every term appears, including ones with nothing - a term the index cannot answer is
+    exactly the signal a breadth-based gate needs, so it must count as a zero rather than
+    being dropped from the average.
+    """
+    by_term: dict[str, list[Document]] = {term: [] for term in query_terms(query)}
+    for document in index_results:
+        if document.term not in by_term or not is_wiki_document(document):
+            continue
+        if stored_only and document.state not in WIKI_STATES:
+            continue
+        by_term[document.term].append(document)
+    return by_term
+
+
+def per_term_best(by_term: dict[str, list[Document]], score: callable) -> list[float]:
+    """The best score among each term's Wikipedia documents; 0.0 for a term with none.
+
+    Scores the whole set in one call rather than per term, because `score` is a model
+    prediction and batching it is most of the cost.
+    """
+    documents, owners = [], []
+    for term, term_documents in by_term.items():
+        for document in term_documents:
+            documents.append(document)
+            owners.append(term)
+
+    best: dict[str, float] = {}
+    if documents:
+        for term, value in zip(owners, score(documents)):
+            best[term] = max(best.get(term, 0.0), value)
+    return [best.get(term, 0.0) for term in by_term]
+
+
+def stored_scores(documents: list[Document]) -> list[float]:
+    """Document.score as stored.
+
+    Be careful reading a gate built on this. In the index `score` is not a relevance
+    number: curated documents carry MAX_CURATED_SCORE - i (~1.1e6), ordinary crawled
+    documents carry None, and documents this cache stored carry their rank in Wikipedia's
+    own results (3/2/1). Across a mixed set the scales are meaningless. Restricted to
+    stored Wikipedia documents it is at least consistent - but then it is nearly a constant,
+    so a gate on it collapses into term coverage.
+    """
+    return [document.score if document.score is not None else 0.0 for document in documents]
+
+
+# Gates that count documents.
+COUNTING_GATES = {
+    "raw_candidates": lambda documents, rank, top_n: count_wiki_results(documents),
+    "ranked_top_n": lambda documents, rank, top_n: count_wiki_results(rank(documents)[:top_n]),
+    "from_wiki_only": lambda documents, rank, top_n: count_stored_wiki_results(rank(documents)[:top_n]),
+}
+
+# Gates that reduce a per-term score profile to one number. The threshold is a float.
+AGGREGATES = {
+    "term_coverage": lambda values: sum(1 for v in values if v > 0) / len(values),
+    "mean_max": lambda values: sum(values) / len(values),
+    "min_max": min,
+    "max_max": max,
+}
+
+# gate name -> (aggregate, whether to use the model's relevance score or the stored one)
+VALUE_GATES = {
+    "term_coverage": ("term_coverage", "stored"),
+    "mean_max_ltr": ("mean_max", "ltr"),
+    "min_max_ltr": ("min_max", "ltr"),
+    "max_max_ltr": ("max_max", "ltr"),
+    "mean_max_stored": ("mean_max", "stored"),
+}
+
+GATES = list(COUNTING_GATES) + list(VALUE_GATES) + ["never", "always"]
+
+
+def have_enough_wiki_results(query: str, index_results: list[Document], rank: callable,
+                             score: callable = None, gate: str = None,
+                             threshold: float = None, top_n: int = None) -> bool:
+    """Whether the index already answered this query well enough to skip the API call.
+
+    `rank` orders index candidates the way the ranker would and `score` returns the model's
+    relevance for each of a list of documents. Both are passed in rather than taken from a
+    ranker, so the gate can be tested and swept without one, and each is only called by the
+    gates that need it - they are the only part of this that costs anything.
+
+    Two families of gate:
+
+    *Counting* - how many Wikipedia results came back.
+      raw_candidates  cheapest: count wiki URLs among the unranked candidates. A broad
+                      query pulls in irrelevant crawled wiki pages, so it over-fires.
+      ranked_top_n    rank first, count wiki URLs in the top N. What the user would see.
+      from_wiki_only  as ranked_top_n, but counting only documents a previous API call
+                      stored - a cache-hit test that ignores crawled coverage.
+
+    *Per-term profile* - how well the index covers each of the query's terms. For every
+    unigram and bigram, take the best stored Wikipedia result's score (0 if the term has
+    none), then reduce:
+      term_coverage   fraction of terms with any stored result at all.
+      mean_max_ltr    mean of the per-term bests, by model relevance. Rewards a query whose
+                      terms are broadly well covered.
+      min_max_ltr     the worst-covered term. Fires only if *every* term is answered.
+      max_max_ltr     the best-covered term. The most permissive.
+      mean_max_stored as mean_max_ltr but on Document.score - see stored_scores for why
+                      that number is close to meaningless.
+
+    And two degenerate ones: `never` always calls (results are still stored, which isolates
+    the effect of serving stored documents from that of skipping calls), `always` never
+    calls. Which gate preserves NDCG is empirical - see
+    mwmbl.rankeval.evaluation.evaluate_wiki_index, which sweeps them.
+    """
+    gate = settings.WIKI_INDEX_GATE if gate is None else gate
+    threshold = settings.WIKI_INDEX_GATE_THRESHOLD if threshold is None else threshold
+    top_n = settings.WIKI_INDEX_GATE_TOP_N if top_n is None else top_n
+
+    if gate == "never":
+        return False
+    if gate == "always":
+        return True
+
+    if gate in VALUE_GATES:
+        aggregate, source = VALUE_GATES[gate]
+        by_term = wiki_documents_by_term(query, index_results)
+        if not by_term:
+            return False
+        score_fn = stored_scores if source == "stored" else score
+        return AGGREGATES[aggregate](per_term_best(by_term, score_fn)) >= threshold
+
+    if gate not in COUNTING_GATES:
+        raise ValueError(f"Unknown wiki index gate: {gate!r}")
+    if threshold <= 0:
+        return True
+    if not index_results:
+        return False
+    return COUNTING_GATES[gate](index_results, rank, top_n) >= threshold
+
+
+def default_index_path() -> str:
+    return str(Path(settings.DATA_PATH) / settings.INDEX_NAME)
+
+
+def store_wiki_results(query: str, documents: list[Document], index_path: str = None,
+                       term_exists=None) -> int:
+    """File a query's Wikipedia results under the query terms they are allowed to take.
+
+    Returns the number of distinct URLs newly stored - zero is normal and expected:
+    Wikipedia spell-corrects and partial-matches, so a returned article need not contain
+    the query's words at all, and the containment rule then stores nothing for it.
+
+    `term_exists` overrides how WIKI_INDEX_REQUIRE_EXISTING_TERM decides whether a term is
+    already in the corpus. In production the corpus is the index being written to, which
+    is the default; an evaluation reading through an overlay has to answer for both halves.
+
+    Never raises. Failing to store costs one re-fetch on the next matching query; it must
+    not be able to affect a search response.
+    """
+    if not documents:
+        return 0
+    try:
+        return index_results_against_query(
+            documents, query, index_path or default_index_path(),
+            max_term_tokens=settings.WIKI_INDEX_MAX_TERM_TOKENS,
+            require_existing_term=settings.WIKI_INDEX_REQUIRE_EXISTING_TERM,
+            term_exists=term_exists,
+            state=DocumentState.FROM_WIKI,
+            keep_score=settings.WIKI_INDEX_KEEP_SCORE,
+        )
+    except Exception:
+        logger.warning("Could not store %d Wikipedia results in the index",
+                       len(documents), exc_info=True)
+        return 0

--- a/mwmbl/tinysearchengine/wiki_index_cache.py
+++ b/mwmbl/tinysearchengine/wiki_index_cache.py
@@ -74,15 +74,43 @@ def query_terms(query: str) -> list[str]:
     return tokens + get_bigrams(len(tokens), tokens)
 
 
+def query_bigrams(query: str) -> list[str]:
+    """The bigrams alone - a narrower denominator, and the one `specific` scoring needs.
+
+    Over `query_terms` this changes nothing on its own. A document only takes a term whose
+    words it all contains, so a copy filed under the bigram "a b" is filed under "a" and
+    "b" in the same write, and every unigram of a query appears in one of its consecutive
+    bigrams: "every bigram covered" and "every term covered" are the same condition. What
+    it changes is which *scores* the gate can see. Under WIKI_INDEX_SCORE_TERMS="specific"
+    only bigrams carry a score, so a denominator including unigrams can never reach full
+    coverage for a multi-token query and the gate dies; and a one-token query can no
+    longer fire on a bare unigram some longer query happened to store, which is the
+    "connections" <- "connections hint september 14" case that _takes_score exists to stop.
+
+    A one-token query has no bigram, and its token *is* the query, so the token stands in.
+    That is also the only case where `specific` files a score under a unigram, which keeps
+    the denominator and the scored terms aligned at every query length.
+    """
+    tokens = tokenize(query)
+    if len(tokens) < 2:
+        return tokens
+    return get_bigrams(len(tokens), tokens)
+
+
+DENOMINATORS = {"terms": query_terms, "bigrams": query_bigrams}
+
+
 def wiki_documents_by_term(query: str, index_results: list[Document],
-                           stored_only: bool = True) -> dict[str, list[Document]]:
+                           stored_only: bool = True,
+                           denominator: str = "terms") -> dict[str, list[Document]]:
     """Each query term mapped to the Wikipedia documents the index returned under it.
 
     Every term appears, including ones with nothing - a term the index cannot answer is
     exactly the signal a breadth-based gate needs, so it must count as a zero rather than
-    being dropped from the average.
+    being dropped from the average. `denominator` chooses which terms are in that
+    accounting - see query_bigrams.
     """
-    by_term: dict[str, list[Document]] = {term: [] for term in query_terms(query)}
+    by_term: dict[str, list[Document]] = {term: [] for term in DENOMINATORS[denominator](query)}
     for document in index_results:
         if document.term not in by_term or not is_wiki_document(document):
             continue
@@ -139,13 +167,15 @@ AGGREGATES = {
     "max_max": max,
 }
 
-# gate name -> (aggregate, whether to use the model's relevance score or the stored one)
+# gate name -> (aggregate, whether to use the model's relevance score or the stored one,
+#               which terms form the denominator)
 VALUE_GATES = {
-    "term_coverage": ("term_coverage", "stored"),
-    "mean_max_ltr": ("mean_max", "ltr"),
-    "min_max_ltr": ("min_max", "ltr"),
-    "max_max_ltr": ("max_max", "ltr"),
-    "mean_max_stored": ("mean_max", "stored"),
+    "term_coverage": ("term_coverage", "stored", "terms"),
+    "bigram_coverage": ("term_coverage", "stored", "bigrams"),
+    "mean_max_ltr": ("mean_max", "ltr", "terms"),
+    "min_max_ltr": ("min_max", "ltr", "terms"),
+    "max_max_ltr": ("max_max", "ltr", "terms"),
+    "mean_max_stored": ("mean_max", "stored", "terms"),
 }
 
 GATES = list(COUNTING_GATES) + list(VALUE_GATES) + ["never", "always"]
@@ -174,6 +204,9 @@ def have_enough_wiki_results(query: str, index_results: list[Document], rank: ca
     unigram and bigram, take the best stored Wikipedia result's score (0 if the term has
     none), then reduce:
       term_coverage   fraction of terms with any stored result at all.
+      bigram_coverage as term_coverage, but counting only the query's bigrams. Identical
+                      to term_coverage under score_terms="all"; the pairing that matters
+                      is with "specific", which scores bigrams only - see query_bigrams.
       mean_max_ltr    mean of the per-term bests, by model relevance. Rewards a query whose
                       terms are broadly well covered.
       min_max_ltr     the worst-covered term. Fires only if *every* term is answered.
@@ -196,8 +229,8 @@ def have_enough_wiki_results(query: str, index_results: list[Document], rank: ca
         return True
 
     if gate in VALUE_GATES:
-        aggregate, source = VALUE_GATES[gate]
-        by_term = wiki_documents_by_term(query, index_results)
+        aggregate, source, denominator = VALUE_GATES[gate]
+        by_term = wiki_documents_by_term(query, index_results, denominator=denominator)
         if not by_term:
             return False
         score_fn = stored_scores if source == "stored" else score

--- a/mwmbl/tinysearchengine/wiki_index_cache.py
+++ b/mwmbl/tinysearchengine/wiki_index_cache.py
@@ -35,7 +35,8 @@ The write happens in the request, not in a background task. Two reasons that is 
     so they are already warm.
   * Correctness. An index page write is a read-modify-write, and an unlocked writer that
     catches another mid-store reads an empty page and stores over everything on it. That is
-    now serialised by a POSIX record lock over the page's bytes - see TinyIndex.locked_page.
+    now serialised inside TinyIndex.update_page, which every read-modify-write goes
+    through, so no caller has to know locking exists.
 """
 from logging import getLogger
 from pathlib import Path

--- a/mwmbl/tinysearchengine/wiki_index_cache.py
+++ b/mwmbl/tinysearchengine/wiki_index_cache.py
@@ -240,7 +240,8 @@ def store_wiki_results(query: str, documents: list[Document], index_path: str = 
             require_existing_term=settings.WIKI_INDEX_REQUIRE_EXISTING_TERM,
             term_exists=term_exists,
             state=DocumentState.FROM_WIKI,
-            keep_score=settings.WIKI_INDEX_KEEP_SCORE,
+            score_terms=settings.WIKI_INDEX_SCORE_TERMS,
+            score_ema_alpha=settings.WIKI_INDEX_SCORE_EMA_ALPHA,
         )
     except Exception:
         logger.warning("Could not store %d Wikipedia results in the index",

--- a/mwmbl/views.py
+++ b/mwmbl/views.py
@@ -299,14 +299,11 @@ def _revert_curation(curation):
         term = " ".join(tokenize(curation.query))
         documents = [Document(**doc) for doc in curation.original_index_results]
 
-        page_index = indexer.get_key_page_index(term)
-        existing_documents = indexer.get_page(page_index)
-        other_term_documents = [doc for doc in existing_documents if doc.term != term]
+        def restore_originals(existing_documents):
+            # Replace all existing documents for the term with the original documents
+            return documents + [doc for doc in existing_documents if doc.term != term]
 
-        # Replace all existing documents for the term with the original documents
-        all_documents = documents + other_term_documents
-
-        indexer.store_in_page(page_index, all_documents)
+        indexer.update_page(indexer.get_key_page_index(term), restore_originals)
 
 
 def _get_curation(request, query, documents, reranked_documents):
@@ -392,21 +389,24 @@ def _save_to_index(query: str, new_results: list[Document]):
         ]
 
         page_index = indexer.get_key_page_index(term)
-        existing_documents_no_terms = indexer.get_page(page_index)
-        existing_documents = add_term_infos(existing_documents_no_terms, indexer, page_index)
-        new_urls = {doc.url for doc in documents}
-        other_documents = [doc for doc in existing_documents if doc.url not in new_urls]
-        logger.info(f"Found {len(other_documents)} other documents for term {term} at page {page_index} "
-                    f"with terms { {doc.term for doc in other_documents} }")
 
-        # Update state for other documents
-        states = {doc.url: doc.state for doc in new_results}
-        for doc in other_documents:
-            doc.state = states.get(doc.url, doc.state)
+        def merge_curated(existing_documents_no_terms):
+            existing_documents = add_term_infos(existing_documents_no_terms, indexer, page_index)
+            new_urls = {doc.url for doc in documents}
+            other_documents = [doc for doc in existing_documents if doc.url not in new_urls]
+            logger.info(f"Found {len(other_documents)} other documents for term {term} at page {page_index} "
+                        f"with terms { {doc.term for doc in other_documents} }")
 
-        all_documents = documents + other_documents
-        logger.info(f"Storing {len(all_documents)} documents at page {page_index}")
-        indexer.store_in_page(page_index, all_documents)
+            # Update state for other documents
+            states = {doc.url: doc.state for doc in new_results}
+            for doc in other_documents:
+                doc.state = states.get(doc.url, doc.state)
+
+            all_documents = documents + other_documents
+            logger.info(f"Storing {len(all_documents)} documents at page {page_index}")
+            return all_documents
+
+        indexer.update_page(page_index, merge_curated)
 
     return {"curation": "ok"}
 

--- a/mwmbl/views.py
+++ b/mwmbl/views.py
@@ -299,11 +299,9 @@ def _revert_curation(curation):
         term = " ".join(tokenize(curation.query))
         documents = [Document(**doc) for doc in curation.original_index_results]
 
-        def restore_originals(existing_documents):
+        with indexer.page(indexer.get_key_page_index(term)) as page:
             # Replace all existing documents for the term with the original documents
-            return documents + [doc for doc in existing_documents if doc.term != term]
-
-        indexer.update_page(indexer.get_key_page_index(term), restore_originals)
+            page.store(documents + [doc for doc in page.documents if doc.term != term])
 
 
 def _get_curation(request, query, documents, reranked_documents):
@@ -390,8 +388,8 @@ def _save_to_index(query: str, new_results: list[Document]):
 
         page_index = indexer.get_key_page_index(term)
 
-        def merge_curated(existing_documents_no_terms):
-            existing_documents = add_term_infos(existing_documents_no_terms, indexer, page_index)
+        with indexer.page(page_index) as page:
+            existing_documents = add_term_infos(page.documents, indexer, page_index)
             new_urls = {doc.url for doc in documents}
             other_documents = [doc for doc in existing_documents if doc.url not in new_urls]
             logger.info(f"Found {len(other_documents)} other documents for term {term} at page {page_index} "
@@ -403,10 +401,8 @@ def _save_to_index(query: str, new_results: list[Document]):
                 doc.state = states.get(doc.url, doc.state)
 
             all_documents = documents + other_documents
-            logger.info(f"Storing {len(all_documents)} documents at page {page_index}")
-            return all_documents
-
-        indexer.update_page(page_index, merge_curated)
+            num_stored = page.store(all_documents)
+            logger.info(f"Stored {num_stored} of {len(all_documents)} documents at page {page_index}")
 
     return {"curation": "ok"}
 

--- a/test/test_index_batches.py
+++ b/test/test_index_batches.py
@@ -269,3 +269,143 @@ def test_index_documents_keeps_everything_when_nothing_blacklisted(index_path):
         index_documents(documents, index_path)
 
     assert "https://example.com/y" in _all_urls(index_path)
+
+
+# ---------------------------------------------------------------------------
+# score_terms and the score EMA
+# ---------------------------------------------------------------------------
+
+def _make_index(temp_dir, num_pages=64):
+    index_path = str(Path(temp_dir) / 'temp-index.tinysearch')
+    with TinyIndex.create(Document, index_path, num_pages=num_pages, page_size=4096):
+        pass
+    return index_path
+
+
+def _scores_by_term(index_path, terms):
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        return {term: {d.url: d.score for d in indexer.retrieve(term)} for term in terms}
+
+
+def test_score_terms_specific_scores_bigrams_only():
+    # The score is the rank the source gave the document for the *whole* query, so on a
+    # multi-token query only the bigrams may carry it - a bare unigram would claim a
+    # ranking that word never earned on its own.
+    doc = Document(title="Rust async programming", url="http://a.example/rust",
+                   extract="async programming in rust", score=3.0)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        index_results_against_query([doc], "rust async programming", index_path,
+                                    max_term_tokens=2, score_terms="specific")
+
+        scores = _scores_by_term(index_path, ["rust", "async", "programming",
+                                              "rust async", "async programming"])
+
+    assert scores["rust"] == {doc.url: None}
+    assert scores["async"] == {doc.url: None}
+    assert scores["programming"] == {doc.url: None}
+    assert scores["rust async"] == {doc.url: 3.0}
+    assert scores["async programming"] == {doc.url: 3.0}
+
+
+def test_score_terms_specific_scores_the_unigram_of_a_one_word_query():
+    # A one-token query *is* its unigram, so the score is honestly that term's own.
+    doc = Document(title="Kitsas dictionary", url="https://en.wiktionary.org/wiki/kitsas",
+                   extract="", score=2.0)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        index_results_against_query([doc], "kitsas", index_path, score_terms="specific")
+        scores = _scores_by_term(index_path, ["kitsas"])
+
+    assert scores["kitsas"] == {doc.url: 2.0}
+
+
+def test_score_terms_exact_scores_nothing_for_a_long_query():
+    # No term equals the whole query once terms are capped at two words, so nothing may
+    # carry a score that only the full query earned.
+    doc = Document(title="Rust async programming", url="http://a.example/rust",
+                   extract="async programming in rust", score=3.0)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        index_results_against_query([doc], "rust async programming", index_path,
+                                    max_term_tokens=2, score_terms="exact")
+        scores = _scores_by_term(index_path, ["rust", "rust async", "async programming"])
+
+    assert all(url_scores == {doc.url: None} for url_scores in scores.values())
+
+
+def test_score_terms_none_is_the_default():
+    doc = Document(title="Rust guide", url="http://a.example/rust", extract="rust", score=3.0)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        index_results_against_query([doc], "rust", index_path)
+        assert _scores_by_term(index_path, ["rust"])["rust"] == {doc.url: None}
+
+
+def test_score_ema_blends_with_the_previous_stored_score():
+    url = "http://a.example/rust"
+    first = Document(title="Rust guide", url=url, extract="rust", score=3.0,
+                     state=DocumentState.FROM_WIKI)
+    second = Document(title="Rust guide", url=url, extract="rust", score=1.0,
+                      state=DocumentState.FROM_WIKI)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        index_results_against_query([first], "rust", index_path, score_terms="all",
+                                    state=DocumentState.FROM_WIKI, score_ema_alpha=0.5)
+        assert _scores_by_term(index_path, ["rust"])["rust"] == {url: 3.0}
+
+        index_results_against_query([second], "rust", index_path, score_terms="all",
+                                    state=DocumentState.FROM_WIKI, score_ema_alpha=0.5)
+        # 0.5 * 1.0 + 0.5 * 3.0
+        assert _scores_by_term(index_path, ["rust"])["rust"] == {url: 2.0}
+
+
+def test_score_ema_alpha_one_overwrites():
+    url = "http://a.example/rust"
+    docs = [Document(title="Rust guide", url=url, extract="rust", score=score,
+                     state=DocumentState.FROM_WIKI) for score in (3.0, 1.0)]
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        for doc in docs:
+            index_results_against_query([doc], "rust", index_path, score_terms="all",
+                                        state=DocumentState.FROM_WIKI)
+        assert _scores_by_term(index_path, ["rust"])["rust"] == {url: 1.0}
+
+
+def test_score_ema_ignores_documents_stored_with_another_state():
+    # Scores are only comparable within one source: a curated document carries ~1.1e6, a
+    # crawled one carries None. Blending across states would mix scales, so a document
+    # filed here under a different state is not a previous value.
+    url = "http://a.example/rust"
+    from_elsewhere = Document(title="Rust guide", url=url, extract="rust", score=100.0,
+                              term="rust", state=DocumentState.FROM_GOOGLE)
+    incoming = Document(title="Rust guide", url=url, extract="rust", score=3.0,
+                        state=DocumentState.FROM_WIKI)
+
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        with TinyIndex(Document, index_path, 'w') as indexer:
+            page_index = indexer.get_key_page_index("rust")
+            with indexer.page(page_index) as page:
+                page.store([from_elsewhere])
+
+        index_results_against_query([incoming], "rust", index_path, score_terms="all",
+                                    state=DocumentState.FROM_WIKI, score_ema_alpha=0.5)
+
+        scores = _scores_by_term(index_path, ["rust"])
+    # Unblended: 0.5 * 3.0 + 0.5 * 100.0 would be 51.5.
+    assert scores["rust"] == {url: 3.0}
+
+
+def test_unknown_score_terms_is_rejected():
+    doc = Document(title="Rust guide", url="http://a.example/rust", extract="rust")
+    with TemporaryDirectory() as temp_dir:
+        index_path = _make_index(temp_dir)
+        with pytest.raises(ValueError):
+            index_results_against_query([doc], "rust", index_path, score_terms="bogus")

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -63,8 +63,9 @@ def test_get_page_data_single_doc():
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmmed data, then it should be equal to the data we persist
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     assert serialized_data == padded_trimmed_data
+    assert num_stored == num_fitting
     
 
 def test_get_page_data_many_docs_all_fit():
@@ -87,10 +88,11 @@ def test_get_page_data_many_docs_all_fit():
     
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmed data, then it should be equal to the data we persist
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
     
     assert serialized_data == padded_trimmed_data
+    assert num_stored == num_fitting
 
 
 def test_get_page_data_many_docs_subset_fit():
@@ -114,10 +116,12 @@ def test_get_page_data_many_docs_subset_fit():
     
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmed data, then it should be equal to the data we persist
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
     
     assert serialized_data == padded_trimmed_data
+    # The count is what store() reports back, so it has to match what was actually kept.
+    assert num_stored == num_fitting
 
 
 def test_constructing_document_removes_none():

--- a/test/test_rank.py
+++ b/test/test_rank.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
+from requests_cache import CachedSession
 from requests.exceptions import RetryError
 from urllib3.exceptions import MaxRetryError, ResponseError
 
@@ -35,7 +37,7 @@ class _TrackingRanker(HeuristicRanker):
         super().__init__(tiny_index, completer)
         self.external_search_calls = []
 
-    def external_search(self, q):
+    def external_search(self, q, index_results):
         self.external_search_calls.append(q)
         return []
 
@@ -70,8 +72,8 @@ def _reset_wiki_circuit():
 
 
 def _get_wiki_results_with_session(session):
-    with patch.object(rank, "request_cache") as mock_request_cache:
-        mock_request_cache.return_value.__enter__.return_value = session
+    with patch.object(rank, "wiki_session") as mock_wiki_session:
+        mock_wiki_session.return_value.__enter__.return_value = session
         return get_wiki_results("query", 5)
 
 
@@ -109,10 +111,10 @@ def test_wiki_query_text_containing_429_is_not_mistaken_for_rate_limit():
 def test_open_wiki_circuit_short_circuits_without_calling_wikipedia():
     rank._trip_wiki_circuit()
 
-    with patch.object(rank, "request_cache") as mock_request_cache:
+    with patch.object(rank, "wiki_session") as mock_wiki_session:
         results = get_wiki_results("query", 5)
 
-    mock_request_cache.assert_not_called()
+    mock_wiki_session.assert_not_called()
     assert results == []
 
 
@@ -122,3 +124,12 @@ def test_is_wiki_rate_limited_detects_429_reason():
 
 def test_is_wiki_rate_limited_ignores_non_429_reason():
     assert not rank._is_wiki_rate_limited(_make_retry_error(503))
+
+
+def test_wiki_session_keeps_the_disk_cache_until_the_index_cache_is_on():
+    # With neither cache every search would call Wikipedia, so the disk cache is retired by
+    # turning WIKI_INDEX_CACHE_ENABLED on, not by this change landing.
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=False):
+        assert isinstance(rank.wiki_session(), CachedSession)
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=True):
+        assert not isinstance(rank.wiki_session(), CachedSession)

--- a/test/test_rankeval_gold.py
+++ b/test/test_rankeval_gold.py
@@ -1,0 +1,73 @@
+"""The gold ranking a query is scored against.
+
+The rankings dataset holds several scrapes of the same query, taken on different dates
+and stored as consecutive rows under the one query - 1,135 of the 5,969 test queries.
+Every harness that scores against it goes through gold_scores_for, so this is where the
+"one query, one ranking" rule has to hold.
+"""
+import pandas as pd
+
+from mwmbl.rankeval.evaluation.evaluate import (
+    CLICK_PROPORTIONS, gold_scores_for, latest_ranking)
+
+
+def _rankings(rows):
+    return pd.DataFrame(rows, columns=["query", "url", "rank", "date_retrieved"])
+
+
+def test_latest_ranking_keeps_only_the_most_recent_scrape():
+    rankings = _rankings([
+        ("piles", "https://old-first", 1, "2025-07-20"),
+        ("piles", "https://old-second", 2, "2025-07-20"),
+        ("piles", "https://new-first", 1, "2026-01-29"),
+        ("piles", "https://new-second", 2, "2026-01-29"),
+    ])
+
+    assert list(latest_ranking(rankings)["url"]) == ["https://new-first", "https://new-second"]
+
+
+def test_latest_ranking_sorts_by_rank():
+    rankings = _rankings([
+        ("piles", "https://second", 2, "2026-01-29"),
+        ("piles", "https://first", 1, "2026-01-29"),
+    ])
+
+    assert list(latest_ranking(rankings)["url"]) == ["https://first", "https://second"]
+
+
+def test_gold_scores_ignore_an_earlier_scrape():
+    # Without this the first ten rows would be the older scrape's, and a URL appearing in
+    # both would take the weight of whichever row came second - the *worse* rank.
+    rankings = _rankings([
+        ("piles", "https://nhs", 5, "2025-07-20"),
+        ("piles", "https://nhs", 1, "2026-01-29"),
+        ("piles", "https://mayo", 2, "2026-01-29"),
+    ])
+
+    assert gold_scores_for(rankings) == {
+        "https://nhs": CLICK_PROPORTIONS[0],
+        "https://mayo": CLICK_PROPORTIONS[1],
+    }
+
+
+def test_gold_scores_drop_a_duplicate_url_keeping_the_best_rank():
+    rankings = _rankings([
+        ("piles", "https://nhs", 1, "2026-01-29"),
+        ("piles", "https://mayo", 2, "2026-01-29"),
+        ("piles", "https://nhs", 3, "2026-01-29"),
+    ])
+
+    assert gold_scores_for(rankings) == {
+        "https://nhs": CLICK_PROPORTIONS[0],
+        "https://mayo": CLICK_PROPORTIONS[1],
+    }
+
+
+def test_gold_scores_take_at_most_ten_results():
+    rankings = _rankings([("piles", f"https://result-{i}", i, "2026-01-29")
+                          for i in range(1, 16)])
+
+    scores = gold_scores_for(rankings)
+    assert len(scores) == len(CLICK_PROPORTIONS)
+    assert scores["https://result-1"] == CLICK_PROPORTIONS[0]
+    assert "https://result-11" not in scores

--- a/test/test_wiki_index_cache.py
+++ b/test/test_wiki_index_cache.py
@@ -5,6 +5,8 @@ stored result may be filed under, and the OverlayIndex the evaluation reads thro
 """
 import fcntl
 import os
+import random
+import string
 from io import UnsupportedOperation
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -427,13 +429,12 @@ def _try_lock_in_child(index_path: str, page: int, queue):
             queue.put(False)
 
 
-def test_update_page_holds_the_lock_across_the_read_and_the_write(index_path):
+def test_page_holds_the_lock_across_the_read_and_the_write(index_path):
     """Changing a page must be atomic, and callers must not have to arrange that.
 
-    _write_page copies ~4 KB into the mmap; a reader catching it half-written gets a
-    ZstdError, which _get_page_tuples turns into an empty page - so a writer that reads
-    empty, merges and stores wipes out everything else on that page. update_page owns the
-    whole read-merge-write, so this checks the lock is held for the duration of `merge`.
+    _write_page copies ~4 KB into the mmap; a reader catching it half-written gets a page
+    that will not decompress. TinyIndex.page owns the whole read-modify-write, so this
+    checks the lock is held for as long as the block runs.
 
     It asserts the exclusion property directly rather than trying to win the race: the
     window is a single memcpy, so a racing test passes with the lock removed and guards
@@ -443,60 +444,73 @@ def test_update_page_holds_the_lock_across_the_read_and_the_write(index_path):
 
     context = multiprocessing.get_context("fork")
     with TinyIndex(Document, index_path, 'r') as indexer:
-        page = indexer.get_key_page_index("zebra")
+        target = indexer.get_key_page_index("zebra")
 
-    def child_can_lock(target_page=page):
+    def child_can_lock(page_index=target):
         queue = context.Queue()
-        child = context.Process(target=_try_lock_in_child, args=(index_path, target_page, queue))
+        child = context.Process(target=_try_lock_in_child, args=(index_path, page_index, queue))
         child.start()
         child.join(timeout=30)
         return queue.get(timeout=5)
 
-    observed = {}
-
-    def merge(existing):
-        observed["locked_during_merge"] = not child_can_lock()
-
-        # An ordinary POSIX record lock is owned by the *process* and is dropped the moment
-        # any fd on the file is closed - and index_results_against_query opens and closes a
-        # read handle on every store, so in a threaded worker that would silently release
-        # the lock mid-write. OFD locks survive it.
-        with TinyIndex(Document, index_path, 'r'):
-            pass
-        observed["locked_after_unrelated_close"] = not child_can_lock()
-
-        # A different page must not contend.
-        observed["other_page_free"] = child_can_lock((page + 1) % 64)
-        return None
-
     with TinyIndex(Document, index_path, 'w') as indexer:
-        indexer.update_page(page, merge)
+        with indexer.page(target) as page:
+            assert not child_can_lock(), "another process took a lock we were holding"
 
-    assert observed["locked_during_merge"], "another process took a lock we were holding"
-    assert observed["locked_after_unrelated_close"], \
-        "closing an unrelated fd released the lock - this needs an OFD lock"
-    assert observed["other_page_free"], "a different page was blocked"
+            # An ordinary POSIX record lock is owned by the *process* and is dropped the
+            # moment any fd on the file is closed - and index_results_against_query opens
+            # and closes a read handle on every store, so in a threaded worker that would
+            # silently release the lock mid-write. OFD locks survive it.
+            with TinyIndex(Document, index_path, 'r'):
+                pass
+            assert not child_can_lock(), \
+                "closing an unrelated fd released the lock - this needs an OFD lock"
+
+            assert child_can_lock((target + 1) % 64), "a different page was blocked"
+            assert page.documents == []
+
     assert child_can_lock(), "the lock was not released"
 
 
-def test_update_page_writes_nothing_when_merge_returns_none(index_path):
+def test_page_writes_nothing_unless_store_is_called(index_path):
     seeded = [Document("Zebra", "https://en.wikipedia.org/wiki/Zebra", "", 3.0, "zebra",
                        state=DocumentState.FROM_WIKI)]
     with TinyIndex(Document, index_path, 'w') as indexer:
-        page = indexer.get_key_page_index("zebra")
-        indexer.store_in_page(page, seeded)
+        target = indexer.get_key_page_index("zebra")
+        indexer.store_in_page(target, seeded)
 
-        unchanged = indexer.update_page(page, lambda existing: None)
-        assert [d.url for d in unchanged] == [seeded[0].url]
+        with indexer.page(target) as page:
+            assert [d.url for d in page.documents] == [seeded[0].url]  # read, then do nothing
 
     with TinyIndex(Document, index_path, 'r') as indexer:
-        assert [d.url for d in indexer.get_page(page)] == [seeded[0].url]
+        assert [d.url for d in indexer.get_page(target)] == [seeded[0].url]
 
 
-def test_update_page_needs_write_mode(index_path):
+def test_store_reports_how_many_documents_actually_fit(index_path):
+    """A page drops the tail that does not fit, which is why this is store() and not an
+    assignment to `documents` - what you pass is not necessarily what is kept."""
+    # Distinct, incompressible extracts - zstd would squeeze 500 identical ones onto a
+    # single page and there would be nothing to truncate.
+    filler = random.Random(0)
+    many = [Document(f"Zebra {i}", f"https://en.wikipedia.org/wiki/Zebra_{i}",
+                     "".join(filler.choices(string.ascii_letters, k=400)),
+                     3.0, "zebra", state=DocumentState.FROM_WIKI)
+            for i in range(500)]
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        with indexer.page(indexer.get_key_page_index("zebra")) as page:
+            num_stored = page.store(many)
+
+    assert 0 < num_stored < len(many), f"expected truncation, stored {num_stored}"
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert len(indexer.get_page(indexer.get_key_page_index("zebra"))) == num_stored
+
+
+def test_page_needs_write_mode(index_path):
     with TinyIndex(Document, index_path, 'r') as indexer:
         with pytest.raises(UnsupportedOperation):
-            indexer.update_page(0, lambda existing: existing)
+            with indexer.page(0):
+                pass
 
 
 def test_writes_continue_when_page_locking_is_unsupported(index_path, monkeypatch):

--- a/test/test_wiki_index_cache.py
+++ b/test/test_wiki_index_cache.py
@@ -21,7 +21,7 @@ from mwmbl.tinysearchengine.ltr_rank import LTRRanker
 from mwmbl.tinysearchengine.rank import HeuristicRanker
 from mwmbl.tinysearchengine.wiki_index_cache import (
     count_stored_wiki_results, count_wiki_results, have_enough_wiki_results, per_term_best,
-    query_terms, store_wiki_results, wiki_documents_by_term,
+    query_bigrams, query_terms, store_wiki_results, wiki_documents_by_term,
 )
 from mwmbl.tokenizer import get_bigrams, tokenize
 
@@ -400,6 +400,99 @@ def test_term_coverage_gate_is_a_fraction_of_terms():
                                     gate="term_coverage", threshold=1 / 3)
     assert not have_enough_wiki_results("bitcoin blockchain", documents, identity_rank,
                                         gate="term_coverage", threshold=0.5)
+
+
+# ---------------------------------------------------------------------------
+# The bigram denominator, and the score policy it exists to serve
+# ---------------------------------------------------------------------------
+
+def test_query_bigrams_drops_the_unigrams():
+    assert query_bigrams("bitcoin blockchain ledger") == ["bitcoin blockchain",
+                                                          "blockchain ledger"]
+
+
+def test_a_one_token_query_stands_in_for_its_own_bigram():
+    # It has no bigram, and the token *is* the query - which is also the one case where
+    # score_terms="specific" files a score under a unigram, so the denominator and the
+    # scored terms stay aligned at every query length.
+    assert query_bigrams("bitcoin") == ["bitcoin"]
+
+
+def test_bigram_coverage_ignores_covered_unigrams():
+    # Both unigrams answered, the bigram not. term_coverage calls that 2/3 covered;
+    # bigram_coverage calls it 0/1, because a document holding both words in one place is
+    # the only evidence that this *query* was answered.
+    unigrams_only = [stored_under("bitcoin"), stored_under("blockchain", "Blockchain")]
+    assert have_enough_wiki_results("bitcoin blockchain", unigrams_only, identity_rank,
+                                    gate="term_coverage", threshold=2 / 3)
+    assert not have_enough_wiki_results("bitcoin blockchain", unigrams_only, identity_rank,
+                                        gate="bigram_coverage", threshold=1.0)
+
+    covered = unigrams_only + [stored_under("bitcoin blockchain", "Bitcoin blockchain")]
+    assert have_enough_wiki_results("bitcoin blockchain", covered, identity_rank,
+                                    gate="bigram_coverage", threshold=1.0)
+
+
+def test_bigram_coverage_does_not_fire_on_a_unigram_a_longer_query_stored(index_path):
+    # "connections" <- "connections hint september 14": the longer query files its results
+    # under the bare unigram too, and under score_terms="all" they carry the rank
+    # Wikipedia gave them for the whole query. term_coverage then answers the short query
+    # from them. With "specific" the unigram copy carries no score and it does not.
+    document = Document("Connections", "https://en.wikipedia.org/wiki/Connections",
+                        "connections hint september puzzle", 3.0, RAW_QUERY,
+                        state=DocumentState.FROM_WIKI)
+    stored = index_results_against_query(
+        [document], "connections hint september", index_path,
+        state=DocumentState.FROM_WIKI, score_terms="specific")
+    assert stored == 1
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        retrieved = indexer.retrieve("connections")
+    assert retrieved, "the unigram copy is still stored - it just has no score"
+    assert all(document.score is None for document in retrieved)
+
+    assert not have_enough_wiki_results("connections", retrieved, identity_rank,
+                                        gate="bigram_coverage", threshold=1.0)
+
+
+def test_term_coverage_cannot_fire_for_a_multi_token_query_under_specific_scoring():
+    # The reason bigram_coverage exists. "specific" leaves unigram copies unscored, and
+    # term_coverage reads an unscored term as uncovered, so every multi-token query is
+    # permanently below full coverage however much the index holds. Pinning it here so the
+    # combination cannot be shipped by accident - see WIKI_INDEX_SCORE_TERMS.
+    fully_stored = [stored_under("bitcoin blockchain", "Bitcoin blockchain"),
+                    Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "e",
+                             None, "bitcoin", state=DocumentState.FROM_WIKI),
+                    Document("Blockchain", "https://en.wikipedia.org/wiki/Blockchain", "e",
+                             None, "blockchain", state=DocumentState.FROM_WIKI)]
+
+    assert not have_enough_wiki_results("bitcoin blockchain", fully_stored, identity_rank,
+                                        gate="term_coverage", threshold=1.0)
+    assert have_enough_wiki_results("bitcoin blockchain", fully_stored, identity_rank,
+                                    gate="bigram_coverage", threshold=1.0)
+
+
+def test_the_two_denominators_agree_when_every_term_is_scored(index_path):
+    # Under score_terms="all" the denominator change is a no-op, and not by coincidence: a
+    # document only takes a term whose words it all contains, so a copy filed under the
+    # bigram "a b" is filed under "a" and "b" in the same write. "Every bigram covered" and
+    # "every term covered" are the same condition. Any measured difference between the two
+    # gates therefore comes from the score policy, never from the denominator.
+    document = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin",
+                        "bitcoin is a blockchain ledger", 3.0, RAW_QUERY,
+                        state=DocumentState.FROM_WIKI)
+    index_results_against_query([document], "bitcoin blockchain ledger", index_path,
+                                state=DocumentState.FROM_WIKI, score_terms="all")
+
+    query = "bitcoin blockchain ledger"
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        retrieved = [d for term in query_terms(query) for d in indexer.retrieve(term)]
+
+    for threshold in (0.5, 1.0):
+        assert (have_enough_wiki_results(query, retrieved, identity_rank,
+                                         gate="term_coverage", threshold=threshold)
+                == have_enough_wiki_results(query, retrieved, identity_rank,
+                                            gate="bigram_coverage", threshold=threshold))
 
 
 def test_value_gates_do_not_rank():

--- a/test/test_wiki_index_cache.py
+++ b/test/test_wiki_index_cache.py
@@ -420,47 +420,102 @@ def _hold_page_lock(index_path: str, page: int, acquired, release):
             release.wait(timeout=30)
 
 
+def _try_lock_in_child(index_path: str, page: int, queue):
+    """Child process: report whether the page lock is free."""
+    from mwmbl.tinysearchengine.indexer import F_OFD_SETLKW, _FLOCK_STRUCT
+    import struct
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        start = page * indexer.page_size + METADATA_SIZE
+        try:
+            fcntl.fcntl(indexer.index_file.fileno(), F_OFD_SETLKW - 1,  # F_OFD_SETLK
+                        struct.pack(_FLOCK_STRUCT, fcntl.F_WRLCK, os.SEEK_SET,
+                                    start, indexer.page_size, 0))
+            queue.put(True)
+        except OSError:
+            queue.put(False)
+
+
 def test_locked_page_excludes_another_process(index_path):
     """The page lock must exclude across processes, which is the only case that matters.
 
     Storing a page is read-merge-write with no atomicity. _write_page copies ~4 KB into the
     mmap; a reader catching it half-written gets a ZstdError, which _get_page_tuples turns
     into an empty page - so an unlocked writer can read empty, merge, and store its own
-    documents over everything else on that page. That is permanent loss, and the wiki index
-    cache writes from the request path in every gunicorn worker.
+    documents over everything else on that page.
 
     This asserts the exclusion property directly rather than trying to win the race: the
     window is a single memcpy, so a racing test passes with the lock removed and guards
-    nothing. POSIX record locks are per-process, so the holder has to be a real child.
+    nothing.
     """
     import multiprocessing
 
     context = multiprocessing.get_context("fork")
-    acquired, release = context.Event(), context.Event()
     with TinyIndex(Document, index_path, 'r') as indexer:
         page = indexer.get_key_page_index("zebra")
 
-    holder = context.Process(target=_hold_page_lock, args=(index_path, page, acquired, release))
-    holder.start()
-    try:
-        assert acquired.wait(timeout=30), "the child never took the lock"
+    def child_can_lock():
+        queue = context.Queue()
+        child = context.Process(target=_try_lock_in_child, args=(index_path, page, queue))
+        child.start()
+        child.join(timeout=30)
+        return queue.get(timeout=5)
 
-        with TinyIndex(Document, index_path, 'w') as indexer:
-            start = page * indexer.page_size + METADATA_SIZE
-            with pytest.raises(BlockingIOError):
-                fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB,
-                            indexer.page_size, start, os.SEEK_SET)
-    finally:
-        release.set()
-        holder.join(timeout=30)
-
-    # Released once the holder is done, so the next writer gets through.
     with TinyIndex(Document, index_path, 'w') as indexer:
-        start = page * indexer.page_size + METADATA_SIZE
-        fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB,
-                    indexer.page_size, start, os.SEEK_SET)
-        fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_UN,
-                    indexer.page_size, start, os.SEEK_SET)
+        with indexer.locked_page(page):
+            assert not child_can_lock(), "another process took a lock we were holding"
+
+            # An ordinary POSIX record lock is owned by the *process* and is dropped the
+            # moment any fd on the file is closed - and index_results_against_query opens
+            # and closes a read handle on every store, so in a threaded worker that would
+            # silently release the lock mid-write. OFD locks are owned by the open file
+            # description and survive it.
+            with TinyIndex(Document, index_path, 'r'):
+                pass
+            assert not child_can_lock(), \
+                "closing an unrelated fd released the lock - this needs an OFD lock"
+
+        assert child_can_lock(), "the lock was not released"
+
+
+def test_locked_page_does_not_serialise_different_pages(index_path):
+    """Per-page granularity: writers of unrelated pages must not block each other."""
+    import multiprocessing
+
+    context = multiprocessing.get_context("fork")
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        page = indexer.get_key_page_index("zebra")
+        other_page = (page + 1) % indexer.num_pages
+
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        with indexer.locked_page(page):
+            queue = context.Queue()
+            child = context.Process(target=_try_lock_in_child,
+                                    args=(index_path, other_page, queue))
+            child.start()
+            child.join(timeout=30)
+            assert queue.get(timeout=5), "a different page was blocked"
+
+
+def test_writes_continue_when_page_locking_is_unsupported(index_path, monkeypatch):
+    """A filesystem without record locks must not break indexing.
+
+    Every path through index_pages ran with no lock at all before this existed, so an
+    environment that cannot lock should degrade to that, not fail.
+    """
+    from mwmbl.tinysearchengine import indexer as indexer_module
+
+    monkeypatch.setattr(indexer_module, "_page_locking_supported", True)
+    monkeypatch.setattr(indexer_module, "_set_page_lock",
+                        lambda *args: (_ for _ in ()).throw(OSError("no locks available")))
+
+    document = Document("Zebra", "https://en.wikipedia.org/wiki/Zebra", "", 3.0, None,
+                        state=DocumentState.FROM_WIKI)
+    assert index_results_against_query([document], "zebra", index_path,
+                                       state=DocumentState.FROM_WIKI) == 1
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert {d.url for d in indexer.retrieve("zebra")} == {document.url}
+    assert indexer_module._page_locking_supported is False
 
 
 def test_locked_page_needs_write_mode(index_path):

--- a/test/test_wiki_index_cache.py
+++ b/test/test_wiki_index_cache.py
@@ -1,0 +1,501 @@
+"""Wikipedia results served from the index instead of the API.
+
+Covers the gate (when a search may skip the Wikipedia call), the privacy rules on what a
+stored result may be filed under, and the OverlayIndex the evaluation reads through.
+"""
+import fcntl
+import os
+from io import UnsupportedOperation
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import override_settings
+
+from mwmbl.indexer.index_batches import index_results_against_query
+from mwmbl.tinysearchengine.indexer import METADATA_SIZE, Document, DocumentState, TinyIndex
+from mwmbl.tinysearchengine.ltr_rank import LTRRanker
+from mwmbl.tinysearchengine.rank import HeuristicRanker
+from mwmbl.tinysearchengine.wiki_index_cache import (
+    count_stored_wiki_results, count_wiki_results, have_enough_wiki_results, per_term_best,
+    query_terms, store_wiki_results, wiki_documents_by_term,
+)
+from mwmbl.tokenizer import get_bigrams, tokenize
+
+
+NUM_PAGES = 64
+RAW_QUERY = "sensitive personal question about someone"
+
+
+def wiki_doc(title: str, extract: str = "", state=DocumentState.FROM_WIKI, term=RAW_QUERY):
+    """A result shaped exactly like get_wiki_results returns: term is the *raw* query."""
+    return Document(title, f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}",
+                    extract, 3.0, term, state=state)
+
+
+def other_doc(title: str, url: str):
+    return Document(title, url, "extract", 1.0, "term")
+
+
+def identity_rank(documents):
+    return documents
+
+
+@pytest.fixture
+def index_path():
+    with TemporaryDirectory() as temp_dir:
+        path = str(Path(temp_dir) / "temp-index.tinysearch")
+        with TinyIndex.create(Document, path, num_pages=NUM_PAGES, page_size=4096):
+            pass
+        yield path
+
+
+# ---------------------------------------------------------------------------
+# Counting
+# ---------------------------------------------------------------------------
+
+def test_count_wiki_results_counts_by_domain():
+    documents = [wiki_doc("Bitcoin"), other_doc("Bitcoin", "https://bitcoin.org/"),
+                 wiki_doc("Blockchain")]
+    assert count_wiki_results(documents) == 2
+
+
+def test_count_stored_wiki_results_ignores_organically_crawled_wiki_pages():
+    crawled = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "e", 1.0, "bitcoin")
+    assert crawled.state is None
+    documents = [crawled, wiki_doc("Blockchain")]
+
+    assert count_wiki_results(documents) == 2
+    assert count_stored_wiki_results(documents) == 1
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("gate", ["raw_candidates", "ranked_top_n", "from_wiki_only"])
+def test_gate_fires_at_or_above_threshold(gate):
+    documents = [wiki_doc("Bitcoin"), wiki_doc("Blockchain")]
+
+    assert have_enough_wiki_results("bitcoin", documents, identity_rank, gate=gate, threshold=2, top_n=10)
+    assert have_enough_wiki_results("bitcoin", documents, identity_rank, gate=gate, threshold=1, top_n=10)
+    assert not have_enough_wiki_results("bitcoin", documents, identity_rank, gate=gate, threshold=3, top_n=10)
+
+
+def test_gate_does_not_fire_on_an_empty_index_result():
+    assert not have_enough_wiki_results("bitcoin", [], identity_rank, gate="ranked_top_n",
+                                        threshold=1, top_n=10)
+
+
+def test_ranked_top_n_gate_ignores_wiki_results_below_the_cut():
+    # The wiki result is ranked 11th, so a top-10 gate must not count it - the user
+    # would never see it, and skipping the call on its account loses a real result.
+    documents = [other_doc(f"t{i}", f"https://e{i}.example/") for i in range(10)]
+    documents.append(wiki_doc("Bitcoin"))
+
+    assert not have_enough_wiki_results("bitcoin", documents, identity_rank, gate="ranked_top_n",
+                                        threshold=1, top_n=10)
+    assert have_enough_wiki_results("bitcoin", documents, identity_rank, gate="raw_candidates",
+                                    threshold=1, top_n=10)
+
+
+def test_from_wiki_only_gate_does_not_count_crawled_wiki_pages():
+    crawled = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "e", 1.0, "bitcoin")
+
+    assert have_enough_wiki_results("bitcoin", [crawled], identity_rank, gate="ranked_top_n",
+                                    threshold=1, top_n=10)
+    assert not have_enough_wiki_results("bitcoin", [crawled], identity_rank, gate="from_wiki_only",
+                                        threshold=1, top_n=10)
+
+
+def test_never_and_always_gates():
+    documents = [wiki_doc("Bitcoin")] * 5
+    assert not have_enough_wiki_results("bitcoin", documents, identity_rank, gate="never", threshold=1)
+    assert have_enough_wiki_results("bitcoin", [], identity_rank, gate="always", threshold=99)
+
+
+def test_unknown_gate_is_an_error():
+    with pytest.raises(ValueError):
+        have_enough_wiki_results("bitcoin", [], identity_rank, gate="nonsense", threshold=1)
+
+
+def test_gate_does_not_rank_when_it_does_not_need_to():
+    # Ranking is the only part of the gate that costs anything, so the cheap gate must
+    # not pay for it.
+    rank = MagicMock(side_effect=identity_rank)
+    have_enough_wiki_results("bitcoin", [wiki_doc("Bitcoin")], rank, gate="raw_candidates",
+                             threshold=1)
+    rank.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Privacy: what may be written under a query-derived term
+# ---------------------------------------------------------------------------
+
+def stored_terms(index_path: str) -> set[str]:
+    terms = set()
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        for page in range(NUM_PAGES):
+            terms |= {document.term for document in indexer.get_page(page)}
+    return terms
+
+
+def test_raw_query_is_never_written_to_the_index(index_path):
+    # get_wiki_results stamps every result's `term` with the raw, untokenized query. If a
+    # write path ever persisted that field as-is, the user's query would land on disk -
+    # exactly what removing the filesystem HTTP cache was for. The failure is silent, so
+    # it needs its own test.
+    documents = [wiki_doc("Someone", extract=RAW_QUERY)]
+    assert documents[0].term == RAW_QUERY
+
+    with override_settings(WIKI_INDEX_MAX_TERM_TOKENS=2, WIKI_INDEX_REQUIRE_EXISTING_TERM=False):
+        store_wiki_results(RAW_QUERY, documents, index_path)
+
+    terms = stored_terms(index_path)
+    assert terms, "nothing was stored, so the test proves nothing"
+    assert RAW_QUERY not in terms
+
+
+def test_stored_terms_are_short_and_contained_in_the_document(index_path):
+    query = "bitcoin blockchain ledger"
+    document = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin",
+                        "A blockchain ledger", 3.0, query, state=DocumentState.FROM_WIKI)
+
+    with override_settings(WIKI_INDEX_MAX_TERM_TOKENS=2, WIKI_INDEX_REQUIRE_EXISTING_TERM=False):
+        store_wiki_results(query, [document], index_path)
+
+    document_words = set(tokenize(document.title)) | set(tokenize(document.extract))
+    for term in stored_terms(index_path):
+        assert len(term.split()) <= 2, f"{term!r} is longer than the token cap"
+        assert set(term.split()) <= document_words, f"{term!r} is not contained in the document"
+
+
+def test_max_term_tokens_excludes_bigrams(index_path):
+    query = "bitcoin blockchain"
+    document = Document("Bitcoin blockchain", "https://en.wikipedia.org/wiki/Bitcoin",
+                        "", 3.0, query, state=DocumentState.FROM_WIKI)
+
+    index_results_against_query([document], query, index_path, max_term_tokens=1)
+
+    assert "bitcoin blockchain" in get_bigrams(2, tokenize(query))
+    assert stored_terms(index_path) == {"bitcoin", "blockchain"}
+
+
+def test_require_existing_term_only_writes_terms_the_index_already_has(index_path):
+    # "bitcoin" is a word the corpus already contains; "oxyphenbutazone" is not, so under
+    # the strict predicate nothing about it may be written.
+    existing = Document("Bitcoin explained", "https://bitcoin.org/", "e", 1.0, "bitcoin")
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        indexer.store_in_page(indexer.get_key_page_index("bitcoin"), [existing])
+
+    document = Document("Bitcoin oxyphenbutazone", "https://en.wikipedia.org/wiki/Bitcoin",
+                        "", 3.0, None, state=DocumentState.FROM_WIKI)
+    index_results_against_query([document], "bitcoin oxyphenbutazone", index_path,
+                                max_term_tokens=2, require_existing_term=True)
+
+    stored = stored_terms(index_path)
+    assert "bitcoin" in stored
+    assert "oxyphenbutazone" not in stored
+    assert "bitcoin oxyphenbutazone" not in stored
+
+
+def test_store_wiki_results_never_raises(index_path):
+    assert store_wiki_results("query", [wiki_doc("Bitcoin")], "/no/such/index") == 0
+
+
+# ---------------------------------------------------------------------------
+# Automatically stored wiki results are not curation
+# ---------------------------------------------------------------------------
+
+def test_stored_wiki_results_are_not_treated_as_curated(index_path):
+    # A one-word query's stored results land under exactly the curation term. Treating a
+    # non-None state as curation would pin them above everything with ranking skipped.
+    term = "bitcoin"
+    stored = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "money", 3.0,
+                      term, state=DocumentState.FROM_WIKI)
+    curated = Document("Bitcoin org", "https://bitcoin.org/", "money", 3.0, term,
+                       state=DocumentState.FROM_WIKI_APPROVED)
+
+    tiny_index = MagicMock()
+    tiny_index.retrieve.return_value = [stored, curated]
+    completer = MagicMock()
+    completer.complete.return_value = []
+
+    ranker = HeuristicRanker(tiny_index, completer)
+    results, _, _ = ranker.get_results(term, [], use_external_search=False)
+
+    assert results[0].url == curated.url, "curated results still come first"
+    # The automatically stored one is present, but as an ordinary ranked candidate.
+    assert stored.url in {result.url for result in results}
+
+
+# ---------------------------------------------------------------------------
+# LTRRanker wiring
+# ---------------------------------------------------------------------------
+
+class _RecordingRanker(LTRRanker):
+    """LTRRanker with the Wikipedia fetch and the index write recorded, not performed."""
+
+    def __init__(self, index_results):
+        tiny_index = MagicMock()
+        tiny_index.retrieve.return_value = []
+        completer = MagicMock()
+        completer.complete.return_value = []
+        self.fetched = []
+        self.written = []
+        super().__init__(
+            tiny_index, completer, model=MagicMock(),
+            wiki_fetcher=self._fetch, wiki_store=self._store, wiki_index_path="/unused",
+        )
+        self.index_results = index_results
+
+    def _fetch(self, query, num_results):
+        self.fetched.append(query)
+        return [wiki_doc("Bitcoin")]
+
+    def _store(self, query, documents, index_path):
+        self.written.append((query, documents))
+        return len(documents)
+
+    def order_results(self, terms, results, is_complete):
+        return results
+
+
+def test_cache_disabled_always_calls_wikipedia_and_writes_nothing():
+    ranker = _RecordingRanker([wiki_doc("Bitcoin")] * 5)
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=False):
+        ranker.external_search("bitcoin", ranker.index_results)
+
+    assert ranker.fetched == ["bitcoin"]
+    assert ranker.written == []
+
+
+def test_gate_suppresses_the_call_when_the_index_already_has_wiki_results():
+    ranker = _RecordingRanker([wiki_doc("Bitcoin"), wiki_doc("Blockchain")])
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=True, WIKI_INDEX_GATE="ranked_top_n",
+                           WIKI_INDEX_GATE_THRESHOLD=2, WIKI_INDEX_GATE_TOP_N=10):
+        results = ranker.external_search("bitcoin", ranker.index_results)
+
+    assert ranker.fetched == []
+    assert results == []
+
+
+def test_a_miss_fetches_and_writes_the_results_back():
+    ranker = _RecordingRanker([])
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=True, WIKI_INDEX_GATE="ranked_top_n",
+                           WIKI_INDEX_GATE_THRESHOLD=2, WIKI_INDEX_GATE_TOP_N=10):
+        results = ranker.external_search("bitcoin", ranker.index_results)
+
+    assert ranker.fetched == ["bitcoin"]
+    assert [query for query, _ in ranker.written] == ["bitcoin"]
+    assert len(results) == 1
+
+
+def test_include_wiki_off_never_calls_or_writes():
+    ranker = _RecordingRanker([])
+    ranker.include_wiki = False
+    with override_settings(WIKI_INDEX_CACHE_ENABLED=True):
+        assert ranker.external_search("bitcoin", ranker.index_results) == []
+    assert ranker.fetched == []
+    assert ranker.written == []
+
+
+# ---------------------------------------------------------------------------
+# What the stored copies look like
+# ---------------------------------------------------------------------------
+
+def stored_documents(index_path: str) -> list[Document]:
+    documents = []
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        for page in range(NUM_PAGES):
+            documents += indexer.get_page(page)
+    return documents
+
+
+def test_stored_results_keep_the_from_wiki_state(index_path):
+    # Without the state the result cannot be shown with source `wikipedia`, and the
+    # from_wiki_only gate - which counts exactly these - can never fire.
+    document = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "", 3.0,
+                        "bitcoin", state=DocumentState.FROM_WIKI)
+
+    store_wiki_results("bitcoin", [document], index_path)
+
+    stored = stored_documents(index_path)
+    assert stored
+    assert all(d.state == DocumentState.FROM_WIKI for d in stored)
+
+
+def test_term_exists_override_decides_which_terms_may_be_written(index_path):
+    # The corpus a caller means need not be the index it writes to: the evaluation reads
+    # through an overlay and has to answer for both halves.
+    document = Document("Bitcoin oxyphenbutazone", "https://en.wikipedia.org/wiki/Bitcoin",
+                        "", 3.0, None, state=DocumentState.FROM_WIKI)
+
+    with override_settings(WIKI_INDEX_REQUIRE_EXISTING_TERM=True, WIKI_INDEX_MAX_TERM_TOKENS=2):
+        store_wiki_results("bitcoin oxyphenbutazone", [document], index_path,
+                           term_exists=lambda term: term == "oxyphenbutazone")
+
+    assert stored_terms(index_path) == {"oxyphenbutazone"}
+
+
+# ---------------------------------------------------------------------------
+# Per-term score-profile gates
+# ---------------------------------------------------------------------------
+
+def constant_score(value: float):
+    return lambda documents: [value] * len(documents)
+
+
+def stored_under(term: str, title: str = "Bitcoin"):
+    document = wiki_doc(title)
+    return Document(document.title, document.url, document.extract, 3.0, term,
+                    state=DocumentState.FROM_WIKI)
+
+
+def test_query_terms_are_unigrams_and_bigrams():
+    assert query_terms("bitcoin blockchain ledger") == [
+        "bitcoin", "blockchain", "ledger", "bitcoin blockchain", "blockchain ledger"]
+
+
+def test_terms_with_no_wiki_results_count_as_zero():
+    # A term the index cannot answer is the whole signal a breadth gate needs, so it has to
+    # stay in the denominator rather than being dropped from the average.
+    by_term = wiki_documents_by_term("bitcoin blockchain", [stored_under("bitcoin")])
+
+    assert set(by_term) == {"bitcoin", "blockchain", "bitcoin blockchain"}
+    assert per_term_best(by_term, constant_score(1.0)) == [1.0, 0.0, 0.0]
+
+
+def test_wiki_documents_by_term_ignores_crawled_wiki_pages_by_default():
+    crawled = Document("Bitcoin", "https://en.wikipedia.org/wiki/Bitcoin", "e", 1.0, "bitcoin")
+    by_term = wiki_documents_by_term("bitcoin", [crawled])
+    assert by_term["bitcoin"] == []
+    assert wiki_documents_by_term("bitcoin", [crawled], stored_only=False)["bitcoin"] == [crawled]
+
+
+def test_mean_max_gate_averages_over_every_query_term():
+    # One of three terms answered at score 0.9 -> mean 0.3.
+    documents = [stored_under("bitcoin")]
+    assert have_enough_wiki_results("bitcoin blockchain", documents, identity_rank,
+                                    constant_score(0.9), gate="mean_max_ltr", threshold=0.3)
+    assert not have_enough_wiki_results("bitcoin blockchain", documents, identity_rank,
+                                        constant_score(0.9), gate="mean_max_ltr", threshold=0.31)
+
+
+def test_min_max_gate_needs_every_term_answered():
+    both = [stored_under("bitcoin"), stored_under("blockchain", "Blockchain"),
+            stored_under("bitcoin blockchain", "Bitcoin blockchain")]
+    assert have_enough_wiki_results("bitcoin blockchain", both, identity_rank,
+                                    constant_score(0.5), gate="min_max_ltr", threshold=0.5)
+    assert not have_enough_wiki_results("bitcoin blockchain", both[:1], identity_rank,
+                                        constant_score(0.5), gate="min_max_ltr", threshold=0.5)
+
+
+def test_term_coverage_gate_is_a_fraction_of_terms():
+    documents = [stored_under("bitcoin")]
+    assert have_enough_wiki_results("bitcoin blockchain", documents, identity_rank,
+                                    gate="term_coverage", threshold=1 / 3)
+    assert not have_enough_wiki_results("bitcoin blockchain", documents, identity_rank,
+                                        gate="term_coverage", threshold=0.5)
+
+
+def test_value_gates_do_not_rank():
+    # Ranking is what the counting gates pay for; a per-term profile does not need an order.
+    rank = MagicMock(side_effect=identity_rank)
+    have_enough_wiki_results("bitcoin", [stored_under("bitcoin")], rank,
+                             constant_score(1.0), gate="mean_max_ltr", threshold=0.5)
+    rank.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writes from the request path
+# ---------------------------------------------------------------------------
+
+def _hold_page_lock(index_path: str, page: int, acquired, release):
+    """Child process: take the page lock, say so, and hold it until told to let go."""
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        with indexer.locked_page(page):
+            acquired.set()
+            release.wait(timeout=30)
+
+
+def test_locked_page_excludes_another_process(index_path):
+    """The page lock must exclude across processes, which is the only case that matters.
+
+    Storing a page is read-merge-write with no atomicity. _write_page copies ~4 KB into the
+    mmap; a reader catching it half-written gets a ZstdError, which _get_page_tuples turns
+    into an empty page - so an unlocked writer can read empty, merge, and store its own
+    documents over everything else on that page. That is permanent loss, and the wiki index
+    cache writes from the request path in every gunicorn worker.
+
+    This asserts the exclusion property directly rather than trying to win the race: the
+    window is a single memcpy, so a racing test passes with the lock removed and guards
+    nothing. POSIX record locks are per-process, so the holder has to be a real child.
+    """
+    import multiprocessing
+
+    context = multiprocessing.get_context("fork")
+    acquired, release = context.Event(), context.Event()
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        page = indexer.get_key_page_index("zebra")
+
+    holder = context.Process(target=_hold_page_lock, args=(index_path, page, acquired, release))
+    holder.start()
+    try:
+        assert acquired.wait(timeout=30), "the child never took the lock"
+
+        with TinyIndex(Document, index_path, 'w') as indexer:
+            start = page * indexer.page_size + METADATA_SIZE
+            with pytest.raises(BlockingIOError):
+                fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB,
+                            indexer.page_size, start, os.SEEK_SET)
+    finally:
+        release.set()
+        holder.join(timeout=30)
+
+    # Released once the holder is done, so the next writer gets through.
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        start = page * indexer.page_size + METADATA_SIZE
+        fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    indexer.page_size, start, os.SEEK_SET)
+        fcntl.lockf(indexer.index_file.fileno(), fcntl.LOCK_UN,
+                    indexer.page_size, start, os.SEEK_SET)
+
+
+def test_locked_page_needs_write_mode(index_path):
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        with pytest.raises(UnsupportedOperation):
+            with indexer.locked_page(0):
+                pass
+
+
+def _store_repeatedly(index_path: str, term: str, url_prefix: str, count: int):
+    """Child-process worker: store documents under `term`, over and over."""
+    for i in range(count):
+        # The title has to contain the term, or the containment rule stores nothing.
+        index_results_against_query(
+            [Document(f"Zebra {url_prefix} {i}", f"https://example.com/{url_prefix}/{i}", "",
+                      3.0, None, state=DocumentState.FROM_WIKI)],
+            term, index_path, state=DocumentState.FROM_WIKI)
+
+
+def test_concurrent_writers_leave_the_page_readable(index_path):
+    """Smoke test: four processes hammering one page leave it decodable, not empty."""
+    import multiprocessing
+
+    context = multiprocessing.get_context("fork")
+    workers = [context.Process(target=_store_repeatedly,
+                               args=(index_path, "zebra", f"w{n}", 30))
+               for n in range(4)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=60)
+        assert worker.exitcode == 0
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        page = indexer.get_page(indexer.get_key_page_index("zebra"))
+
+    assert page, "the page was left empty"
+    assert all(document.title and document.url for document in page)

--- a/test/test_wiki_index_cache.py
+++ b/test/test_wiki_index_cache.py
@@ -412,14 +412,6 @@ def test_value_gates_do_not_rank():
 # Concurrent writes from the request path
 # ---------------------------------------------------------------------------
 
-def _hold_page_lock(index_path: str, page: int, acquired, release):
-    """Child process: take the page lock, say so, and hold it until told to let go."""
-    with TinyIndex(Document, index_path, 'w') as indexer:
-        with indexer.locked_page(page):
-            acquired.set()
-            release.wait(timeout=30)
-
-
 def _try_lock_in_child(index_path: str, page: int, queue):
     """Child process: report whether the page lock is free."""
     from mwmbl.tinysearchengine.indexer import F_OFD_SETLKW, _FLOCK_STRUCT
@@ -435,15 +427,15 @@ def _try_lock_in_child(index_path: str, page: int, queue):
             queue.put(False)
 
 
-def test_locked_page_excludes_another_process(index_path):
-    """The page lock must exclude across processes, which is the only case that matters.
+def test_update_page_holds_the_lock_across_the_read_and_the_write(index_path):
+    """Changing a page must be atomic, and callers must not have to arrange that.
 
-    Storing a page is read-merge-write with no atomicity. _write_page copies ~4 KB into the
-    mmap; a reader catching it half-written gets a ZstdError, which _get_page_tuples turns
-    into an empty page - so an unlocked writer can read empty, merge, and store its own
-    documents over everything else on that page.
+    _write_page copies ~4 KB into the mmap; a reader catching it half-written gets a
+    ZstdError, which _get_page_tuples turns into an empty page - so a writer that reads
+    empty, merges and stores wipes out everything else on that page. update_page owns the
+    whole read-merge-write, so this checks the lock is held for the duration of `merge`.
 
-    This asserts the exclusion property directly rather than trying to win the race: the
+    It asserts the exclusion property directly rather than trying to win the race: the
     window is a single memcpy, so a racing test passes with the lock removed and guards
     nothing.
     """
@@ -453,47 +445,58 @@ def test_locked_page_excludes_another_process(index_path):
     with TinyIndex(Document, index_path, 'r') as indexer:
         page = indexer.get_key_page_index("zebra")
 
-    def child_can_lock():
+    def child_can_lock(target_page=page):
         queue = context.Queue()
-        child = context.Process(target=_try_lock_in_child, args=(index_path, page, queue))
+        child = context.Process(target=_try_lock_in_child, args=(index_path, target_page, queue))
         child.start()
         child.join(timeout=30)
         return queue.get(timeout=5)
 
+    observed = {}
+
+    def merge(existing):
+        observed["locked_during_merge"] = not child_can_lock()
+
+        # An ordinary POSIX record lock is owned by the *process* and is dropped the moment
+        # any fd on the file is closed - and index_results_against_query opens and closes a
+        # read handle on every store, so in a threaded worker that would silently release
+        # the lock mid-write. OFD locks survive it.
+        with TinyIndex(Document, index_path, 'r'):
+            pass
+        observed["locked_after_unrelated_close"] = not child_can_lock()
+
+        # A different page must not contend.
+        observed["other_page_free"] = child_can_lock((page + 1) % 64)
+        return None
+
     with TinyIndex(Document, index_path, 'w') as indexer:
-        with indexer.locked_page(page):
-            assert not child_can_lock(), "another process took a lock we were holding"
+        indexer.update_page(page, merge)
 
-            # An ordinary POSIX record lock is owned by the *process* and is dropped the
-            # moment any fd on the file is closed - and index_results_against_query opens
-            # and closes a read handle on every store, so in a threaded worker that would
-            # silently release the lock mid-write. OFD locks are owned by the open file
-            # description and survive it.
-            with TinyIndex(Document, index_path, 'r'):
-                pass
-            assert not child_can_lock(), \
-                "closing an unrelated fd released the lock - this needs an OFD lock"
-
-        assert child_can_lock(), "the lock was not released"
+    assert observed["locked_during_merge"], "another process took a lock we were holding"
+    assert observed["locked_after_unrelated_close"], \
+        "closing an unrelated fd released the lock - this needs an OFD lock"
+    assert observed["other_page_free"], "a different page was blocked"
+    assert child_can_lock(), "the lock was not released"
 
 
-def test_locked_page_does_not_serialise_different_pages(index_path):
-    """Per-page granularity: writers of unrelated pages must not block each other."""
-    import multiprocessing
-
-    context = multiprocessing.get_context("fork")
-    with TinyIndex(Document, index_path, 'r') as indexer:
+def test_update_page_writes_nothing_when_merge_returns_none(index_path):
+    seeded = [Document("Zebra", "https://en.wikipedia.org/wiki/Zebra", "", 3.0, "zebra",
+                       state=DocumentState.FROM_WIKI)]
+    with TinyIndex(Document, index_path, 'w') as indexer:
         page = indexer.get_key_page_index("zebra")
-        other_page = (page + 1) % indexer.num_pages
+        indexer.store_in_page(page, seeded)
 
-    with TinyIndex(Document, index_path, 'w') as indexer:
-        with indexer.locked_page(page):
-            queue = context.Queue()
-            child = context.Process(target=_try_lock_in_child,
-                                    args=(index_path, other_page, queue))
-            child.start()
-            child.join(timeout=30)
-            assert queue.get(timeout=5), "a different page was blocked"
+        unchanged = indexer.update_page(page, lambda existing: None)
+        assert [d.url for d in unchanged] == [seeded[0].url]
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert [d.url for d in indexer.get_page(page)] == [seeded[0].url]
+
+
+def test_update_page_needs_write_mode(index_path):
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        with pytest.raises(UnsupportedOperation):
+            indexer.update_page(0, lambda existing: existing)
 
 
 def test_writes_continue_when_page_locking_is_unsupported(index_path, monkeypatch):
@@ -516,13 +519,6 @@ def test_writes_continue_when_page_locking_is_unsupported(index_path, monkeypatc
     with TinyIndex(Document, index_path, 'r') as indexer:
         assert {d.url for d in indexer.retrieve("zebra")} == {document.url}
     assert indexer_module._page_locking_supported is False
-
-
-def test_locked_page_needs_write_mode(index_path):
-    with TinyIndex(Document, index_path, 'r') as indexer:
-        with pytest.raises(UnsupportedOperation):
-            with indexer.locked_page(0):
-                pass
 
 
 def _store_repeatedly(index_path: str, term: str, url_prefix: str, count: int):


### PR DESCRIPTION
Two related pieces of work. The **index-safety half is the part I'd argue for merging**;
the Wikipedia caching half is behind a flag that I do **not** recommend turning on yet, for
reasons the evaluation makes clear below.

`WIKI_INDEX_CACHE_ENABLED` defaults to `false`. While it is off, `get_wiki_results` keeps
using the existing disk cache, so nothing about today's behaviour changes on merge.

---

# Part 1 — Index page writes are not safe, and weren't before this PR

Changing a page is read → merge → write. `_write_page` copies ~4 KB into an mmap, and a
reader catching it half-written gets a page that will not decompress. `_get_page_tuples`
caught that `ZstdError` and returned `[]` — **indistinguishable from a page with no
documents**. A writer then merged onto nothing and stored the result over everything else
on that page. Permanent loss in a 400 GB index.

Demonstrated by zeroing 64 bytes mid-page:

```
before:                    5 documents
after partial overwrite:   0 documents   <- a writer would merge onto THIS
```

This predates the PR — `POST /crawler/results`, curation, Super Search and batch indexing
all do in-request read-modify-writes today. Wikipedia caching is what would make it likely
rather than theoretical.

### Fixes

**One way to change a page, already correct.** `TinyIndex.page(i)` owns the whole
read-modify-write under a page lock, so no caller has to know locking exists:

```python
with index.page(page_index) as page:
    page.store(merge(page.documents))
```

It is `store()` rather than assigning to `documents` because a page holds a fixed number of
bytes and drops the tail that does not fit — what you pass is not what is kept. `store()`
now **returns how many actually fit** (`_get_page_data` already computed this and discarded
it), so truncation is logged instead of silent:

```
Storing 38 of 42 documents for page 824, originally 39
```

Converted every read-modify-write site: `index_pages`, `purge_documents`, `_save_to_index`,
`_revert_curation` — three of which were racing and had no lock at all.

**Open File Description locks, not `lockf`.** POSIX record locks are owned by the *process*
and are dropped when *any* fd on the file is closed — and `index_results_against_query`
opens and closes a read handle on every store, so in a threaded worker the lock would be
released mid-write:

```
1. while holding the lock, nothing else touched:   blocked (lock held correctly)
2. after another fd on the same file was closed:   ACQUIRED (lock was NOT held)
```

`F_OFD_SETLKW` locks are owned by the open file description, survive that, and keep
byte-range granularity so different pages still don't contend. The test fails against the
old implementation.

**Corruption raises instead of looking empty.** `_get_page_tuples` now raises `PageError`.
`retrieve()` catches it and returns `[]`, so search degrades exactly as before — one
unreadable page costs one query the results for one term. Writers propagate and abort
rather than wipe. This is what makes the *degraded* path safe: where locking is
unsupported, a writer refuses instead of destroying.

Raising is **not** a substitute for the lock. Unserialised writers can interleave their
memcpys into a page that is neither writer's image; the old `return []` repaired that on
the next write at the cost of its contents, whereas raising would leave it permanently
dead. Serialising writes is what stops that page existing.

Locking degrades to unlocked with one warning if the kernel or filesystem won't support it
— every indexing path ran with no lock before this existed, so turning that into a hard
failure of all of them would be a worse regression than the race.

### Pre-existing bugs also fixed

- `get_results` treated any non-`None` state under the curation term as curated, so stored
  results for a one-word query would have been pinned above everything with ranking skipped.
- `score_result` exempted any non-`None` state from the minimum-term-match rule.
- `index_results_against_query` dropped the incoming document's `score`. A live Wikipedia
  result carries its rank (3/2/1) and the LTR model reads `score` as a feature, so stored
  copies were handicapped against the identical result fetched live.

---

# Part 2 — Wikipedia results in the index (flag off, not recommended)

## Why

`get_wiki_results` cached through a *filesystem* `requests-cache` rooted at
`REQUEST_CACHE_PATH` — the same volume as the 400 GB index — with no LRU, no size cap and
nothing calling `delete(expired=True)`. 91,000 files / 4.5 GB on the dev box, the raw user
query written to disk inside the stored request URL, and a miss was still a blocking HTTP
round trip.

## What the evaluation actually found

The rule implemented is: skip the call only when **every** query unigram and bigram already
has a stored Wikipedia result. At 596 queries that scored +0.0000. **It did not replicate.**

| | 596 queries | 1,790 queries |
|---|---|---|
| overall Δ NDCG | +0.0000 | **−0.0054** |
| fired | 9 | 35 |
| Δ on fired subset | +0.0000 | **−0.1927** |

**No gate avoids calls without paying on the queries it fires on.** The overall figure stays
small only because it rarely acts. Every rule tried looked best at the sample size where it
fired least.

### It is an exact-query cache in disguise, and a lossy one

Tracing which earlier query stored the documents that let a later query skip its call:

- Of 797 firings on a repeat-weighted stream, **794 were the same query asked again; 3 were
  a different query.**
- On the gold set (no repeats) it fires on 7/596 = 1.2%. Six of seven are single-word
  queries whose word was stored by a longer query containing it — `connections` ←
  `connections hint september 14`, `jobs` ← `shunter jobs near me`.
- It catches only **794 of 1,597 repeats (49.7%)**. A repeat still needs *every* term
  covered, and bigrams usually aren't — 2-token queries account for 436 of the misses.

Cross-query matching won't scale: bigrams are the bottleneck and distinct bigrams grow
nearly linearly with volume. Gold-set fire rate by decile is flat noise.

### Storing is not free once the index is dense

`indexed-nogate` calls Wikipedia **every** time and still loses 0.0210 on the repeat stream,
raising wiki@10 from 1.24 → 1.31 and displacing non-wiki gold results. Invisible on the
sparse gold set (−0.0005); production density only increases.

## Recommendation

**Merge for Part 1; leave `WIKI_INDEX_CACHE_ENABLED` off.**

The gate should be replaced by a query-keyed cache (`b39e9f8`'s approach), which catches all
1,597 repeats rather than 794, cannot fire on the wrong query, and — because a hash-keyed
entry never enters the candidate pool for other queries — sidesteps the density problem
entirely.

## Evaluation harness

`mwmbl/rankeval/evaluation/evaluate_wiki_index.py`: an `OverlayIndex` (remote production
index unioned with a fresh local writable one, since the dev index is far too small for a
gate to mean anything), exact counting of the calls each policy would make while serving
responses from a joblib cache, and a repeat-weighted stream because the gold set has no
repeated queries.

```bash
DATABASE_URL="postgres://daoud@" DJANGO_SETTINGS_MODULE=mwmbl.settings_dev \
  uv run python -m mwmbl.rankeval.evaluation.evaluate_wiki_index --fraction 0.3 --zipf 2000
```

Full results and caveats in `mwmbl/rankeval/WIKI_INDEX_CACHE_FINDINGS.md`.

## Known limits

- **Eviction is not measured.** The overlay index starts empty; production pages are >90%
  full. `store()` now reports truncation, which is the first step toward measuring it.
- **Single seed, single ordering**, and the Zipf repeat distribution is a modelling
  assumption — your Search Console data would estimate the real repeat rate far better.
- **Latency**: storing costs ~1.2 ms per query term and only runs on a miss, where the API
  call already cost 100–500 ms. Measured on the dev index (fully page-cached); production is
  400 GB, though the pages written are the ones retrieval just read.
- **Fidelity gaps untested**: 3 results per entry vs many more live; the stored extract is
  the snippet Wikipedia chose *because* it matched that query; results are never filed under
  their own tokens the way a crawled page is.

559 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
