### PR TITLE
Record the crawl time as a naive UTC datetime

### DIFF
--- a/mwmbl/crawler/urls.py
+++ b/mwmbl/crawler/urls.py
@@ -2,7 +2,7 @@
 Database storing info on URLs
 """
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from logging import getLogger
 from pathlib import Path
@@ -108,8 +108,11 @@ class URLDatabase:
                 # before this batch), so queue_urls treats it as never-crawled and hands
                 # it out again. The bloom filters only record the month, which is too
                 # coarse to use here: on the 31st, the start of the month is already 30
-                # days ago, which is exactly the re-queue threshold.
-                found_date = url.timestamp
+                # days ago, which is exactly the re-queue threshold. Crawl timestamps
+                # are timezone-aware, while last_crawled is naive UTC everywhere else
+                # (the bloom filter dates, and the comparison in queue_urls), so convert
+                # it here.
+                found_date = url.timestamp.astimezone(timezone.utc).replace(tzinfo=None)
 
             new_urls.append(FoundURL(url.url, url.user_id_hash, url.status, url.timestamp, found_date))
         return new_urls

--- a/test/test_url_database.py
+++ b/test/test_url_database.py
@@ -10,13 +10,14 @@ as never-crawled.
 """
 import glob
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import fakeredis
 import pytest
 
 from mwmbl.crawler.urls import URLDatabase, FoundURL, URLStatus
 from mwmbl.indexer.blacklist_providers import StaticBlacklistProvider
+from mwmbl.indexer.update_urls import get_datetime_from_timestamp
 from mwmbl.redis_url_queue import RedisURLQueue
 
 
@@ -110,6 +111,30 @@ def test_crawl_date_is_the_crawl_time_not_the_start_of_the_month(clean_bloom_fil
         new_urls = url_db.update_found_urls([found])
 
     assert new_urls[0].last_crawled == crawled_at
+
+
+def test_crawl_date_from_a_real_batch_timestamp_is_naive(clean_bloom_filters):
+    """Batch timestamps are timezone-aware, but last_crawled is compared against a naive
+    datetime.utcnow() in queue_urls, which raises if the two are mixed."""
+    crawled_at = get_datetime_from_timestamp(datetime.now(timezone.utc).timestamp())
+    found = FoundURL(
+        url="https://aware.example/page",
+        user_id_hash="user",
+        status=URLStatus.CRAWLED,
+        timestamp=crawled_at,
+        last_crawled=None,
+    )
+    with URLDatabase() as url_db:
+        new_urls = url_db.update_found_urls([found])
+
+    assert new_urls[0].last_crawled.tzinfo is None
+    assert new_urls[0].last_crawled == crawled_at.replace(tzinfo=None)
+
+    redis = fakeredis.FakeRedis(decode_responses=True)
+    url_queue = RedisURLQueue(redis, lambda: set(), StaticBlacklistProvider(set()))
+    url_queue.queue_urls(new_urls)
+
+    assert url_queue.get_domain_count("aware.example") == 0
 
 
 def test_url_queue_gives_its_curated_domains_to_the_default_blacklist():


### PR DESCRIPTION
The crawler has been dying on every batch since ab0d0c2:

```
ERROR:mwmbl.crawl:Error processing batch: 'can't subtract offset-naive and offset-aware datetimes'
  File "mwmbl/redis_url_queue.py", line 70, in queue_urls
    time_since_crawled = (datetime.utcnow() - url.last_crawled
TypeError: can't subtract offset-naive and offset-aware datetimes
```

`update_found_urls` started using the batch's crawl timestamp as `last_crawled`, but `get_datetime_from_timestamp` builds those timezone-aware, while `last_crawled` is naive UTC everywhere else — the bloom filter month dates, and the `datetime.utcnow()` it is subtracted from in `queue_urls`.

Convert to naive UTC where the crawl time is recorded.

The existing tests all passed against the broken code because they built `FoundURL`s with naive `datetime.utcnow()` rather than the aware value production actually supplies. The new test goes through `get_datetime_from_timestamp` and on into `queue_urls`; it reproduces the `TypeError` on the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iym3BCWhwxdNhSmp3GmQa