### PR TITLE
Give the issue automation a working tool set

### DIFF
--- a/.github/claude/plan-issue.md
+++ b/.github/claude/plan-issue.md
@@ -11,6 +11,11 @@ file. **Write no application code in this run.**
 - `gh issue view $N --comments` — read the whole thread, including what people have
   ruled out.
 - Read `AGENTS.md` for the project's commands and conventions.
+- The project is **not installed** in this job — there is no virtualenv, no database and
+  no Rust build, so `uv`, `make` and `pytest` will not work. Plan from reading the code.
+  Where the issue quotes a command whose output you would need (a lint count, a test
+  result), say in the plan that the implementing run must confirm it, rather than
+  guessing a number or trying to install anything.
 - Explore the code the issue touches before deciding anything. Search for functions,
   models and helpers that already do part of the job: a plan that reuses what exists is
   worth far more than one that invents a parallel implementation.

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -11,7 +11,9 @@ name: Claude issue automation
 # docs/plans/README.md for the plan format.
 #
 # Note that an issue only enters these queues once someone with write access labels it,
-# so untriaged issue text never reaches a run.
+# so untriaged issue text never reaches a run. That gate is what makes an unrestricted
+# Bash tool below reasonable: the runner is ephemeral, but it holds an API key and a
+# repository token, so nothing unreviewed should ever reach it.
 
 on:
   schedule:
@@ -81,6 +83,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          display_report: true
           prompt: |
             Follow the instructions in .github/claude/plan-issue.md exactly.
 
@@ -90,7 +93,7 @@ jobs:
           claude_args: |
             --model claude-opus-5
             --max-turns 60
-            --allowedTools "Read,Glob,Grep,Edit,Write,TodoWrite,Bash(git:*),Bash(gh:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(mkdir:*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,TodoWrite,Bash"
 
   implement:
     needs: select
@@ -150,6 +153,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: mwmbl.settings_test
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          display_report: true
           prompt: |
             Follow the instructions in .github/claude/implement-issue.md exactly.
 
@@ -159,4 +163,4 @@ jobs:
           claude_args: |
             --model claude-opus-5
             --max-turns 100
-            --allowedTools "Read,Glob,Grep,Edit,Write,TodoWrite,Bash(git:*),Bash(gh:*),Bash(make:*),Bash(uv:*),Bash(python:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(mkdir:*),Bash(sed:*),Bash(diff:*)"
+            --allowedTools "Read,Glob,Grep,Edit,Write,TodoWrite,Bash"


### PR DESCRIPTION
The first real run of the hourly automation (issue #371, "ready to plan") failed: five permission denials, no plan, no pull request.

The prefix-by-prefix `Bash(...)` allowlist cannot anticipate what exploring an unfamiliar part of the codebase needs, and a gap costs a wasted run rather than a degraded one, so this allows `Bash` outright in both jobs. An issue only reaches these queues once someone with write access labels it, which is the gate that makes that reasonable — the runner is ephemeral but holds an API key and a repository token.

The plan job has no virtualenv, database or Rust build, so its instructions now say so. Issue #371 asks for a `uv run ruff --select DTZ` count, which that job can never produce; it should plan from reading the code and leave the count for the implementing run to confirm.

`display_report: true` on both steps puts Claude's own report in the step summary, so the next failure is readable without `gh run view --log`.

Confirmed working from that run: the Claude GitHub App is installed and issues an app token, the selector picked issue #371 correctly, and the failure left no branch or pull request behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6
