### PR TITLE
Base the crawler image on bookworm instead of EOL bullseye

### DIFF
--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -1,4 +1,4 @@
-FROM python:3.11.12-bullseye AS base
+FROM python:3.11.12-bookworm AS base
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \


### PR DESCRIPTION
## Problem

The crawler image build has been failing on `main` ([run 34211730097](https://github.com/mwmbl/mwmbl/actions/runs/34211730097)):

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 12h 32min 40s).
ERROR: process "/bin/sh -c apt-get update && apt-get install -y clang libclang-dev patchelf curl && ..."
   did not complete successfully: exit code: 100
```

Debian 11 (bullseye) has reached end of life and its `bullseye-security` Release file expired about 12 hours before that run. apt refuses expired repository metadata, so the builder stage's `apt-get install` fails. Nothing in the triggering commit was at fault — this was a time bomb.

## Fix

`Dockerfile.crawler` was the last place still on bullseye; the main `Dockerfile` already uses `python:3.11.12-bookworm`. This moves the crawler to the same base.

## Verification

Built the full multi-stage image locally and confirmed `import mwmbl_rank` works in the final image, so the maturin / xgboost / `patchelf --set-rpath` chain still resolves against bookworm's newer glibc.

## Follow-up (not in this PR)

`Dockerfile:1` still uses `node:hydrogen-bullseye` for the front-end stage. It only runs `npm install && npm run build` — no apt — so it isn't failing, but it's on the same EOL base and Node 18 (hydrogen) is itself EOL. Worth bumping separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6