### PR TITLE
Never suggest a rejection that cannot be sent back

### DIFF
--- a/mwmbl/crawler/urls.py
+++ b/mwmbl/crawler/urls.py
@@ -102,11 +102,14 @@ class URLDatabase:
 
             if url.status in CRAWLED_STATUSES:
                 most_recent_urls.add(url.url)
-                # The URL has just been crawled (or failed): mark it as crawled now so
-                # it isn't immediately re-queued. Without this, a first-time crawl has
-                # found_date=None (it wasn't in any bloom filter before this batch), so
-                # queue_urls treats it as never-crawled and hands it out again.
-                found_date = most_recent_date
+                # The URL has just been crawled (or failed): mark it as crawled at the
+                # time of the crawl so it isn't immediately re-queued. Without this, a
+                # first-time crawl has found_date=None (it wasn't in any bloom filter
+                # before this batch), so queue_urls treats it as never-crawled and hands
+                # it out again. The bloom filters only record the month, which is too
+                # coarse to use here: on the 31st, the start of the month is already 30
+                # days ago, which is exactly the re-queue threshold.
+                found_date = url.timestamp
 
             new_urls.append(FoundURL(url.url, url.user_id_hash, url.status, url.timestamp, found_date))
         return new_urls

--- a/mwmbl/moderation/model.py
+++ b/mwmbl/moderation/model.py
@@ -37,7 +37,7 @@ from django.utils import timezone
 
 from mwmbl.models import ModerationModelArtifact
 from mwmbl.moderation.features import Featuriser, ModerationExample
-from mwmbl.moderation.rules import APPROVE, EvidenceItem, REJECT, decisive
+from mwmbl.moderation.rules import APPROVE, EvidenceItem, REJECT, decisive, implied_detail
 
 logger = getLogger(__name__)
 
@@ -62,11 +62,22 @@ MODEL_REFRESH_SECONDS = 60
 REASON_CONFIDENCE_CAP = {"OFFENSIVE": 0.6}
 
 
+# Reasons a suggestion cannot be handed to a moderator as a one-keystroke rejection. OTHER is
+# a real class - moderators reach for it often - but it is the one reason that says nothing on
+# its own, so the API refuses it without a written detail, and the model has no sentence to
+# offer. A blank reason is here for the same reason from the other end: it names nothing at
+# all. A check that implies OTHER is unaffected; its label is the detail (see implied_detail).
+UNUSABLE_MODEL_REASONS = frozenset({"", "OTHER"})
+
+
 @dataclass
 class Suggestion:
     action: str                       # APPROVE | REJECT | UNSURE
     confidence: float
     reason: str = ""
+    # What the submitter would be told. Non-empty whenever ``reason`` is OTHER and empty
+    # otherwise: the other reasons are their own explanation.
+    reason_detail: str = ""
     reason_confidence: float = 0.0
     reason_source: str = "model"      # model | derived | rule
     model_version: str = ""
@@ -144,6 +155,7 @@ def suggest(domain: str, page_texts: list[str], evidence_items: list[EvidenceIte
             action=decisive_item.implies_action,
             confidence=decisive_item.implies_confidence,
             reason=decisive_item.implies_reason,
+            reason_detail=implied_detail(decisive_item),
             reason_confidence=decisive_item.implies_confidence,
             reason_source="rule",
             model_version=model.version if model else "",
@@ -179,6 +191,15 @@ def suggest(domain: str, page_texts: list[str], evidence_items: list[EvidenceIte
         action, confidence = "UNSURE", 1.0 - abs(reject_probability - 0.5) * 2
 
     suggested_reason = reason if action == "REJECT" else ""
+    if action == "REJECT" and suggested_reason in UNUSABLE_MODEL_REASONS:
+        # A rejection we cannot give the reason for is not one to suggest. The reason head can
+        # land on OTHER - it is trained on decisions and moderators use it - but nothing here
+        # can write the detail that goes with it, and a "Reject - other" button that fails
+        # validation when pressed is worse than no suggestion. Back to the moderator, who is
+        # the only one who can say what is wrong.
+        return Suggestion(action="UNSURE", confidence=0.0, model_version=model.version,
+                          evidence=[item.to_dict() for item in evidence_items])
+
     return Suggestion(
         action=action,
         confidence=float(confidence),

--- a/mwmbl/moderation/rules.py
+++ b/mwmbl/moderation/rules.py
@@ -205,16 +205,57 @@ def decisive(items: list[EvidenceItem]) -> Optional[EvidenceItem]:
     return max(decisive_items, key=lambda item: item.implies_confidence)
 
 
+# What a check tells the *submitter*, where its label is the wrong sentence to send. A label
+# is written for the moderator deciding the case, so it may name the exception we caught or be
+# written from our side of the transaction; a detail is read by the person whose site was
+# rejected. Most labels serve both - "Homepage returns HTTP 404" is exactly what a submitter
+# needs to hear, and naming the domain a site redirects to tells them what to submit instead -
+# and the ones that do not are overridden here. Any new check that implies OTHER needs an
+# entry unless its label reads as a sentence to the submitter.
+#
+# Keyed on kind rather than carried on the item so that evidence stored before an entry was
+# written is covered too: crawl evidence is cached and a rescore reuses it, so a new field on
+# EvidenceItem would stay empty until the domain happened to be crawled again.
+SUBMITTER_DETAIL = {
+    "unreachable": "We could not fetch this site when we tried to crawl it.",
+    "do_not_crawl": "We don't index search engines or our own site.",
+}
+
+# "Some cached check implies OTHER", as a containment test the queue's SQL can run against the
+# stored evidence. It is the same question :func:`other_detail` answers, and the two have to
+# answer alike: the queue filters and orders thousands of rows on this without being able to
+# call the Python (see mwmbl.moderation.suggest.annotate_queue), and where they disagree it
+# hides rows that are on screen. Written down here so the pair stays visible from one place.
+IMPLIES_OTHER = [{"implies_action": "REJECT", "implies_reason": "OTHER"}]
+
+
 def implied_detail(item: EvidenceItem) -> str:
     """What a check's rejection tells the submitter, for a reason that says nothing on its own.
 
-    Only OTHER needs one - "spam" explains itself, "other" does not - and the check's label is
-    already that sentence: "Homepage returns HTTP 404" is exactly what was wrong. Every OTHER
-    a check implies is one of these, which is what lets the API refuse an OTHER rejection with
-    no detail (mwmbl.platform.schemas.RejectionFieldsMixin) without making the suggestion
+    Only OTHER needs one - "spam" explains itself, "other" does not - and for most checks the
+    label is already that sentence; SUBMITTER_DETAIL covers the rest. Every OTHER a check
+    implies has one of these, which is what lets the API refuse an OTHER rejection with no
+    detail (mwmbl.platform.schemas.RejectionFieldsMixin) without making the suggestion
     untakeable.
     """
-    return item.label if item.implies_reason == "OTHER" else ""
+    if item.implies_reason != "OTHER":
+        return ""
+    return SUBMITTER_DETAIL.get(item.kind, item.label)
+
+
+def other_detail(items: list[EvidenceItem]) -> str:
+    """The sentence behind an OTHER rejection a check decided, or "" when none did.
+
+    Deliberately not :func:`decisive`: the reason being explained is OTHER, so what explains it
+    is the strongest check implying OTHER, which need not be the strongest check in the list.
+    That is also the only form of the question SQL can ask of stored evidence - see
+    IMPLIES_OTHER - which is what lets the queue agree with what the moderator is shown.
+    """
+    implying_other = [item for item in items
+                      if item.implies_action == "REJECT" and item.implies_reason == "OTHER"]
+    if not implying_other:
+        return ""
+    return implied_detail(max(implying_other, key=lambda item: item.implies_confidence))
 
 
 def _tld(domain: str) -> str:

--- a/mwmbl/moderation/rules.py
+++ b/mwmbl/moderation/rules.py
@@ -205,6 +205,18 @@ def decisive(items: list[EvidenceItem]) -> Optional[EvidenceItem]:
     return max(decisive_items, key=lambda item: item.implies_confidence)
 
 
+def implied_detail(item: EvidenceItem) -> str:
+    """What a check's rejection tells the submitter, for a reason that says nothing on its own.
+
+    Only OTHER needs one - "spam" explains itself, "other" does not - and the check's label is
+    already that sentence: "Homepage returns HTTP 404" is exactly what was wrong. Every OTHER
+    a check implies is one of these, which is what lets the API refuse an OTHER rejection with
+    no detail (mwmbl.platform.schemas.RejectionFieldsMixin) without making the suggestion
+    untakeable.
+    """
+    return item.label if item.implies_reason == "OTHER" else ""
+
+
 def _tld(domain: str) -> str:
     labels = domain.lower().split(".")
     return labels[-1] if len(labels) > 1 else ""

--- a/mwmbl/moderation/suggest.py
+++ b/mwmbl/moderation/suggest.py
@@ -31,7 +31,7 @@ from django.db.models.functions import Coalesce, Substr
 from mwmbl.models import DomainEvidence, DomainSubmission, SearchResultVote
 from mwmbl.moderation import rules
 from mwmbl.moderation.evidence import page_texts
-from mwmbl.moderation.model import Suggestion, suggest
+from mwmbl.moderation.model import Suggestion, UNUSABLE_MODEL_REASONS, suggest
 
 logger = getLogger(__name__)
 
@@ -87,6 +87,7 @@ def suggestion_for(submission: DomainSubmission,
             action=decisive_live.implies_action,
             confidence=decisive_live.implies_confidence,
             reason=decisive_live.implies_reason,
+            reason_detail=rules.implied_detail(decisive_live),
             reason_confidence=decisive_live.implies_confidence,
             reason_source="rule",
             model_version=evidence.model_version,
@@ -105,10 +106,25 @@ def suggestion_for(submission: DomainSubmission,
         # (precision 0.88 on this same slice), so only the approve side is withheld.
         action, confidence = "UNSURE", 0.0
 
+    reason = evidence.suggested_reason if action == "REJECT" else ""
+    source = evidence.reason_source or "model"
+    # OTHER is the one reason that explains nothing on its own, and a decision may not carry
+    # it without the sentence the submitter is shown. When a check decided it that sentence is
+    # the check's own label, which is what reason_source == "rule" means here; when the model
+    # did there is none, and a suggestion no client can send back is not one to draw - so it
+    # goes to the moderator as UNSURE instead. model.suggest already stops storing those; this
+    # is for the rows stored before it did, and annotate_queue mirrors it so the queue filters
+    # and orders on what is actually drawn.
+    detail = (rules.implied_detail(cached_decisive)
+              if reason == "OTHER" and source == "rule" and cached_decisive is not None else "")
+    if action == "REJECT" and reason in UNUSABLE_MODEL_REASONS and not detail:
+        action, confidence, reason = "UNSURE", 0.0, ""
+
     return Suggestion(
         action=action,
         confidence=confidence,
-        reason=evidence.suggested_reason if action == "REJECT" else "",
+        reason=reason,
+        reason_detail=detail,
         # The reason's own confidence, not the rejection's. A model can be sure a domain
         # should go and barely have a view on why, and showing "SPAM (0.92)" when the reason
         # head scored 0.31 would present a guess as a finding.
@@ -177,11 +193,19 @@ def annotate_queue(submissions):
     # No cached check implies APPROVE - they are all reasons to reject - so a stored APPROVE
     # is always the model's, which is what the withheld-approval rule is about.
     withheld = scored & Q(evidence_action="APPROVE") & Q(submitter_decided=False)
+    # suggestion_for's other downgrade: a stored REJECT nobody can send back - one whose
+    # reason is OTHER with no check behind it, so there is no detail to send, or one carrying
+    # no reason at all. reason_source is again how we know a check produced it, and only then
+    # is the detail the check's own label.
+    unexplained = scored & Q(evidence_action="REJECT") & (
+        (Q(evidence_reason="OTHER") & ~Q(evidence_source="rule"))
+        | Q(evidence_reason="") | Q(evidence_reason__isnull=True))
 
     submissions = submissions.annotate(
         displayed_action=Case(
             When(prior_approval, then=Value("APPROVE")),
             When(prior_rejection, then=Value("REJECT")),
+            When(unexplained, then=Value("UNSURE")),
             When(withheld, then=Value("UNSURE")),
             When(scored, then=F("evidence_action")),
             default=Value(None),
@@ -190,6 +214,7 @@ def annotate_queue(submissions):
         displayed_confidence=Case(
             When(prior_approval | prior_rejection,
                  then=Value(rules.PRIOR_DECISION_CONFIDENCE)),
+            When(unexplained, then=Value(0.0)),
             When(withheld, then=Value(0.0)),
             When(scored, then=F("evidence_confidence")),
             default=Value(None),
@@ -197,7 +222,7 @@ def annotate_queue(submissions):
         ),
         displayed_reason=Case(
             When(prior_rejection, then=Value(rules.PRIOR_DECISION_REASON)),
-            When(scored & Q(evidence_action="REJECT") & ~prior_approval,
+            When(scored & Q(evidence_action="REJECT") & ~prior_approval & ~unexplained,
                  then=F("evidence_reason")),
             When(scored, then=Value("")),
             default=Value(None),

--- a/mwmbl/moderation/suggest.py
+++ b/mwmbl/moderation/suggest.py
@@ -109,14 +109,18 @@ def suggestion_for(submission: DomainSubmission,
     reason = evidence.suggested_reason if action == "REJECT" else ""
     source = evidence.reason_source or "model"
     # OTHER is the one reason that explains nothing on its own, and a decision may not carry
-    # it without the sentence the submitter is shown. When a check decided it that sentence is
-    # the check's own label, which is what reason_source == "rule" means here; when the model
+    # it without the sentence the submitter is shown. When a check decided it that sentence
+    # comes from the check, which is what reason_source == "rule" means here; when the model
     # did there is none, and a suggestion no client can send back is not one to draw - so it
     # goes to the moderator as UNSURE instead. model.suggest already stops storing those; this
     # is for the rows stored before it did, and annotate_queue mirrors it so the queue filters
     # and orders on what is actually drawn.
-    detail = (rules.implied_detail(cached_decisive)
-              if reason == "OTHER" and source == "rule" and cached_decisive is not None else "")
+    #
+    # The stored reason is not taken as proof that a check is still behind it: reason_source
+    # says one was when the row was written, and a check that stops being decisive - or stops
+    # implying OTHER - leaves rows saying "rule" with nothing left to explain them until the
+    # next rescore. rules.other_detail asks the evidence itself, as does the queue.
+    detail = rules.other_detail(cached) if reason == "OTHER" and source == "rule" else ""
     if action == "REJECT" and reason in UNUSABLE_MODEL_REASONS and not detail:
         action, confidence, reason = "UNSURE", 0.0, ""
 
@@ -179,6 +183,12 @@ def annotate_queue(submissions):
             name=OuterRef("name"), status="REJECTED")),
         submitter_decided=Exists(DomainSubmission.objects.filter(
             DECIDED, submitted_by_id=OuterRef("submitted_by_id"))),
+        # rules.other_detail, as far as SQL can ask it: is there a cached check implying
+        # OTHER, and so a sentence to send with an OTHER rejection. A containment test rather
+        # than a column comparison because it is a question about the evidence list, and
+        # Exists rather than a lookup on the annotation above so it reads as the join it is.
+        explained_by_a_check=Exists(DomainEvidence.objects.filter(
+            domain=OuterRef("name"), evidence__contains=rules.IMPLIES_OTHER)),
     )
 
     scored = Q(evidence_state=DomainEvidence.State.READY)
@@ -195,10 +205,12 @@ def annotate_queue(submissions):
     withheld = scored & Q(evidence_action="APPROVE") & Q(submitter_decided=False)
     # suggestion_for's other downgrade: a stored REJECT nobody can send back - one whose
     # reason is OTHER with no check behind it, so there is no detail to send, or one carrying
-    # no reason at all. reason_source is again how we know a check produced it, and only then
-    # is the detail the check's own label.
+    # no reason at all. Both halves of what suggestion_for asks: reason_source says a check
+    # produced the reason, and the evidence still has to contain the check that explains it -
+    # a stale row can say "rule" and have nothing implying OTHER left in its evidence.
+    explained = Q(evidence_source="rule") & Q(explained_by_a_check=True)
     unexplained = scored & Q(evidence_action="REJECT") & (
-        (Q(evidence_reason="OTHER") & ~Q(evidence_source="rule"))
+        (Q(evidence_reason="OTHER") & ~explained)
         | Q(evidence_reason="") | Q(evidence_reason__isnull=True))
 
     submissions = submissions.annotate(

--- a/mwmbl/platform/schemas.py
+++ b/mwmbl/platform/schemas.py
@@ -248,6 +248,14 @@ class SuggestionSchema(Schema):
     action: str = Field(description="`APPROVE`, `REJECT` or `UNSURE`.")
     confidence: float
     reason: str = Field(default="", description="Rejection reason; empty unless action is REJECT.")
+    reason_detail: str = Field(
+        default="",
+        description=(
+            "What the submitter would be told, to be sent back as `rejection_detail`. "
+            "Non-empty whenever `reason` is OTHER, which a decision may not carry without "
+            "one, and empty otherwise - the other reasons explain themselves."
+        ),
+    )
     reason_confidence: float = 0.0
     reason_source: str = Field(
         default="model",

--- a/test/test_domain_moderation.py
+++ b/test/test_domain_moderation.py
@@ -167,6 +167,31 @@ def test_a_check_that_implies_other_carries_the_detail_the_submitter_is_shown():
     assert suggestion.reason_detail == "Homepage returns HTTP 404"
 
 
+def test_a_check_written_for_the_moderator_tells_the_submitter_something_readable():
+    """A label is read by whoever is deciding the case and a detail by the person whose site
+    was rejected, so a label naming the exception we caught is not the sentence to send."""
+    items = rules.crawl_evidence(
+        "example.com", {"error": "AbortError", "pages": [], "signals": {}})
+    suggestion = suggest("example.com", [], items, model=mock.Mock(version="test"))
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "OTHER")
+    assert suggestion.reason_detail == "We could not fetch this site when we tried to crawl it."
+    # The moderator still gets the exception, in the evidence list where it belongs.
+    assert "Could not be fetched (AbortError)" in [
+        item["label"] for item in suggestion.evidence]
+
+
+def test_the_do_not_crawl_list_explains_itself_from_the_submitters_side():
+    """Its label is written from ours - "we don't crawl ourselves" - and is about our policy
+    rather than about the site the submitter sent."""
+    items = rules.crawl_evidence(
+        "google.com", {"http_status": 200, "pages": [], "signals": {}})
+    suggestion = suggest("google.com", [], items, model=mock.Mock(version="test"))
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "OTHER")
+    assert suggestion.reason_detail == "We don't index search engines or our own site."
+
+
 def test_a_reason_that_explains_itself_needs_no_detail():
     model = mock.Mock(version="test")
     model.predict.return_value = [(0.92, "SPAM", 0.8)]
@@ -1298,6 +1323,25 @@ def test_a_previous_rejection_of_the_same_domain_says_so_as_the_detail(submitter
     assert suggestion.reason_detail == "This domain has already been rejected before"
 
 
+@pytest.mark.django_db
+def test_a_rule_scored_other_with_no_check_left_behind_it_is_not_suggested(submitter):
+    """reason_source records that a check decided the reason when the row was written, not
+    that one still does. A check that stops being decisive - or stops implying OTHER - leaves
+    stored rows claiming "rule" with nothing left to explain them, and a rejection whose
+    detail cannot be written is one the API would refuse. So it goes back as UNSURE, and the
+    detail is read off the evidence rather than assumed from the column."""
+    demoted = rules.EvidenceItem(
+        "http_status", rules.REJECT, "Homepage returns HTTP 404").to_dict()
+    submission = DomainSubmission.objects.create(name="stale.example", submitted_by=submitter)
+    evidence = ready_evidence("stale.example", suggested_action="REJECT",
+                              suggested_reason="OTHER", confidence=0.9,
+                              reason_source="rule", evidence=[demoted])
+
+    suggestion = suggestion_for(submission, evidence)
+
+    assert (suggestion.action, suggestion.reason, suggestion.reason_detail) == ("UNSURE", "", "")
+
+
 # --------------------------------------------------------------------- queue parity
 
 @pytest.mark.django_db
@@ -1326,6 +1370,13 @@ def test_queue_display_matches_suggestion_for(submitter, established):
         # A reason the model cannot explain, so not shown as a suggestion at all.
         ("unexplained.example", submitter, {"suggested_action": "REJECT",
                                             "suggested_reason": "OTHER", "confidence": 0.93}),
+        # The same, from the other side: a row that says a check decided the reason, with
+        # nothing implying OTHER left in its evidence to write the detail from.
+        ("stale-rule.example", submitter,
+         {"suggested_action": "REJECT", "suggested_reason": "OTHER", "confidence": 0.93,
+          "reason_source": "rule",
+          "evidence": [rules.EvidenceItem(
+              "http_status", rules.REJECT, "Homepage returns HTTP 404").to_dict()]}),
         ("approved-before.example", submitter, {"suggested_action": "REJECT",
                                                 "suggested_reason": "SPAM"}),
         ("rejected-before.example", submitter, {}),

--- a/test/test_domain_moderation.py
+++ b/test/test_domain_moderation.py
@@ -89,7 +89,13 @@ def ready_evidence(domain, **overrides):
         "evidence": [],
         "model_version": "test-model",
     }
-    return DomainEvidence.objects.create(domain=domain, **(defaults | overrides))
+    fields = defaults | overrides
+    # A stored REJECT always names a reason - the reason head returns one of its classes, and
+    # every check that implies REJECT implies OTHER - and suggestion_for will not show one
+    # that does not. A fixture without a reason would be a row that cannot occur.
+    if fields["suggested_action"] == "REJECT" and not fields.get("suggested_reason"):
+        fields["suggested_reason"] = "SPAM"
+    return DomainEvidence.objects.create(domain=domain, **fields)
 
 
 # --------------------------------------------------------------------- rules
@@ -148,6 +154,40 @@ def test_a_deterministic_check_beats_the_model():
     assert suggestion.action == "REJECT"
     assert suggestion.reason_source == "rule"
     model.predict.assert_not_called()
+
+
+def test_a_check_that_implies_other_carries_the_detail_the_submitter_is_shown():
+    """OTHER is the one reason that explains nothing on its own, so a suggestion carrying it
+    has to carry the sentence too - the API refuses a decision that does not."""
+    items = rules.crawl_evidence(
+        "example.com", {"http_status": 404, "pages": [], "signals": {}})
+    suggestion = suggest("example.com", [], items, model=mock.Mock(version="test"))
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "OTHER")
+    assert suggestion.reason_detail == "Homepage returns HTTP 404"
+
+
+def test_a_reason_that_explains_itself_needs_no_detail():
+    model = mock.Mock(version="test")
+    model.predict.return_value = [(0.92, "SPAM", 0.8)]
+
+    suggestion = suggest("example.com", [], [], model=model)
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "SPAM")
+    assert suggestion.reason_detail == ""
+
+
+@pytest.mark.parametrize("reason", ["OTHER", ""])
+def test_the_model_does_not_suggest_a_rejection_it_cannot_give_the_reason_for(reason):
+    """The reason head is trained on decisions and moderators do use OTHER, but nothing here
+    can write the detail that has to go with it. A "Reject - other" button that fails
+    validation when pressed is worse than no suggestion, so it goes back as UNSURE."""
+    model = mock.Mock(version="test")
+    model.predict.return_value = [(0.92, reason, 0.8)]
+
+    suggestion = suggest("example.com", [], [], model=model)
+
+    assert (suggestion.action, suggestion.reason, suggestion.reason_detail) == ("UNSURE", "", "")
 
 
 def test_missing_model_degrades_to_unsure_not_to_a_default():
@@ -1214,6 +1254,50 @@ def test_the_reason_is_shown_with_its_own_confidence(submitter):
     assert suggestion.reason_source == "model"
 
 
+@pytest.mark.django_db
+def test_a_stored_unexplainable_rejection_is_not_shown_as_a_suggestion(submitter):
+    """Rows scored before the model stopped proposing a bare OTHER are still in the table, and
+    a moderator pressing the button on one gets a 422 rather than a decision."""
+    submission = DomainSubmission.objects.create(name="stale.example", submitted_by=submitter)
+    evidence = ready_evidence("stale.example", suggested_action="REJECT",
+                              suggested_reason="OTHER", confidence=0.93,
+                              reason_source="model")
+
+    suggestion = suggestion_for(submission, evidence)
+
+    assert (suggestion.action, suggestion.reason, suggestion.reason_detail) == ("UNSURE", "", "")
+
+
+@pytest.mark.django_db
+def test_a_rule_scored_rejection_keeps_its_reason_and_carries_the_detail(submitter):
+    a_404 = rules.EvidenceItem(
+        "http_status", rules.REJECT, "Homepage returns HTTP 404", implies_action="REJECT",
+        implies_reason="OTHER", implies_confidence=0.9).to_dict()
+    submission = DomainSubmission.objects.create(name="dead.example", submitted_by=submitter)
+    evidence = ready_evidence("dead.example", suggested_action="REJECT",
+                              suggested_reason="OTHER", confidence=0.9,
+                              reason_source="rule", evidence=[a_404])
+
+    suggestion = suggestion_for(submission, evidence)
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "OTHER")
+    assert suggestion.reason_detail == "Homepage returns HTTP 404"
+
+
+@pytest.mark.django_db
+def test_a_previous_rejection_of_the_same_domain_says_so_as_the_detail(submitter, established):
+    """The prior-decision check implies OTHER too, and its label is the sentence."""
+    DomainSubmission.objects.create(name="again.example", submitted_by=established,
+                                    status="REJECTED")
+    submission = DomainSubmission.objects.create(name="again.example", submitted_by=submitter)
+    evidence = ready_evidence("again.example")
+
+    suggestion = suggestion_for(submission, evidence)
+
+    assert (suggestion.action, suggestion.reason) == ("REJECT", "OTHER")
+    assert suggestion.reason_detail == "This domain has already been rejected before"
+
+
 # --------------------------------------------------------------------- queue parity
 
 @pytest.mark.django_db
@@ -1239,6 +1323,9 @@ def test_queue_display_matches_suggestion_for(submitter, established):
         ("reject.example", submitter, {"suggested_action": "REJECT",
                                        "suggested_reason": "SPAM", "confidence": 0.91}),
         ("unsure.example", submitter, {"suggested_action": "UNSURE", "confidence": 0.1}),
+        # A reason the model cannot explain, so not shown as a suggestion at all.
+        ("unexplained.example", submitter, {"suggested_action": "REJECT",
+                                            "suggested_reason": "OTHER", "confidence": 0.93}),
         ("approved-before.example", submitter, {"suggested_action": "REJECT",
                                                 "suggested_reason": "SPAM"}),
         ("rejected-before.example", submitter, {}),

--- a/test/test_url_database.py
+++ b/test/test_url_database.py
@@ -32,40 +32,37 @@ def clean_bloom_filters():
     _remove()
 
 
-def _current_month():
-    now = datetime.utcnow()
-    return datetime(now.year, now.month, 1)
-
-
 def test_crawled_url_marked_as_recently_crawled(clean_bloom_filters):
-    """A first-time crawled URL should come back with last_crawled set to now."""
+    """A first-time crawled URL should come back with last_crawled set to the crawl time."""
+    crawled_at = datetime.utcnow()
     found = FoundURL(
         url="https://example.com/page",
         user_id_hash="user",
         status=URLStatus.CRAWLED,
-        timestamp=datetime.utcnow(),
+        timestamp=crawled_at,
         last_crawled=None,
     )
     with URLDatabase() as url_db:
         new_urls = url_db.update_found_urls([found])
 
     assert len(new_urls) == 1
-    assert new_urls[0].last_crawled == _current_month()
+    assert new_urls[0].last_crawled == crawled_at
 
 
 def test_robots_denied_url_marked_as_recently_crawled(clean_bloom_filters):
     """A robots-denied URL must also be marked crawled so it isn't re-attempted."""
+    crawled_at = datetime.utcnow()
     found = FoundURL(
         url="https://example.com/blocked",
         user_id_hash="user",
         status=URLStatus.ERROR_ROBOTS_DENIED,
-        timestamp=datetime.utcnow(),
+        timestamp=crawled_at,
         last_crawled=None,
     )
     with URLDatabase() as url_db:
         new_urls = url_db.update_found_urls([found])
 
-    assert new_urls[0].last_crawled == _current_month()
+    assert new_urls[0].last_crawled == crawled_at
 
 
 def test_crawled_url_is_not_requeued(clean_bloom_filters):
@@ -95,6 +92,24 @@ def test_crawled_url_is_not_requeued(clean_bloom_filters):
 
     assert url_queue.get_domain_count("crawled.example") == 0
     assert url_queue.get_domain_count("discovered.example") == 1
+
+
+def test_crawl_date_is_the_crawl_time_not_the_start_of_the_month(clean_bloom_filters):
+    """The bloom filters only record the month a URL was crawled in. Reporting the start
+    of that month as the crawl date makes a URL crawled on the 31st look 30 days old -
+    exactly the age at which queue_urls hands it out again."""
+    crawled_at = datetime(2026, 8, 31, 12, 0, 0)
+    found = FoundURL(
+        url="https://end-of-month.example/page",
+        user_id_hash="user",
+        status=URLStatus.CRAWLED,
+        timestamp=crawled_at,
+        last_crawled=None,
+    )
+    with URLDatabase() as url_db:
+        new_urls = url_db.update_found_urls([found])
+
+    assert new_urls[0].last_crawled == crawled_at
 
 
 def test_url_queue_gives_its_curated_domains_to_the_default_blacklist():


### PR DESCRIPTION
## The bug

Pressing the suggested-action button on a `Reject — other` suggestion in the moderation screen fails:

> Value error, rejection_detail is required when rejection_reason is OTHER - it is what the submitter is shown

The validator is right — that detail is the only thing a rejected submitter learns. The suggestion was the problem: every decision is checked for it, but `SuggestionSchema` carried only `reason`, so no client had anything to put in the detail.

Five places suggest `REJECT`/`OTHER`: the do-not-crawl list, an unreachable domain, a non-2xx homepage, an off-domain redirect, and a domain rejected before — plus the model's reason head.

## The fix

**The checks have the sentence already.** "Homepage returns HTTP 404" is exactly what was wrong, and better text than a moderator would type, so a suggestion now carries the decisive check's label as `reason_detail` (`rules.implied_detail`). Only `OTHER` gets one; the other reasons explain themselves.

**The model does not.** The reason head is trained on real decisions and moderators do reach for `OTHER`, so it can propose one out of nothing. A rejection we cannot give the reason for is not one to suggest, so those go back to the moderator as `UNSURE`.

The invariant, end to end: a suggested rejection always names a reason, and an `OTHER` always carries the detail that explains it.

`suggestion_for` makes the same call on rows scored before this, so no rescore is needed to stop the error, and `annotate_queue` mirrors it in SQL so the queue still filters and orders on what is actually drawn (`test_queue_display_matches_suggestion_for` covers the new branch).

## Notes

- No migration. `reason_detail` is derived from evidence already stored on the row.
- `ready_evidence` in the tests was building stored `REJECT` rows with no reason at all — a row that cannot occur — so it now fills one in.
- Still accepted, deliberately untouched here: a decision with status `REJECTED` and a blank `rejection_reason`. Tightening that would also hit the older `/submissions` PATCH path, which is wider than this bug.
- The front-end half is mwmbl/front-end#54.

## Testing

Full suite: 708 passed, 9 skipped. New tests cover the detail travelling with a check-implied `OTHER`, the `UNSURE` downgrade for a model-proposed one, a stale stored row, and the prior-rejection case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zKyYeuU462hKmXEdBW3zt