### PR TITLE
Let the planning run measure the codebase instead of estimating it

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -1,0 +1,29 @@
+name: Set up the project
+description: >-
+  Install python, uv, the Rust toolchain and the project itself, so that make check and
+  uv run pytest work. These are the same steps as the test job in ci.yml; a job that uses
+  this still has to provide the postgres service and DATABASE_URL itself.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11.12'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Install dependencies
+      run: uv sync --group dev
+      shell: bash
+    - name: Install project with maturin
+      run: uv run maturin develop
+      shell: bash
+    - name: Create test directories and files
+      run: mkdir -p /tmp/test_mwmbl_data
+      shell: bash

--- a/.github/claude/plan-issue.md
+++ b/.github/claude/plan-issue.md
@@ -11,11 +11,11 @@ file. **Write no application code in this run.**
 - `gh issue view $N --comments` — read the whole thread, including what people have
   ruled out.
 - Read `AGENTS.md` for the project's commands and conventions.
-- The project is **not installed** in this job — there is no virtualenv, no database and
-  no Rust build, so `uv`, `make` and `pytest` will not work. Plan from reading the code.
-  Where the issue quotes a command whose output you would need (a lint count, a test
-  result), say in the plan that the implementing run must confirm it, rather than
-  guessing a number or trying to install anything.
+- The project is installed and a test database is running, so you can check facts rather
+  than estimate them: run the linter, run `uv run pytest`, run whatever command the issue
+  quotes. A count you measured is worth far more in a plan than one you guessed, and it
+  is what makes the per-section line estimates trustworthy. Put the numbers you measured
+  in the plan, and say how you got them.
 - Explore the code the issue touches before deciding anything. Search for functions,
   models and helpers that already do part of the job: a plan that reuses what exists is
   worth far more than one that invents a parallel implementation.

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -60,7 +60,7 @@ jobs:
     needs: select
     if: needs.select.outputs.has_plan == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.select.outputs.plan_matrix) }}
@@ -70,17 +70,40 @@ jobs:
       group: claude-issue-${{ matrix.item.issue }}
       cancel-in-progress: false
     name: "plan #${{ matrix.item.issue }}"
+
+    # A plan is only as good as the facts behind it, so give the planning run the same
+    # environment as the implementing one: it can then count lint violations, run the
+    # suite and check what actually breaks, rather than estimating from a read.
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_mwmbl
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       # Full history: the instructions diff the branch against main.
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up the project
+        uses: ./.github/actions/setup-project
       # No github_token input: the action then authenticates as the Claude GitHub App,
       # which sets GH_TOKEN and the git credentials for Claude and, unlike the workflow
       # token, lets CI run on the pull requests it pushes.
       - name: Write the plan
         uses: anthropics/claude-code-action@v1
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_mwmbl
+          DJANGO_SETTINGS_MODULE: mwmbl.settings_test
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           display_report: true
@@ -108,8 +131,8 @@ jobs:
       cancel-in-progress: false
     name: "implement #${{ matrix.item.issue }}"
 
-    # The environment below is the test job of ci.yml: Claude has to get the same gates
-    # green before it opens a pull request, so it needs the same database and toolchain.
+    # Claude has to get the same gates green before it opens a pull request as CI runs
+    # afterwards, so it needs the same database and toolchain as ci.yml's test job.
     services:
       postgres:
         image: postgres:15
@@ -129,23 +152,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11.12'
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install dependencies
-        run: uv sync --group dev
-      - name: Install project with maturin
-        run: uv run maturin develop
-      - name: Create test directories and files
-        run: mkdir -p /tmp/test_mwmbl_data
+      - name: Set up the project
+        uses: ./.github/actions/setup-project
       - name: Implement the next part
         uses: anthropics/claude-code-action@v1
         env:


### PR DESCRIPTION
The `plan` job had no environment: no virtualenv, no database, no Rust build. That is exactly what tripped the first run — issue #371's whole premise is a `uv run ruff --select DTZ` count that the planning job could not produce.

This gives the plan job the same environment as the implement job, so it can run the linter and the test suite and put **measured** numbers into the plan. The per-section line estimates are only trustworthy if they come from something the planner actually looked at.

- `plan` gains the postgres service, the toolchain, and `DATABASE_URL` / `DJANGO_SETTINGS_MODULE`.
- The setup is now identical in both jobs, so it moves into `.github/actions/setup-project` (a local composite action) rather than being written out twice.
- `plan-issue.md` asks for measured counts and for how they were obtained.
- The plan job's timeout goes from 30 to 45 minutes to cover the extra install.

Cost: roughly 1–2 minutes of extra runner time per planning run, plus the Rust build. Planning runs are rare — one per issue — so this is cheap next to a plan built on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6
