### PR TITLE
Order the Claude work queues by priority label

### DIFF
--- a/.github/scripts/select-claude-work.sh
+++ b/.github/scripts/select-claude-work.sh
@@ -14,6 +14,10 @@
 # is what enforces "one PR at a time per issue": the next part cannot start until the
 # previous one is merged (or closed).
 #
+# Each queue is ordered by the "priority: high|medium|low" label before it is truncated to
+# CLAUDE_MAX_ITEMS, so raising an issue's priority moves it up the queue. Issues without a
+# priority label sort last, behind "priority: low".
+#
 # Writes plan_matrix/implement_matrix (and has_plan/has_implement) to $GITHUB_OUTPUT, or
 # to stdout when that is unset, so the selection can be dry-run locally with:
 #
@@ -53,6 +57,18 @@ has_pending_section() {
     ((total > done_count))
 }
 
+# Sort key for a queue: lower comes first. Unlabelled issues sort behind "priority: low",
+# so adding the label can only ever promote an issue, never demote it below the backlog.
+priority_rank() {
+    case ",$1," in
+        *,"priority: high",*) echo 0 ;;
+        *,"priority: medium",*) echo 1 ;;
+        *,"priority: low",*) echo 2 ;;
+        *) echo 3 ;;
+    esac
+}
+
+# Each entry is "<rank>\t<item json>", so the arrays can be sorted before the max_items cut.
 plan_items=()
 implement_items=()
 
@@ -66,7 +82,9 @@ while IFS=$'\t' read -r number title labels; do
     fi
 
     plan_file=$(plan_file_for "$number")
-    item=$(jq -nc --argjson issue "$number" --arg title "$title" '{issue: $issue, title: $title}')
+    item=$(printf '%s\t%s' \
+        "$(priority_rank "$labels")" \
+        "$(jq -nc --argjson issue "$number" --arg title "$title" '{issue: $issue, title: $title}')")
 
     if [[ -n $plan_file ]]; then
         if has_pending_section "$plan_file"; then
@@ -80,6 +98,18 @@ while IFS=$'\t' read -r number title labels; do
         plan_items+=("$item")
     fi
 done < <(jq -r '.[] | [.number, .title, ([.labels[].name] | join(","))] | @tsv' <<<"$open_issues")
+
+# Highest priority first, and a stable sort within a rank so that equal-priority issues
+# keep the order gh listed them in.
+by_priority() {
+    if (($# == 0)); then
+        return
+    fi
+    printf '%s\n' "$@" | sort -s -n -k1,1 | cut -f2-
+}
+
+mapfile -t plan_items < <(by_priority ${plan_items+"${plan_items[@]}"})
+mapfile -t implement_items < <(by_priority ${implement_items+"${implement_items[@]}"})
 
 # Finishing work already under way beats starting more of it, so implement items take
 # the budget first.


### PR DESCRIPTION
Follow-up to the Sentry triage that produced #373, #374 and #375, and the piece that makes the new `priority:` labels do something rather than just decorate.

## Problem

`select-claude-work.sh` truncates each queue to `CLAUDE_MAX_ITEMS` in whatever order `gh issue list` returned, which is newest-first. With 63 open issues and a budget of 3 per hourly run, "which issue Claude works on next" was effectively arbitrary — and a newly filed high-priority bug would sit behind whatever happened to be created after it.

## Change

Rank each queued item by its `priority: high|medium|low` label and sort before the cut.

- **Stable sort**, so equal-priority issues keep the order `gh` listed them in.
- **Unlabelled issues rank behind `priority: low`** (rank 3). The label can only ever promote an issue, never push it below the unlabelled backlog — so the 24 open issues carrying no labels at all need no triage pass to keep behaving exactly as they do today.
- Both queues are sorted; implement items still take the budget before plan items, as before.

## Labels

Created on the repo alongside this:

| Label | Meaning |
| --- | --- |
| `priority: high` | Do next |
| `priority: medium` | Wanted, scheduled |
| `priority: low` | Wanted, not scheduled |

These live as labels rather than as a Project field specifically so this script can read them — a Project custom field would need a separate `read:project` token and a GraphQL call, and is not filterable from the repo Issues tab either.

## Testing

- `bash -n` clean.
- Dry-run against the live repo (`GH_TOKEN=$(gh auth token) bash .github/scripts/select-claude-work.sh`) produces the same selection as before, as expected while only one issue is queued.
- The ranking and sort were exercised directly with synthetic items, by sourcing `priority_rank` and `by_priority` out of the script so the test cannot drift from the implementation: correct ordering across all four ranks, stable within a rank, and no error on an empty queue under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3sCnW1CiosQrbeATTEqTF
