### PR TITLE
Authenticate the issue automation with a subscription token

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -10,6 +10,11 @@ name: Claude issue automation
 # after the previous one is merged. See .github/claude/*.md for what Claude is told, and
 # docs/plans/README.md for the plan format.
 #
+# Both jobs authenticate with the CLAUDE_CODE_OAUTH_TOKEN secret, a one-year token from
+# `claude setup-token`. It runs against a Claude subscription rather than API credit, so
+# these runs share the usage windows of an interactive session, and the token has to be
+# regenerated when it expires.
+#
 # Note that an issue only enters these queues once someone with write access labels it,
 # so untriaged issue text never reaches a run. That gate is what makes an unrestricted
 # Bash tool below reasonable: the runner is ephemeral, but it holds an API key and a
@@ -105,7 +110,10 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_mwmbl
           DJANGO_SETTINGS_MODULE: mwmbl.settings_test
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # A subscription token from `claude setup-token`, not a Console API key: these
+          # runs draw on the same subscription as an interactive session, so they share
+          # its usage windows.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           display_report: true
           prompt: |
             Follow the instructions in .github/claude/plan-issue.md exactly.
@@ -160,7 +168,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_mwmbl
           DJANGO_SETTINGS_MODULE: mwmbl.settings_test
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           display_report: true
           prompt: |
             Follow the instructions in .github/claude/implement-issue.md exactly.


### PR DESCRIPTION
The workflow was passing the repository's `ANTHROPIC_API_KEY` — a Console key billing against API credit. The first run spent $0.97 of it; the next failed on its first request in 375 ms having billed nothing (`total_cost_usd: 0`, `modelUsage: {}`, `num_turns: 1`). The balance is gone.

Mwmbl's Claude access is a subscription, not API credit, so both jobs now take `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` instead. Runs then draw on the subscription and share the usage windows of an interactive session.

Both jobs stay on `claude-opus-5`.

## Before merging

The `CLAUDE_CODE_OAUTH_TOKEN` secret has to exist:

```sh
claude setup-token                      # opens a browser, prints a one-year token
gh secret set CLAUDE_CODE_OAUTH_TOKEN   # paste it at the prompt
```

The token lasts a year, so it will need regenerating around September 2027 — the workflow header notes this. The now-empty `ANTHROPIC_API_KEY` secret is no longer read by this workflow and can be deleted if nothing else uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6
