### PR TITLE
Add a dry_run option to the crawler results endpoint

### DIFF
--- a/mwmbl/crawler/app.py
+++ b/mwmbl/crawler/app.py
@@ -284,10 +284,12 @@ def _register_routes(r: Router | NinjaAPI, batch_cache: BatchCache, queued_batch
             "Requires a valid crawl-scoped API key passed in the `X-API-Key` request header "
             "(preferred) or in the request body `api_key` field (deprecated). "
             "Results are indexed immediately and also stored in object storage. "
-            "This endpoint is intended for trusted crawlers."
+            "This endpoint is intended for trusted crawlers.\n\n"
+            "Pass `?dry_run=true` to authenticate and validate the request without indexing "
+            "or storing anything. Useful for exercising the submission path from CI."
         ),
     )
-    def post_results(request, results: Results):
+    def post_results(request, results: Results, dry_run: bool = False):
         # Prefer X-API-Key header; fall back to deprecated body field
         raw_key = request.headers.get("X-API-Key") or results.api_key
         if not raw_key:
@@ -322,6 +324,9 @@ def _register_routes(r: Router | NinjaAPI, batch_cache: BatchCache, queued_batch
                     last_crawled=last_crawled,
                 )
             )
+
+        if dry_run:
+            return {"status": "dry-run", "url": None}
 
         index_path = f"{settings.DATA_PATH}/{settings.INDEX_NAME}"
         index_documents(documents, index_path)

--- a/mwmbl/crawler/batch.py
+++ b/mwmbl/crawler/batch.py
@@ -215,11 +215,14 @@ class PostResultsResponse(Schema):
     """Response returned after successfully submitting results for indexing."""
 
     status: str = Field(
-        description="Always `ok` on success.",
+        description="`ok` when the results were indexed, `dry-run` when they were only validated.",
         example="ok",
     )
-    url: str = Field(
-        description="Public URL of the uploaded results file in object storage.",
+    url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Public URL of the uploaded results file in object storage. Null for a dry run, which uploads nothing."
+        ),
         example="https://storage.mwmbl.org/1/v1/2024-01-01/results/username/00001__abcd1234.json.gz",
     )
 

--- a/test/test_search_api_key.py
+++ b/test/test_search_api_key.py
@@ -568,6 +568,55 @@ def test_post_results_uses_submitted_last_crawled(api_client, crawl_api_key):
 
 
 @pytest.mark.django_db
+def test_post_results_dry_run_validates_without_indexing(api_client, crawl_api_key):
+    """A dry run authenticates and validates the payload but must not touch the index."""
+    past_ts = int(datetime.now(stdlib_timezone.utc).timestamp()) - 60
+
+    with (
+        patch("mwmbl.crawler.app.index_documents") as index_documents,
+        patch("mwmbl.crawler.app.upload_object") as upload_object,
+        patch("mwmbl.crawler.app.stats_manager") as stats_manager,
+    ):
+        response = api_client.post(
+            "/api/v1/crawler/results?dry_run=true",
+            content_type="application/json",
+            data={"results": [{"url": "https://example.com", "title": "t", "extract": "e", "last_crawled": past_ts}]},
+            **api_key_header(crawl_api_key.raw_key),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "dry-run", "url": None}
+    index_documents.assert_not_called()
+    upload_object.assert_not_called()
+    stats_manager.record_results.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_post_results_dry_run_still_requires_a_valid_key(api_client, search_api_key):
+    """dry_run must not become an unauthenticated endpoint."""
+    response = api_client.post(
+        "/api/v1/crawler/results?dry_run=true",
+        content_type="application/json",
+        data={"results": []},
+        **api_key_header(search_api_key.raw_key),
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_post_results_dry_run_still_rejects_future_last_crawled(api_client, crawl_api_key):
+    """Validation a real submission would fail on has to fail the dry run too, or CI proves nothing."""
+    future_ts = int(datetime.now(stdlib_timezone.utc).timestamp()) + 3600
+    response = api_client.post(
+        "/api/v1/crawler/results?dry_run=true",
+        content_type="application/json",
+        data={"results": [{"url": "https://example.com", "title": "t", "extract": "e", "last_crawled": future_ts}]},
+        **api_key_header(crawl_api_key.raw_key),
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
 def test_post_results_sets_user_id(api_client, crawl_api_key, verified_user):
     captured = []
 


### PR DESCRIPTION
## Why

We want to run the crawler as a CI smoke test (see #380 for the failure that prompted this). To be worth anything the smoke test has to cover result submission — but a CI run must not write into the production index.

A `dry_run` option gives us the whole submission path with none of the side effects.

## What

`POST /api/v1/crawler/results?dry_run=true`:

- authenticates the API key and checks it carries the `crawl` scope
- validates every result in the payload, including the future-`last_crawled` check
- returns `{"status": "dry-run", "url": null}`
- does **not** call `index_documents`, `upload_object`, or `stats_manager.record_results`

The early return is placed after validation and after `Document` construction, so anything a real submission would reject is rejected here too. A dry run that returns 200 means the real call would have been accepted.

`PostResultsResponse.url` becomes `Optional[str]`, since a dry run uploads nothing and so has no object-storage URL to report.

## Verification

Three new tests in `test/test_search_api_key.py`:

- `test_post_results_dry_run_validates_without_indexing` — asserts 200 + the dry-run body, and that all three side-effecting calls were never made
- `test_post_results_dry_run_still_requires_a_valid_key` — a search-scoped key still gets 401, so `dry_run` isn't an auth bypass
- `test_post_results_dry_run_still_rejects_future_last_crawled` — still 400, so the dry run can't pass where a real one would fail

`make check` and the `post_results` + `test_openapi.py` suites pass locally (11 and 5 passed).

## Follow-up

This is the first of three. Next: CI options on the crawler itself (bounded batch size, domain allowlist, one-shot mode), then the workflow that uses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6