### PR TITLE
Make index page writes safe

### DIFF
--- a/mwmbl/count_urls.py
+++ b/mwmbl/count_urls.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from pydistinct.stats_estimators import smoothed_jackknife_estimator
 from redis import Redis
 
-from mwmbl.tinysearchengine.indexer import TinyIndex, Document
+from mwmbl.tinysearchengine.indexer import Document, PageError, TinyIndex
 from mwmbl.utils import parse_url
 
 INDEX_RESULT_COUNT_KEY = "index-result-count-{date}"
@@ -57,7 +57,14 @@ def count_urls():
         domain_counts = Counter()
         total_docs = 0
         for i in page_sample:
-            page = index.get_page(i)
+            try:
+                page = index.get_page(i)
+            except PageError:
+                # An unlocked read while the indexer is writing, so most of these are torn
+                # rather than damaged. Count the page as empty, as retrieve() does, rather
+                # than abandoning the sample.
+                logger.warning("Could not read index page %d while counting URLs", i)
+                continue
             url_counts.update({doc.url for doc in page})
             domains = [parse_url(doc.url).netloc for doc in page]
             domain_counts.update(domains)

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -16,7 +16,8 @@ from mwmbl.indexer.batch_cache import BatchCache
 from mwmbl.indexer.blacklist_snapshot import get_snapshot_blacklist
 from mwmbl.indexer.index import tokenize_document, prepare_url_for_tokenizing
 from mwmbl.indexer.indexdb import BatchStatus
-from mwmbl.tinysearchengine.indexer import Document, TinyIndex, DocumentState, CURATED_STATES
+from mwmbl.tinysearchengine.indexer import (
+    CURATED_STATES, Document, DocumentState, PageError, TinyIndex)
 from mwmbl.tinysearchengine.rank import score_result, DOCUMENT_FREQUENCIES, N_DOCUMENTS, HeuristicRanker
 from mwmbl.tokenizer import tokenize, get_bigrams
 from mwmbl.utils import add_term_infos, get_domain
@@ -115,11 +116,19 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
         for page_index, documents in page_documents.items():
-            with indexer.page(page_index) as page:
-                combined_documents = combine_documents(page.documents, documents, mark_synced, ranker)
-                num_stored = page.store(combined_documents)
-                logger.info(f"Storing {num_stored} of {len(combined_documents)} documents for "
-                            f"page {page_index}, originally {len(page.documents)}")
+            try:
+                with indexer.page(page_index) as page:
+                    combined_documents = combine_documents(page.documents, documents, mark_synced, ranker)
+                    num_stored = page.store(combined_documents)
+                    logger.info(f"Storing {num_stored} of {len(combined_documents)} documents for "
+                                f"page {page_index}, originally {len(page.documents)}")
+            except PageError:
+                # One page we cannot safely write costs the documents bound for it, not the
+                # rest of the batch. Letting it propagate would abort every remaining page,
+                # and this runs inside POST /crawler/results and the batch indexer, where
+                # that means a 500 or a batch that is never marked done and retries forever.
+                logger.exception("Skipping index page %d", page_index)
+                continue
 
             term_new_doc_counts.update(document.term for document in combined_documents[:num_stored]
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
@@ -174,7 +183,14 @@ def index_results_against_query(documents: list[Document], query: str, index_pat
                     term=term, last_crawled=doc.last_crawled,
                 ))
                 if page not in existing_keys:
-                    existing_keys[page] = {(d.term, d.url) for d in indexer.get_page(page)}
+                    try:
+                        existing_keys[page] = {(d.term, d.url) for d in indexer.get_page(page)}
+                    except PageError:
+                        # An unlocked read, so most likely another writer mid-store. It only
+                        # decides whether a URL counts as new; the write below takes the
+                        # page's lock and reads it properly.
+                        logger.warning("Could not read index page %d while counting new URLs", page)
+                        existing_keys[page] = set()
                 if (term, doc.url) not in existing_keys[page]:
                     new_urls.add(doc.url)
 

--- a/mwmbl/indexer/index_batches.py
+++ b/mwmbl/indexer/index_batches.py
@@ -114,13 +114,14 @@ def index_pages(index_path: str, page_documents: dict[int, list[Document]], mark
     term_new_doc_counts = Counter()
     with TinyIndex(Document, index_path, 'w') as indexer:
         ranker = HeuristicRanker(indexer, None, score_threshold=float('-inf'))
-        for page, documents in page_documents.items():
-            existing_documents = indexer.get_page(page)
-            combined_documents = combine_documents(existing_documents, documents, mark_synced, ranker)
-            logger.info(f"Storing {len(combined_documents)} documents for page {page}, originally {len(existing_documents)}")
-            indexer.store_in_page(page, combined_documents)
+        for page_index, documents in page_documents.items():
+            with indexer.page(page_index) as page:
+                combined_documents = combine_documents(page.documents, documents, mark_synced, ranker)
+                num_stored = page.store(combined_documents)
+                logger.info(f"Storing {num_stored} of {len(combined_documents)} documents for "
+                            f"page {page_index}, originally {len(page.documents)}")
 
-            term_new_doc_counts.update(document.term for document in combined_documents
+            term_new_doc_counts.update(document.term for document in combined_documents[:num_stored]
                                        if document.state != DocumentState.SYNCED_WITH_MAIN_INDEX)
     return term_new_doc_counts
 

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -24,7 +24,7 @@ from logging import getLogger
 from typing import Callable, Iterable, Optional
 
 from mwmbl.indexer.index import tokenize_document
-from mwmbl.tinysearchengine.indexer import Document, TinyIndex
+from mwmbl.tinysearchengine.indexer import Document, PageError, TinyIndex
 from mwmbl.utils import get_domain
 
 logger = getLogger(__name__)
@@ -79,19 +79,29 @@ def purge_documents(index: TinyIndex, documents: Iterable[Document],
     # pages, so counting each removal would report an order of magnitude too many.
     removed_urls_by_domain: dict[str, set[str]] = defaultdict(set)
     for page_index, urls in pages_to_urls.items():
-        with index.page(page_index) as page:
-            kept = [d for d in page.documents if d.url not in urls]
-            if len(kept) == len(page.documents):
-                # Nothing to remove here, so leave the page alone rather than rewriting it.
-                continue
+        try:
+            with index.page(page_index) as page:
+                kept = [d for d in page.documents if d.url not in urls]
+                if len(kept) == len(page.documents):
+                    # Nothing to remove here, so leave the page alone rather than rewriting it.
+                    continue
 
-            for document in page.documents:
-                if document.url in urls:
-                    try:
-                        removed_urls_by_domain[get_domain(document.url)].add(document.url)
-                    except ValueError:
-                        removed_urls_by_domain[document.url].add(document.url)
-            page.store(kept)
+                for document in page.documents:
+                    if document.url in urls:
+                        try:
+                            removed_urls_by_domain[get_domain(document.url)].add(document.url)
+                        except ValueError:
+                            removed_urls_by_domain[document.url].add(document.url)
+                num_stored = page.store(kept)
+                if num_stored < len(kept):
+                    logger.warning("Page %d only held %d of %d documents kept after purging",
+                                   page_index, num_stored, len(kept))
+        except PageError:
+            # The caller has already drained these documents out of the purge queue, so
+            # letting one unreadable page propagate would lose the whole batch - including
+            # every page that purged cleanly - and it would do so on every run.
+            logger.exception("Skipping index page %d while purging", page_index)
+            continue
 
     removed_by_domain = {domain: len(urls) for domain, urls in removed_urls_by_domain.items()}
     if removed_by_domain:

--- a/mwmbl/indexer/purge_blacklisted.py
+++ b/mwmbl/indexer/purge_blacklisted.py
@@ -79,18 +79,19 @@ def purge_documents(index: TinyIndex, documents: Iterable[Document],
     # pages, so counting each removal would report an order of magnitude too many.
     removed_urls_by_domain: dict[str, set[str]] = defaultdict(set)
     for page_index, urls in pages_to_urls.items():
-        page = index.get_page(page_index)
-        kept = [d for d in page if d.url not in urls]
-        if len(kept) == len(page):
-            continue
+        with index.page(page_index) as page:
+            kept = [d for d in page.documents if d.url not in urls]
+            if len(kept) == len(page.documents):
+                # Nothing to remove here, so leave the page alone rather than rewriting it.
+                continue
 
-        for document in page:
-            if document.url in urls:
-                try:
-                    removed_urls_by_domain[get_domain(document.url)].add(document.url)
-                except ValueError:
-                    removed_urls_by_domain[document.url].add(document.url)
-        index.store_in_page(page_index, kept)
+            for document in page.documents:
+                if document.url in urls:
+                    try:
+                        removed_urls_by_domain[get_domain(document.url)].add(document.url)
+                    except ValueError:
+                        removed_urls_by_domain[document.url].add(document.url)
+            page.store(kept)
 
     removed_by_domain = {domain: len(urls) for domain, urls in removed_urls_by_domain.items()}
     if removed_by_domain:

--- a/mwmbl/rankeval/evaluation/evaluate.py
+++ b/mwmbl/rankeval/evaluation/evaluate.py
@@ -29,6 +29,32 @@ class RankingModel(ABC):
         pass
 
 
+def latest_ranking(rankings):
+    """The most recent scrape of one query's results, in rank order.
+
+    The rankings dataset holds several scrapes of the same query taken on different
+    dates - 1,135 of the 5,969 test queries, up to 16 dates each - and their rows sit
+    consecutively under the one query. Taking the first ten rows therefore mixes dates:
+    the ten are not one ranking, and a URL that appears in two scrapes appears twice at
+    two different ranks. Keeping only the latest date makes the gold set what it is meant
+    to be - one ranking per query.
+    """
+    latest = rankings["date_retrieved"].max()
+    return rankings[rankings["date_retrieved"] == latest].sort_values("rank")
+
+
+def gold_scores_for(rankings) -> dict[str, float]:
+    """The gold URL -> click-weight map for one query's rows of the rankings dataset.
+
+    Duplicate URLs are dropped keeping the best rank, because the map is keyed by URL:
+    left in, the *worse* rank's weight is the one that would survive.
+    """
+    ranking = latest_ranking(rankings).drop_duplicates(subset="url", keep="first")
+    top_ranked = ranking[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
+    top_ranked["score"] = CLICK_PROPORTIONS[:len(top_ranked)]
+    return top_ranked.set_index("url")["score"].to_dict()
+
+
 def evaluate(ranking_model: RankingModel, fraction: float = 1.0, use_test=False):
     # TODO:
     #  - output feature importances from XGBoost
@@ -57,9 +83,7 @@ def evaluate(ranking_model: RankingModel, fraction: float = 1.0, use_test=False)
         if query not in random_queries:
             continue
 
-        top_ranked = rankings[['url']].iloc[:NUM_RESULTS_FOR_EVAL]
-        top_ranked['score'] = CLICK_PROPORTIONS[:len(top_ranked)]
-        scores = top_ranked.set_index('url')['score'].to_dict()
+        scores = gold_scores_for(rankings)
         print(f"Query: '{query}'", scores)
 
         start_time = time.perf_counter()

--- a/mwmbl/rankeval/evaluation/evaluate_fallback.py
+++ b/mwmbl/rankeval/evaluation/evaluate_fallback.py
@@ -53,7 +53,7 @@ django.setup()
 
 import mwmbl.rankeval.evaluation.evaluate_super_search as ss_module  # noqa: E402
 from mwmbl.rankeval.evaluation.evaluate import (  # noqa: E402
-    CLICK_PROPORTIONS, NUM_RESULTS_FOR_EVAL, RankingModel)
+    NUM_RESULTS_FOR_EVAL, RankingModel, gold_scores_for)
 from mwmbl.rankeval.evaluation.evaluate_ranker import DummyCompleter, MwmblRankingModel  # noqa: E402
 from mwmbl.rankeval.evaluation.evaluate_super_search import SuperSearchRankingModel  # noqa: E402
 from mwmbl.rankeval.evaluation.remote_index import RemoteIndex  # noqa: E402
@@ -166,9 +166,7 @@ def run():
     for query, rankings in dataset.groupby("query"):
         if query not in sampled:
             continue
-        top_ranked = rankings[["url"]].iloc[:NUM_RESULTS_FOR_EVAL].copy()
-        top_ranked["score"] = CLICK_PROPORTIONS[:len(top_ranked)]
-        gold_scores = top_ranked.set_index("url")["score"].to_dict()
+        gold_scores = gold_scores_for(rankings)
 
         std_results = standard.predict(query)
         standard_count[query] = len(std_results)

--- a/mwmbl/tinysearchengine/copy_index.py
+++ b/mwmbl/tinysearchengine/copy_index.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from logging import getLogger
 
 from mwmbl.indexer.index_batches import index_pages, get_url_score
-from mwmbl.tinysearchengine.indexer import TinyIndex, Document
+from mwmbl.tinysearchengine.indexer import Document, PageError, TinyIndex
 from mwmbl.utils import add_term_infos
 
 logger = getLogger(__name__)
@@ -25,7 +25,13 @@ def copy_pages(old_index_path: str, new_index_path: str, start_page: int, num_pa
                 if page_index >= old_index.num_pages:
                     break
 
-                documents = old_index.get_page(page_index)
+                try:
+                    documents = old_index.get_page(page_index)
+                except PageError:
+                    # A whole-index scan meets every damaged page there is. Losing one
+                    # page's documents is the cost of the copy finishing at all.
+                    logger.warning("Skipping unreadable page %d of %s", page_index, old_index_path)
+                    continue
                 documents_with_terms = add_term_infos(documents, old_index, page_index)
                 documents_with_scores = [Document(
                     document.title,

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, asdict, field
 from enum import IntEnum
 from io import UnsupportedOperation
+from json import JSONDecodeError
 from logging import getLogger
 from mmap import mmap, PROT_READ, PROT_WRITE
 from typing import TypeVar, Generic, Callable, List, Optional
@@ -34,6 +35,9 @@ logger = getLogger(__name__)
 F_OFD_SETLKW = 38
 # struct flock { short l_type; short l_whence; off_t l_start; off_t l_len; pid_t l_pid; }
 # Padded to the native 32 bytes so nothing past our buffer is read. l_pid must be 0 for OFD.
+# The q's assume a 64-bit off_t, i.e. an LP64 build - true of every platform this runs on.
+# On a 32-bit build the buffer would be the wrong shape and fcntl would answer EINVAL,
+# which UNSUPPORTED_LOCK_ERRNOS reads as "this kernel cannot lock" and latches locking off.
 _FLOCK_STRUCT = "hhqqi4x"
 
 # Errnos that mean this kernel or filesystem cannot do the lock at all, as opposed to a
@@ -212,10 +216,27 @@ def _pad_to_page_size(data: bytes, page_size: int):
 class _OpenPage(Generic[T]):
     """One page of the index, open for a read-modify-write. See TinyIndex.page."""
 
-    def __init__(self, index: 'TinyIndex[T]', page_index: int):
+    def __init__(self, index: 'TinyIndex[T]', page_index: int, locked: bool):
         self._index = index
         self._page_index = page_index
-        self.documents: List[T] = index.get_page(page_index)
+        self.reset = False
+        try:
+            self.documents: List[T] = index.get_page(page_index)
+        except PageError:
+            if not locked:
+                # Without the lock this could equally be another writer's memcpy in
+                # progress, and merging onto an empty list would store over whatever it
+                # is writing. Refuse; the caller skips this page.
+                raise
+            # Holding the page's exclusive lock, no other writer that takes the lock can
+            # be part-way through it, so this is real damage - a bad block, or a write
+            # from before locking existed - rather than a torn read. Nothing else will
+            # ever repair it, because every reader treats it as empty and every writer
+            # would refuse it, so this write resets the page. That costs whatever was on
+            # it, which is already unreadable.
+            logger.error("Index page %d is corrupt; resetting it", page_index)
+            self.documents = []
+            self.reset = True
 
     def store(self, values: List[T]) -> int:
         """Write these values to the page, returning how many of them actually fit.
@@ -325,7 +346,7 @@ class TinyIndex(Generic[T]):
                     logger.warning("Could not lock index page %d (%s); writing it unlocked",
                                    i, e)
         try:
-            yield
+            yield locked
         finally:
             if locked:
                 try:
@@ -366,9 +387,13 @@ class TinyIndex(Generic[T]):
         decompressor = ZstdDecompressor()
         try:
             decompressed_data = decompressor.decompress(page_data)
-        except ZstdError as e:
-            raise PageError(f"Could not decompress page {i}: {e}") from e
-        return json.loads(decompressed_data.decode('utf8'))
+            return json.loads(decompressed_data.decode('utf8'))
+        except (ZstdError, UnicodeDecodeError, JSONDecodeError) as e:
+            # Damage that gets past zstd's checksum lands on the decode or the parse
+            # instead, and it is the same kind of unreadable. Callers catch PageError and
+            # nothing else, so anything raised from here that is not one would escape
+            # them - retrieve() would 500 a search rather than degrading to no results.
+            raise PageError(f"Could not read page {i}: {e}") from e
 
     def store_in_page(self, page_index: int, values: list[T]) -> int:
         """Overwrite a page, returning how many of `values` actually fit on it.
@@ -411,9 +436,16 @@ class TinyIndex(Generic[T]):
 
         Not calling store() writes nothing, which is what a caller that finds nothing to
         change should do.
+
+        Raises PageError if the page will not decode and the lock was not taken, since a
+        page that is merely being written by someone else looks exactly the same and must
+        not be merged onto. A caller looping over pages should catch that and skip the
+        page rather than abandon the rest of them. Holding the lock, an unreadable page is
+        real damage instead, and the block runs with `documents` empty and `reset` set -
+        see _OpenPage.
         """
-        with self._locked_page(i):
-            yield _OpenPage(self, i)
+        with self._locked_page(i) as locked:
+            yield _OpenPage(self, i, locked)
 
     @staticmethod
     def create(item_factory: Callable[..., T], index_path: str, num_pages: int, page_size: int):

--- a/mwmbl/tinysearchengine/indexer.py
+++ b/mwmbl/tinysearchengine/indexer.py
@@ -1,5 +1,9 @@
+import errno
+import fcntl
 import json
 import os
+import struct
+from contextlib import contextmanager
 from dataclasses import dataclass, asdict, field
 from enum import IntEnum
 from io import UnsupportedOperation
@@ -18,6 +22,34 @@ PAGE_SIZE = 4096
 
 
 logger = getLogger(__name__)
+
+
+# Open File Description locks (Linux 3.15+). Byte-range like POSIX record locks, but owned
+# by the open file description like flock - which is the property that matters here.
+# Ordinary fcntl/lockf record locks are owned by the *process* and are dropped as soon as
+# any fd on the file is closed, and index_results_against_query opens and closes a read
+# handle on the index on every store, so in a threaded worker a plain lockf would be
+# released out from under whoever held it. Verified: with lockf, closing an unrelated fd
+# lets another process take the "held" lock; with OFD locks it does not.
+F_OFD_SETLKW = 38
+# struct flock { short l_type; short l_whence; off_t l_start; off_t l_len; pid_t l_pid; }
+# Padded to the native 32 bytes so nothing past our buffer is read. l_pid must be 0 for OFD.
+_FLOCK_STRUCT = "hhqqi4x"
+
+# Errnos that mean this kernel or filesystem cannot do the lock at all, as opposed to a
+# one-off failure to take it: an old kernel rejects the F_OFD_SETLKW command with EINVAL,
+# and a filesystem with no record-lock support answers ENOLCK/ENOSYS/ENOTSUP. Only these
+# latch locking off for the process - see _locked_page.
+UNSUPPORTED_LOCK_ERRNOS = frozenset({errno.EINVAL, errno.ENOLCK, errno.ENOSYS,
+                                     errno.ENOTSUP, errno.EOPNOTSUPP})
+
+# Set False the first time locking turns out to be unsupported here - see _locked_page.
+_page_locking_supported = True
+
+
+def _set_page_lock(fileno: int, lock_type: int, start: int, length: int):
+    fcntl.fcntl(fileno, F_OFD_SETLKW,
+                struct.pack(_FLOCK_STRUCT, lock_type, os.SEEK_SET, start, length, 0))
 
 
 class DocumentState(IntEnum):
@@ -159,12 +191,13 @@ def _trim_items_to_page(compressor: ZstdCompressor, page_size: int, items:list[T
 
 
 def _get_page_data(page_size: int, items: list[T]):
+    """The padded page bytes, and how many of `items` actually fit on it."""
     compressor = ZstdCompressor()
     num_fitting, serialised_data = _trim_items_to_page(compressor, page_size, items)
 
     compressed_data = compressor.compress(json.dumps(items[:num_fitting]).encode('utf8'))
     assert len(compressed_data) <= page_size, "The data shouldn't get bigger"
-    return _pad_to_page_size(compressed_data, page_size)
+    return _pad_to_page_size(compressed_data, page_size), num_fitting
 
 
 def _pad_to_page_size(data: bytes, page_size: int):
@@ -174,6 +207,24 @@ def _pad_to_page_size(data: bytes, page_size: int):
     padding = b'\x00' * (page_size - page_length)
     page_data = data + padding
     return page_data
+
+
+class _OpenPage(Generic[T]):
+    """One page of the index, open for a read-modify-write. See TinyIndex.page."""
+
+    def __init__(self, index: 'TinyIndex[T]', page_index: int):
+        self._index = index
+        self._page_index = page_index
+        self.documents: List[T] = index.get_page(page_index)
+
+    def store(self, values: List[T]) -> int:
+        """Write these values to the page, returning how many of them actually fit.
+
+        A page holds a fixed number of bytes and the tail that does not fit is dropped, so
+        pass them best-first. It is store() rather than an assignment to `documents`
+        precisely because what you pass is not necessarily what ends up stored.
+        """
+        return self._index.store_in_page(self._page_index, values)
 
 
 class TinyIndex(Generic[T]):
@@ -213,12 +264,75 @@ class TinyIndex(Generic[T]):
     def retrieve(self, key: str) -> List[T]:
         index = self.get_key_page_index(key)
         logger.debug(f"Retrieving index {index}")
-        page = self.get_page(index)
+        try:
+            page = self.get_page(index)
+        except PageError:
+            # One unreadable page costs this query the results for one term, and the next
+            # read of it will very likely succeed. Writers do not swallow this.
+            logger.exception("Could not read index page %d", index)
+            return []
         return [item for item in page if item.term is None or item.term == key]
 
     def get_key_page_index(self, key) -> int:
         key_hash = mmh3.hash(key, signed=False)
         return key_hash % self.num_pages
+
+    @contextmanager
+    def _locked_page(self, i: int):
+        """Hold an exclusive lock on page i for a read-modify-write.
+
+        Storing a page is read -> merge -> write, with no atomicity of its own. Two writers
+        on the same page lose one writer's documents, which for a cache is tolerable. The
+        serious case is a *torn* read: _write_page copies ~4 KB into the mmap, and a reader
+        that catches it half-written gets a ZstdError, which _get_page_tuples turns into an
+        empty page. A writer that reads empty then merges and stores wipes out everything
+        else on that page - permanent loss in a 400 GB index, not a transient blip. Since
+        the wiki index cache writes from the request path, on a large fraction of searches
+        and from every gunicorn worker, that stops being hypothetical.
+
+        Private: every read-modify-write on the index goes through page(), so no
+        caller has to know this exists. Readers deliberately do not take it - search would
+        pay a syscall per retrieve on the hot path, and a torn read costs a reader only one
+        query's results for one term, which the next read fixes.
+
+        If the lock cannot be taken, carry on without one. Every indexing path here - batch
+        indexing, curation, POST /crawler/results, copy_index, purge - ran with no lock at
+        all before this existed, so turning a failure to lock into a hard failure of all of
+        them would be a much worse regression than the race it is guarding. An errno that
+        means this environment does not support the lock at all latches
+        _page_locking_supported off, so the warning is said once rather than per page;
+        anything else is treated as a one-off and locking is tried again next time.
+        """
+        global _page_locking_supported
+        if self.mode != 'w':
+            raise UnsupportedOperation("The file is open in read mode, you cannot lock a page")
+
+        start = i * self.page_size + METADATA_SIZE
+        fileno = self.index_file.fileno()
+        locked = False
+        if _page_locking_supported:
+            try:
+                _set_page_lock(fileno, fcntl.F_WRLCK, start, self.page_size)
+                locked = True
+            except OSError as e:
+                if e.errno in UNSUPPORTED_LOCK_ERRNOS:
+                    _page_locking_supported = False
+                    logger.warning(
+                        "Index page locking is not available here (%s); index writes will "
+                        "race as they did before it was added. Concurrent writers to one "
+                        "page can lose documents.", e)
+                else:
+                    logger.warning("Could not lock index page %d (%s); writing it unlocked",
+                                   i, e)
+        try:
+            yield
+        finally:
+            if locked:
+                try:
+                    _set_page_lock(fileno, fcntl.F_UNLCK, start, self.page_size)
+                except OSError:
+                    # Dropped on close anyway; failing here would mask the caller's own error.
+                    logger.warning("Could not release the lock on index page %d", i)
 
     def get_page(self, i) -> list[T]:
         """
@@ -240,30 +354,66 @@ class TinyIndex(Generic[T]):
         return items
 
     def _get_page_tuples(self, i):
+        """The raw tuples on page i. Raises PageError if the page will not decode.
+
+        It deliberately does not fall back to an empty page. A page that fails to
+        decompress is either corrupt or caught mid-write, and treating that as "no
+        documents here" is how a writer comes to merge onto nothing and store its result
+        over everything that was on the page. Readers that would rather have no results
+        than an error catch this - see retrieve.
+        """
         page_data = self.mmap[i * self.page_size + METADATA_SIZE:(i + 1) * self.page_size + METADATA_SIZE]
         decompressor = ZstdDecompressor()
         try:
             decompressed_data = decompressor.decompress(page_data)
         except ZstdError as e:
-            logger.exception(f"Error decompressing page {i}: {e}")
-            return []
+            raise PageError(f"Could not decompress page {i}: {e}") from e
         return json.loads(decompressed_data.decode('utf8'))
 
-    def store_in_page(self, page_index: int, values: list[T]):
-        value_tuples = [value.as_tuple() for value in values]
-        self._write_page(value_tuples, page_index)
+    def store_in_page(self, page_index: int, values: list[T]) -> int:
+        """Overwrite a page, returning how many of `values` actually fit on it.
 
-    def _write_page(self, data, i: int):
+        A page holds a fixed number of bytes and the tail that does not fit is dropped, so
+        pass the values best-first. To change a page based on what it already holds, use
+        page() instead, which does the read and the write under one lock."""
+        value_tuples = [value.as_tuple() for value in values]
+        return self._write_page(value_tuples, page_index)
+
+    def _write_page(self, data, i: int) -> int:
         """
         Serialise the data using JSON, compress it and store it at index i.
-        If the data is too big, it will store the first items in the list and discard the rest.
+        If the data is too big, it will store the first items in the list and discard the
+        rest; the number actually stored is returned.
         """
         if self.mode != 'w':
             raise UnsupportedOperation("The file is open in read mode, you cannot write")
 
-        page_data = _get_page_data(self.page_size, data)
+        page_data, num_stored = _get_page_data(self.page_size, data)
         logger.debug(f"Got page data of length {len(page_data)}")
         self.mmap[i * self.page_size + METADATA_SIZE:(i+1) * self.page_size + METADATA_SIZE] = page_data
+        return num_stored
+
+    @contextmanager
+    def page(self, i: int):
+        """Open page i for a read-modify-write, holding its lock throughout.
+
+        Changing a page is read -> merge -> write, and the three have to be atomic
+        together. _write_page copies ~4 KB into the mmap; a reader catching it half-written
+        gets a page that will not decompress, and a writer that took that for an empty page
+        would store its result over everything else there.
+
+        Locking lives here rather than in the callers because "hold a lock across your read
+        and your write" is the kind of rule that gets quietly forgotten. There is one way to
+        change a page and it is already correct::
+
+            with index.page(page_index) as page:
+                page.store(merge(page.documents))
+
+        Not calling store() writes nothing, which is what a caller that finds nothing to
+        change should do.
+        """
+        with self._locked_page(i):
+            yield _OpenPage(self, i)
 
     @staticmethod
     def create(item_factory: Callable[..., T], index_path: str, num_pages: int, page_size: int):
@@ -274,7 +424,7 @@ class TinyIndex(Generic[T]):
         metadata_bytes = metadata.to_bytes()
         metadata_padded = _pad_to_page_size(metadata_bytes, METADATA_SIZE)
 
-        page_bytes = _get_page_data(page_size, [])
+        page_bytes, _ = _get_page_data(page_size, [])
 
         with open(index_path, 'wb') as index_file:
             index_file.write(metadata_padded)

--- a/mwmbl/views.py
+++ b/mwmbl/views.py
@@ -299,9 +299,13 @@ def _revert_curation(curation):
         term = " ".join(tokenize(curation.query))
         documents = [Document(**doc) for doc in curation.original_index_results]
 
-        with indexer.page(indexer.get_key_page_index(term)) as page:
+        page_index = indexer.get_key_page_index(term)
+        with indexer.page(page_index) as page:
             # Replace all existing documents for the term with the original documents
-            page.store(documents + [doc for doc in page.documents if doc.term != term])
+            all_documents = documents + [doc for doc in page.documents if doc.term != term]
+            num_stored = page.store(all_documents)
+            logger.info(f"Reverted to {num_stored} of {len(all_documents)} documents "
+                        f"at page {page_index}")
 
 
 def _get_curation(request, query, documents, reranked_documents):

--- a/mwmbl/views.py
+++ b/mwmbl/views.py
@@ -299,14 +299,9 @@ def _revert_curation(curation):
         term = " ".join(tokenize(curation.query))
         documents = [Document(**doc) for doc in curation.original_index_results]
 
-        page_index = indexer.get_key_page_index(term)
-        existing_documents = indexer.get_page(page_index)
-        other_term_documents = [doc for doc in existing_documents if doc.term != term]
-
-        # Replace all existing documents for the term with the original documents
-        all_documents = documents + other_term_documents
-
-        indexer.store_in_page(page_index, all_documents)
+        with indexer.page(indexer.get_key_page_index(term)) as page:
+            # Replace all existing documents for the term with the original documents
+            page.store(documents + [doc for doc in page.documents if doc.term != term])
 
 
 def _get_curation(request, query, documents, reranked_documents):
@@ -392,21 +387,22 @@ def _save_to_index(query: str, new_results: list[Document]):
         ]
 
         page_index = indexer.get_key_page_index(term)
-        existing_documents_no_terms = indexer.get_page(page_index)
-        existing_documents = add_term_infos(existing_documents_no_terms, indexer, page_index)
-        new_urls = {doc.url for doc in documents}
-        other_documents = [doc for doc in existing_documents if doc.url not in new_urls]
-        logger.info(f"Found {len(other_documents)} other documents for term {term} at page {page_index} "
-                    f"with terms { {doc.term for doc in other_documents} }")
 
-        # Update state for other documents
-        states = {doc.url: doc.state for doc in new_results}
-        for doc in other_documents:
-            doc.state = states.get(doc.url, doc.state)
+        with indexer.page(page_index) as page:
+            existing_documents = add_term_infos(page.documents, indexer, page_index)
+            new_urls = {doc.url for doc in documents}
+            other_documents = [doc for doc in existing_documents if doc.url not in new_urls]
+            logger.info(f"Found {len(other_documents)} other documents for term {term} at page {page_index} "
+                        f"with terms { {doc.term for doc in other_documents} }")
 
-        all_documents = documents + other_documents
-        logger.info(f"Storing {len(all_documents)} documents at page {page_index}")
-        indexer.store_in_page(page_index, all_documents)
+            # Update state for other documents
+            states = {doc.url: doc.state for doc in new_results}
+            for doc in other_documents:
+                doc.state = states.get(doc.url, doc.state)
+
+            all_documents = documents + other_documents
+            num_stored = page.store(all_documents)
+            logger.info(f"Stored {num_stored} of {len(all_documents)} documents at page {page_index}")
 
     return {"curation": "ok"}
 

--- a/test/test_index_page_writes.py
+++ b/test/test_index_page_writes.py
@@ -17,8 +17,10 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from mwmbl.indexer.index_batches import index_results_against_query
-from mwmbl.tinysearchengine.indexer import METADATA_SIZE, Document, DocumentState, TinyIndex
+from mwmbl.indexer.index_batches import index_pages, index_results_against_query
+from mwmbl.indexer.purge_blacklisted import purge_documents
+from mwmbl.tinysearchengine.indexer import (
+    METADATA_SIZE, Document, DocumentState, PageError, TinyIndex)
 
 
 NUM_PAGES = 64
@@ -201,3 +203,113 @@ def test_concurrent_writers_leave_the_page_readable(index_path):
 
     assert page, "the page was left empty"
     assert all(document.title and document.url for document in page)
+
+
+# ---------------------------------------------------------------------------
+# A page that will not decode
+# ---------------------------------------------------------------------------
+
+def _doc(i: int, term: str) -> Document:
+    return Document(f"Title {i}", f"https://example.com/{i}", "extract", 1.0, term)
+
+
+def _corrupt(index_path: str, page_index: int):
+    """Damage a page that has real content on it.
+
+    It has to be written first: a freshly created page is a few bytes of compressed `[]`
+    followed by zero padding, so overwriting the padding with zeros changes nothing.
+    """
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        indexer.store_in_page(page_index, [_doc(i, "seeded") for i in range(5)])
+
+    with open(index_path, "r+b") as index_file:
+        index_file.seek(METADATA_SIZE + page_index * 4096 + 16)
+        index_file.write(b"\0" * 64)
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        with pytest.raises(PageError):
+            indexer.get_page(page_index)
+
+
+def test_one_unreadable_page_does_not_abandon_the_rest_of_the_batch(index_path):
+    """index_pages runs inside POST /crawler/results and the batch indexer.
+
+    Letting a single page propagate would 500 the submission, or leave a batch unmarked
+    and retried forever, and would skip every page after it in the same call.
+    """
+    _corrupt(index_path, 3)
+
+    counts = index_pages(index_path, {3: [_doc(1, "a")], 4: [_doc(2, "b")], 5: [_doc(3, "c")]})
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert len(indexer.get_page(4)) == 1, "a later page was skipped"
+        assert len(indexer.get_page(5)) == 1, "a later page was skipped"
+    assert counts["b"] == 1 and counts["c"] == 1
+
+
+def test_a_corrupt_page_is_reset_by_a_writer_holding_its_lock(index_path):
+    """Holding the page's exclusive lock, no other locked writer can be mid-write on it,
+    so an unreadable page is real damage rather than a torn read - and nothing else will
+    ever repair it, since readers treat it as empty and writers refuse it."""
+    _corrupt(index_path, 3)
+
+    index_pages(index_path, {3: [_doc(1, "a")]})
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert [d.url for d in indexer.get_page(3)] == ["https://example.com/1"]
+
+
+def test_an_unlocked_writer_refuses_a_page_it_could_not_read(index_path, monkeypatch):
+    """Without the lock, a page that will not decode is just as likely to be another
+    writer's memcpy in progress, and resetting it would store over what they are writing.
+    Skip it - and leave it for a writer that can take the lock."""
+    _corrupt(index_path, 3)
+    _fail_to_lock(monkeypatch, OSError(errno.ENOLCK, "no locks available"))
+
+    index_pages(index_path, {3: [_doc(1, "a")], 4: [_doc(2, "b")]})
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert len(indexer.get_page(4)) == 1, "a later page was skipped"
+        with pytest.raises(PageError):
+            indexer.get_page(3)  # left alone, not reset and not merged onto
+
+
+def test_purging_skips_a_page_it_cannot_read(index_path):
+    """purge_documents' caller has already drained these documents out of the purge queue,
+    so one propagating page would lose the whole batch on every run."""
+    blacklisted = Document("Spam", "https://spam.example.com/1", "extract", 1.0, None)
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        pages = {indexer.get_key_page_index(term)
+                 for term in ("spam", "extract", "spam example com")}
+    assert len(pages) > 1, "expected the document to be filed under several terms"
+
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        for page_index in pages:
+            indexer.store_in_page(page_index, [blacklisted])
+    _corrupt(index_path, sorted(pages)[0])
+
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        removed = purge_documents(indexer, [blacklisted], lambda domain: True)
+
+    assert removed == {"spam.example.com": 1}, "the readable pages were not purged"
+
+
+def test_damage_that_gets_past_zstd_still_degrades_to_no_results(index_path):
+    """retrieve() catches PageError and nothing else, so a page that decompresses into
+    something that is not JSON has to arrive as one too - or it 500s a search."""
+    from zstandard import ZstdCompressor
+
+    from mwmbl.tinysearchengine.indexer import _pad_to_page_size
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        page_index = indexer.get_key_page_index("zebra")
+
+    payload = ZstdCompressor().compress(b"\xff\xfe definitely not json")
+    with open(index_path, "r+b") as index_file:
+        index_file.seek(METADATA_SIZE + page_index * 4096)
+        index_file.write(_pad_to_page_size(payload, 4096))
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        with pytest.raises(PageError):
+            indexer.get_page(page_index)
+        assert indexer.retrieve("zebra") == []

--- a/test/test_index_page_writes.py
+++ b/test/test_index_page_writes.py
@@ -1,0 +1,203 @@
+"""Changing an index page is read -> merge -> write, and has to be atomic.
+
+_write_page copies ~4 KB into the mmap, and a reader catching it half-written gets a page
+that will not decompress. Every read-modify-write goes through TinyIndex.page(), which
+holds the page's lock for the whole block, so no caller has to know locking exists.
+"""
+import errno
+import fcntl
+import multiprocessing
+import os
+import random
+import string
+import struct
+from io import UnsupportedOperation
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from mwmbl.indexer.index_batches import index_results_against_query
+from mwmbl.tinysearchengine.indexer import METADATA_SIZE, Document, DocumentState, TinyIndex
+
+
+NUM_PAGES = 64
+
+# The non-blocking form of the lock the index takes, for a child that wants to find out
+# whether a page is free rather than wait for it.
+F_OFD_SETLK = 37
+
+
+@pytest.fixture
+def index_path():
+    with TemporaryDirectory() as temp_dir:
+        path = str(Path(temp_dir) / "temp-index.tinysearch")
+        with TinyIndex.create(Document, path, num_pages=NUM_PAGES, page_size=4096):
+            pass
+        yield path
+
+
+def _try_lock_in_child(index_path: str, page: int, queue):
+    """Child process: report whether the page lock is free."""
+    from mwmbl.tinysearchengine.indexer import _FLOCK_STRUCT
+
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        start = page * indexer.page_size + METADATA_SIZE
+        try:
+            fcntl.fcntl(indexer.index_file.fileno(), F_OFD_SETLK,
+                        struct.pack(_FLOCK_STRUCT, fcntl.F_WRLCK, os.SEEK_SET,
+                                    start, indexer.page_size, 0))
+            queue.put(True)
+        except OSError:
+            queue.put(False)
+
+
+def test_page_holds_the_lock_across_the_read_and_the_write(index_path):
+    """The lock must be held for as long as the block runs, and no longer.
+
+    It asserts the exclusion property directly rather than trying to win the race: the
+    window is a single memcpy, so a racing test passes with the lock removed and guards
+    nothing.
+    """
+    context = multiprocessing.get_context("fork")
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        target = indexer.get_key_page_index("zebra")
+
+    def child_can_lock(page_index=target):
+        queue = context.Queue()
+        child = context.Process(target=_try_lock_in_child, args=(index_path, page_index, queue))
+        child.start()
+        child.join(timeout=30)
+        return queue.get(timeout=5)
+
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        with indexer.page(target) as page:
+            assert not child_can_lock(), "another process took a lock we were holding"
+
+            # An ordinary POSIX record lock is owned by the *process* and is dropped the
+            # moment any fd on the file is closed - and index_results_against_query opens
+            # and closes a read handle on every store, so in a threaded worker that would
+            # silently release the lock mid-write. OFD locks survive it.
+            with TinyIndex(Document, index_path, 'r'):
+                pass
+            assert not child_can_lock(), \
+                "closing an unrelated fd released the lock - this needs an OFD lock"
+
+            assert child_can_lock((target + 1) % NUM_PAGES), "a different page was blocked"
+            assert page.documents == []
+
+    assert child_can_lock(), "the lock was not released"
+
+
+def test_page_writes_nothing_unless_store_is_called(index_path):
+    seeded = [Document("Zebra", "https://en.wikipedia.org/wiki/Zebra", "", 3.0, "zebra",
+                       state=DocumentState.FROM_WIKI)]
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        target = indexer.get_key_page_index("zebra")
+        indexer.store_in_page(target, seeded)
+
+        with indexer.page(target) as page:
+            assert [d.url for d in page.documents] == [seeded[0].url]  # read, then do nothing
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert [d.url for d in indexer.get_page(target)] == [seeded[0].url]
+
+
+def test_store_reports_how_many_documents_actually_fit(index_path):
+    """A page drops the tail that does not fit, which is why this is store() and not an
+    assignment to `documents` - what you pass is not necessarily what is kept."""
+    # Distinct, incompressible extracts - zstd would squeeze 500 identical ones onto a
+    # single page and there would be nothing to truncate.
+    filler = random.Random(0)
+    many = [Document(f"Zebra {i}", f"https://en.wikipedia.org/wiki/Zebra_{i}",
+                     "".join(filler.choices(string.ascii_letters, k=400)),
+                     3.0, "zebra", state=DocumentState.FROM_WIKI)
+            for i in range(500)]
+    with TinyIndex(Document, index_path, 'w') as indexer:
+        with indexer.page(indexer.get_key_page_index("zebra")) as page:
+            num_stored = page.store(many)
+
+    assert 0 < num_stored < len(many), f"expected truncation, stored {num_stored}"
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert len(indexer.get_page(indexer.get_key_page_index("zebra"))) == num_stored
+
+
+def test_page_needs_write_mode(index_path):
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        with pytest.raises(UnsupportedOperation):
+            with indexer.page(0):
+                pass
+
+
+def _fail_to_lock(monkeypatch, err: OSError):
+    from mwmbl.tinysearchengine import indexer as indexer_module
+
+    monkeypatch.setattr(indexer_module, "_page_locking_supported", True)
+    monkeypatch.setattr(indexer_module, "_set_page_lock",
+                        lambda *args: (_ for _ in ()).throw(err))
+    return indexer_module
+
+
+def _store_one(index_path: str) -> Document:
+    document = Document("Zebra", "https://en.wikipedia.org/wiki/Zebra", "", 3.0, None)
+    assert index_results_against_query([document], "zebra", index_path) == 1
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        assert {d.url for d in indexer.retrieve("zebra")} == {document.url}
+    return document
+
+
+def test_writes_continue_when_page_locking_is_unsupported(index_path, monkeypatch):
+    """A filesystem without record locks must not break indexing.
+
+    Every path through index_pages ran with no lock at all before this existed, so an
+    environment that cannot lock should degrade to that, not fail.
+    """
+    indexer_module = _fail_to_lock(monkeypatch, OSError(errno.ENOLCK, "no locks available"))
+
+    _store_one(index_path)
+
+    assert indexer_module._page_locking_supported is False
+
+
+def test_a_one_off_lock_failure_does_not_disable_locking(index_path, monkeypatch):
+    """Only an errno meaning "this environment cannot lock" latches locking off.
+
+    Anything else - a deadlock detection, an interrupted call - is a one-off. Latching on
+    it would silently drop the lock for the rest of the process's life on a blip.
+    """
+    indexer_module = _fail_to_lock(monkeypatch, OSError(errno.EDEADLK, "resource deadlock"))
+
+    _store_one(index_path)
+
+    assert indexer_module._page_locking_supported is True
+
+
+def _store_repeatedly(index_path: str, term: str, url_prefix: str, count: int):
+    """Child-process worker: store documents under `term`, over and over."""
+    for i in range(count):
+        # The title has to contain the term, or the containment rule stores nothing.
+        index_results_against_query(
+            [Document(f"Zebra {url_prefix} {i}", f"https://example.com/{url_prefix}/{i}", "",
+                      3.0, None)],
+            term, index_path)
+
+
+def test_concurrent_writers_leave_the_page_readable(index_path):
+    """Smoke test: four processes hammering one page leave it decodable, not empty."""
+    context = multiprocessing.get_context("fork")
+    workers = [context.Process(target=_store_repeatedly,
+                               args=(index_path, "zebra", f"w{n}", 30))
+               for n in range(4)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=60)
+        assert worker.exitcode == 0
+
+    with TinyIndex(Document, index_path, 'r') as indexer:
+        page = indexer.get_page(indexer.get_key_page_index("zebra"))
+
+    assert page, "the page was left empty"
+    assert all(document.title and document.url for document in page)

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -63,8 +63,9 @@ def test_get_page_data_single_doc():
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmmed data, then it should be equal to the data we persist
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     assert serialized_data == padded_trimmed_data
+    assert num_stored == num_fitting
     
 
 def test_get_page_data_many_docs_all_fit():
@@ -87,10 +88,11 @@ def test_get_page_data_many_docs_all_fit():
     
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmed data, then it should be equal to the data we persist
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
     
     assert serialized_data == padded_trimmed_data
+    assert num_stored == num_fitting
 
 
 def test_get_page_data_many_docs_subset_fit():
@@ -114,10 +116,12 @@ def test_get_page_data_many_docs_subset_fit():
     
     # Compare the trimmed data to the actual data we're persisting
     # We need to pad the trimmed data, then it should be equal to the data we persist
-    serialized_data = _get_page_data(page_size, items)
+    serialized_data, num_stored = _get_page_data(page_size, items)
     padded_trimmed_data = _pad_to_page_size(trimmed_data, page_size)
     
     assert serialized_data == padded_trimmed_data
+    # The count is what store() reports back, so it has to match what was actually kept.
+    assert num_stored == num_fitting
 
 
 def test_constructing_document_removes_none():

--- a/test/test_rankeval_gold.py
+++ b/test/test_rankeval_gold.py
@@ -1,0 +1,73 @@
+"""The gold ranking a query is scored against.
+
+The rankings dataset holds several scrapes of the same query, taken on different dates
+and stored as consecutive rows under the one query - 1,135 of the 5,969 test queries.
+Every harness that scores against it goes through gold_scores_for, so this is where the
+"one query, one ranking" rule has to hold.
+"""
+import pandas as pd
+
+from mwmbl.rankeval.evaluation.evaluate import (
+    CLICK_PROPORTIONS, gold_scores_for, latest_ranking)
+
+
+def _rankings(rows):
+    return pd.DataFrame(rows, columns=["query", "url", "rank", "date_retrieved"])
+
+
+def test_latest_ranking_keeps_only_the_most_recent_scrape():
+    rankings = _rankings([
+        ("piles", "https://old-first", 1, "2025-07-20"),
+        ("piles", "https://old-second", 2, "2025-07-20"),
+        ("piles", "https://new-first", 1, "2026-01-29"),
+        ("piles", "https://new-second", 2, "2026-01-29"),
+    ])
+
+    assert list(latest_ranking(rankings)["url"]) == ["https://new-first", "https://new-second"]
+
+
+def test_latest_ranking_sorts_by_rank():
+    rankings = _rankings([
+        ("piles", "https://second", 2, "2026-01-29"),
+        ("piles", "https://first", 1, "2026-01-29"),
+    ])
+
+    assert list(latest_ranking(rankings)["url"]) == ["https://first", "https://second"]
+
+
+def test_gold_scores_ignore_an_earlier_scrape():
+    # Without this the first ten rows would be the older scrape's, and a URL appearing in
+    # both would take the weight of whichever row came second - the *worse* rank.
+    rankings = _rankings([
+        ("piles", "https://nhs", 5, "2025-07-20"),
+        ("piles", "https://nhs", 1, "2026-01-29"),
+        ("piles", "https://mayo", 2, "2026-01-29"),
+    ])
+
+    assert gold_scores_for(rankings) == {
+        "https://nhs": CLICK_PROPORTIONS[0],
+        "https://mayo": CLICK_PROPORTIONS[1],
+    }
+
+
+def test_gold_scores_drop_a_duplicate_url_keeping_the_best_rank():
+    rankings = _rankings([
+        ("piles", "https://nhs", 1, "2026-01-29"),
+        ("piles", "https://mayo", 2, "2026-01-29"),
+        ("piles", "https://nhs", 3, "2026-01-29"),
+    ])
+
+    assert gold_scores_for(rankings) == {
+        "https://nhs": CLICK_PROPORTIONS[0],
+        "https://mayo": CLICK_PROPORTIONS[1],
+    }
+
+
+def test_gold_scores_take_at_most_ten_results():
+    rankings = _rankings([("piles", f"https://result-{i}", i, "2026-01-29")
+                          for i in range(1, 16)])
+
+    scores = gold_scores_for(rankings)
+    assert len(scores) == len(CLICK_PROPORTIONS)
+    assert scores["https://result-1"] == CLICK_PROPORTIONS[0]
+    assert "https://result-11" not in scores


### PR DESCRIPTION
Extracted from #359, which bundled this with the Wikipedia index cache. This half stands on its own and is not about Wikipedia: **index page writes are not safe, and weren't before either PR existed.**

Nothing here changes what a search returns.

## The bug

Changing a page is read → merge → write, with no atomicity of its own. `_write_page` copies ~4 KB into an mmap, and a reader catching it half-written gets a page that will not decompress. `_get_page_tuples` caught that `ZstdError` and returned `[]` — **indistinguishable from a page with no documents**. A writer then merged onto nothing and stored the result over everything else on that page. Permanent loss in a 400 GB index.

Demonstrated by zeroing 64 bytes mid-page:

```
before:                    5 documents
after partial overwrite:   0 documents   <- a writer would merge onto THIS
```

This is live, not hypothetical. `super_search._index_results` calls `index_results_against_query` from the request path (`super_search.py:486`), curation (`views.py:303`, `views.py:395`) and `POST /crawler/results` do in-request read-modify-writes, and `purge_documents` races the batch indexer. None of them held a lock.

## Fixes

**One way to change a page, already correct.** `TinyIndex.page(i)` owns the whole read-modify-write under a page lock, so no caller has to know locking exists:

```python
with index.page(page_index) as page:
    page.store(merge(page.documents))
```

It is `store()` rather than assigning to `documents` because a page holds a fixed number of bytes and drops the tail that does not fit — what you pass is not what is kept. `store()` now **returns how many actually fit** (`_get_page_data` already computed this and threw it away), so truncation is logged instead of silent:

```
Storing 38 of 42 documents for page 824, originally 39
```

That number is also the instrument for measuring eviction later, when deciding whether Wikipedia articles can go into the index as corpus content.

Converted every read-modify-write site: `index_pages`, `purge_documents`, `_save_to_index`, `_revert_curation` — three of which were racing and had no lock at all. `index_pages` now also counts only the documents actually stored.

**Open File Description locks, not `lockf`.** POSIX record locks are owned by the *process* and are dropped when *any* fd on the file is closed — and `index_results_against_query` opens and closes a read handle on the index on every store, so in a threaded worker the lock would be released mid-write. Confirmed by running the new test with `_set_page_lock` swapped for a plain `lockf`:

```
1. while holding the lock, nothing else touched:   blocked (lock held correctly)
2. after another fd on the same file was closed:   ACQUIRED (lock was NOT held)
```

`F_OFD_SETLKW` locks are owned by the open file description, survive that, and keep byte-range granularity so writers of different pages still don't contend.

**Corruption raises instead of looking empty.** `_get_page_tuples` now raises `PageError`. `retrieve()` catches it and returns `[]`, so search degrades exactly as before — one unreadable page costs one query the results for one term. Writers propagate and abort rather than wipe. This is what makes the *degraded* path safe: where locking is unsupported, a writer refuses instead of destroying.

Raising is **not** a substitute for the lock. Unserialised writers can interleave their memcpys into a page that is neither writer's image; the old `return []` repaired that on the next write at the cost of its contents, whereas raising would leave it permanently dead. Serialising writes is what stops that page existing.

**Locking degrades to unlocked rather than failing.** Every indexing path ran with no lock before this existed, so turning an environment's lack of support into a hard failure of all of them would be a worse regression than the race. Only an errno meaning this kernel or filesystem cannot do the lock at all (`EINVAL`/`ENOLCK`/`ENOSYS`/`ENOTSUP`) latches locking off for the process and logs the warning once; anything else is treated as a one-off and the lock is tried again next time.

## Second commit: one gold ranking per query

Separate and eval-only, but it belongs with this rather than with any Wikipedia work, because every harness that scores against the gold set is wrong until it lands.

`evaluate()` took a query's first ten rows of the rankings dataset, but the dataset holds repeat scrapes of the same query on different dates — **1,135 of the 5,969 test queries**, up to 16 dates each, stored as consecutive rows. So for those queries the "top ten" mixed dates and was not one ranking, and because the gold map is keyed by URL, a URL appearing in two scrapes kept the **worse** rank's weight.

`latest_ranking()` takes the most recent scrape in rank order; `gold_scores_for()` drops any remaining duplicate URL keeping the best rank. `evaluate_fallback` had its own copy of the same inline scoring and now goes through `gold_scores_for` too.

**Absolute NDCG measured before this change is not comparable with anything measured after it.**

`scripts/super_search_new_sources_eval.py` has a third copy of the inline scoring; left alone as a past one-off, but it has the same defect if it is ever re-run.

## Tests

`test/test_index_page_writes.py` — 7 tests: the lock is held across the read and the write and released after; an unrelated `close()` does not drop it (fails against `lockf`); a different page is not blocked; not calling `store()` writes nothing; `store()` reports truncation; `page()` refuses read mode; an unsupported-lock errno degrades to unlocked and latches, a one-off errno does not.

`test/test_rankeval_gold.py` — 4 tests on the gold ranking.

Full suite: **535 passed, 9 skipped**.

## Not in this PR

The Wikipedia caching half of #359 (`WIKI_INDEX_CACHE_ENABLED` and the gate) is deliberately left out — its own evaluation recommends against it. #357's general-indexing path is the piece worth pursuing there, on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
