### PR TITLE
fix: require app label in domain submission permission check

### DIFF
--- a/mwmbl/platform/api.py
+++ b/mwmbl/platform/api.py
@@ -236,7 +236,7 @@ def update_submission_status(request, submission_id: int, update_submission: Upd
     if submission is None:
         raise InvalidRequest("Submission not found.", status=404)
 
-    if not request.user.has_perm("change_domain_submission_status"):
+    if not request.user.has_perm("mwmbl.change_domain_submission_status"):
         raise InvalidRequest("You do not have permission to update this submission.")
 
     submission.status = update_submission.status

--- a/test/test_domain_submissions.py
+++ b/test/test_domain_submissions.py
@@ -4,10 +4,12 @@ domain, so that the submission list can reverse the "domain" URL for each one.
 """
 
 import importlib
+import json
 
 import pytest
 from allauth.account.models import EmailAddress
 from django.apps import apps as django_apps
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from ninja_jwt.tokens import RefreshToken
 
@@ -131,3 +133,30 @@ def test_api_rejects_invalid_domain(client, access_token):
 
     assert response.status_code == 400
     assert DomainSubmission.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_api_update_submission_status_grants_moderator_permission(client, verified_user, access_token):
+    """A user with the change_domain_submission_status permission can moderate via the API.
+
+    Regression test: the endpoint checked `has_perm("change_domain_submission_status")`
+    without the `mwmbl.` app label, which Django never matches (permissions are stored
+    as `app_label.codename`), so moderation always failed with 400.
+    """
+    submission = DomainSubmission.objects.create(name="example.com", submitted_by=verified_user)
+    permission = Permission.objects.get(
+        codename="change_domain_submission_status",
+        content_type__app_label="mwmbl",
+    )
+    verified_user.user_permissions.add(permission)
+
+    response = client.post(
+        f"/api/v1/platform/domain-submissions/ids/{submission.id}",
+        data=json.dumps({"status": "APPROVED", "rejection_reason": "", "rejection_detail": ""}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {access_token}",
+    )
+
+    assert response.status_code == 200
+    submission.refresh_from_db()
+    assert submission.status == "APPROVED"


### PR DESCRIPTION
The domain-submission status update endpoint (`POST /api/v1/platform/domain-submissions/ids/{id}`) always returns `400 "You do not have permission to update this submission."`, even for moderators and superusers.

This seems to be because `mwmbl/platform/api.py` checks:

   request.user.has_perm("change_domain_submission_status")

without the `mwmbl.` app label. Django stores and matches permissions as `app_label.codename` (e.g. `mwmbl.change_domain_submission_status`), so the bare codename never matches and `has_perm` is always `False`.

The web UI (`mwmbl/views.py`) already uses the correct prefixed form:

    request.user.has_perm("mwmbl.change_domain_submission_status")

so moderation works in the browser but not through the API.

The fix is presumably to add the `mwmbl.` prefix to the API check.

See draft test: `test_api_update_submission_status_grants_moderator_permission`, which grants the permission and asserts a moderator can approve a submission via the API. I cannot test the test without the test DB and environment, so it will need checking.