### PR TITLE
Set up Django before importing mwmbl modules in the crawler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Create test directories and files
         run: |
           mkdir -p /tmp/test_mwmbl_data
+      #----------------------------------------------
+      # The crawler container runs mwmbl-crawl with no DJANGO_SETTINGS_MODULE and no
+      # database - mwmbl.crawl configures Django itself. Import it with that environment
+      # (this step deliberately sets neither) so an import reaching Django models before
+      # django.setup() fails here rather than in the running container.
+      #----------------------------------------------
+      - name: Check the crawler entry point imports standalone
+        run: uv run python -c "from mwmbl.crawl import run"
       - name: Run tests
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_mwmbl

--- a/mwmbl/crawl.py
+++ b/mwmbl/crawl.py
@@ -11,17 +11,13 @@ import requests
 from django.conf import settings
 from redis import Redis
 
-from mwmbl.crawler.env_vars import CRAWLER_WORKERS, CRAWL_DELAY_SECONDS, MWMBL_API_KEY, MWMBL_CONTACT_INFO
-from mwmbl.rankeval.evaluation.remote_index import RemoteIndex
-from mwmbl.redis_url_queue import RedisURLQueue
-from mwmbl.tinysearchengine.indexer import TinyIndex, Document
-from mwmbl.tinysearchengine.rank import score_result
-from mwmbl.tokenizer import tokenize
-
 FORMAT = "%(process)d:%(levelname)s:%(name)s:%(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
+# The mwmbl imports below reach Django models, so the app registry has to be ready before
+# any of them run. The app registry creates the index on startup, so the data path has to
+# exist before that.
 os.environ["DJANGO_SETTINGS_MODULE"] = "mwmbl.settings_crawler"
 
 data_path = Path(settings.DATA_PATH)
@@ -32,10 +28,16 @@ print("Mwmbl crawling statistics: https://mwmbl.org/stats")
 
 django.setup()
 
-from mwmbl.indexer.update_urls import record_urls_in_database
-from mwmbl.crawler.retrieve import crawl_batch, crawl_url, CRAWLER_VERSION, USER_AGENT
 from mwmbl.crawler.batch import HashedBatch, Result, Results
+from mwmbl.crawler.env_vars import CRAWLER_WORKERS, CRAWL_DELAY_SECONDS, MWMBL_API_KEY, MWMBL_CONTACT_INFO
+from mwmbl.crawler.retrieve import crawl_batch, crawl_url, CRAWLER_VERSION, USER_AGENT
 from mwmbl.indexer.index_batches import index_batches, index_pages
+from mwmbl.indexer.update_urls import record_urls_in_database
+from mwmbl.rankeval.evaluation.remote_index import RemoteIndex
+from mwmbl.redis_url_queue import RedisURLQueue
+from mwmbl.tinysearchengine.indexer import TinyIndex, Document
+from mwmbl.tinysearchengine.rank import score_result
+from mwmbl.tokenizer import tokenize
 
 BATCH_QUEUE_KEY = "batch-queue"
 REMOTE_SERVER = "https://api.mwmbl.org"

--- a/test/test_crawl_import_order.py
+++ b/test/test_crawl_import_order.py
@@ -1,0 +1,31 @@
+"""The standalone crawler has no database and no DJANGO_SETTINGS_MODULE in its environment.
+
+mwmbl.crawl sets the settings module and calls django.setup() itself, so every mwmbl import
+in it must come after that call - the mwmbl package reaches Django models (via
+curated_domains) and raises ImproperlyConfigured if the app registry is not ready.
+"""
+import ast
+from pathlib import Path
+
+CRAWL_PATH = Path(__file__).parent.parent / "mwmbl" / "crawl.py"
+
+
+def _django_setup_line(module: ast.Module) -> int:
+    for node in ast.walk(module):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "setup" and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "django"):
+            return node.lineno
+    raise AssertionError("mwmbl/crawl.py does not call django.setup()")
+
+
+def test_mwmbl_imports_come_after_django_setup():
+    module = ast.parse(CRAWL_PATH.read_text())
+    setup_line = _django_setup_line(module)
+
+    early_imports = [
+        node.module for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.lineno < setup_line
+        and node.module is not None and node.module.startswith("mwmbl")
+    ]
+    assert early_imports == []


### PR DESCRIPTION
## Problem

The standalone crawler has been crash-looping since the curated-domains work landed:

```
django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS,
but settings are not configured.
```

`83cd13a` gave `mwmbl/indexer/blacklist.py` an import of `mwmbl.curated_domains`, which imports `mwmbl.models`. `crawl.py` imported `mwmbl.redis_url_queue` — and so, transitively, the Django models — at line 16, *before* it set `DJANGO_SETTINGS_MODULE` and called `django.setup()` further down the file. The model class bodies ran with no app registry.

## Fix

Move every `mwmbl.*` import in `crawl.py` below `django.setup()`. The data-path `mkdir` stays above it, because the app registry's `ready()` creates the index there.

## Preventing a repeat

The test suite always runs with `DJANGO_SETTINGS_MODULE=mwmbl.settings_test` and a database configured, so no test could ever have caught this. Two additions:

- `test/test_crawl_import_order.py` — asserts no `mwmbl` import in `crawl.py` precedes `django.setup()`. Cheap, runs locally, and fails against the broken file.
- A CI step that imports the crawler entry point in the environment the container actually gives it — no settings module, no database:
  ```yaml
  - name: Check the crawler entry point imports standalone
    run: uv run python -c "from mwmbl.crawl import run"
  ```
  This is the real guard: it catches any future import chain that reaches Django too early or needs a database. It sits before the test step so it fails fast. (It's a CI step rather than a pytest test because importing the module builds a 391 MB crawl index — fine on a runner, unwanted on every local `pytest`.)

## Verification

- `env -u DJANGO_SETTINGS_MODULE -u DATABASE_URL uv run python -c "from mwmbl.crawl import run"` → exits 0 (fails on `main`).
- The new import-order test fails against the pre-fix `crawl.py`, passes after.
- Blacklist / curated-domain suites: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)