### PR TITLE
Build and smoke-run the crawler image in CI

### DIFF
--- a/.github/workflows/crawler-smoke.yml
+++ b/.github/workflows/crawler-smoke.yml
@@ -23,6 +23,13 @@ on:
     - cron: "0 5 * * 1"  # 05:00 UTC every Monday
   workflow_dispatch:
 
+# A push to a pull request supersedes the run already going for it. Without this each
+# force-push leaves a full image build running for a commit that no longer exists.
+# Runs on main and on the schedule are never cancelled - those are the ones we act on.
+concurrency:
+  group: crawler-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/crawler-smoke.yml
+++ b/.github/workflows/crawler-smoke.yml
@@ -1,0 +1,93 @@
+name: Crawler smoke
+
+# Builds the crawler image and runs it, which nothing else in CI does. Two failures came
+# from that gap: the image stopped building when Debian bullseye went end of life (#380),
+# and before that the container crash-looped on an import that reached Django too early
+# (#360). Both were only noticed after they had landed on main.
+#
+# The run is bounded so it can go on every pull request: one batch of at most ten URLs,
+# from two domains we chose, submitting nothing to the production index. `--once` makes
+# the crawler do a single crawl and indexing pass and exit with a status - the normal
+# loops catch every exception and restart, so a container that is failing every pass
+# still looks alive.
+#
+# The schedule matters as much as the pull request trigger: the bullseye expiry broke the
+# build with no commit to blame, and only a scheduled run catches that kind of breakage
+# before someone's unrelated push does.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 5 * * 1"  # 05:00 UTC every Monday
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      redis:
+        image: redis:alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Load the image into the local daemon instead of pushing it: this job only needs to
+      # run it. Single platform, because the run is what we are testing and the multi-arch
+      # build already happens on the publish workflow.
+      - name: Build the crawler image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.crawler
+          push: false
+          load: true
+          tags: mwmbl/crawler:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Pull requests from a fork get no secrets, so there is no key to submit with and the
+      # run has to skip submission. Everything else - the crawl, the local index, the sync
+      # against the remote index - still runs. With a key we go one step further and post
+      # the results as a dry run, which authenticates and validates them server-side
+      # without indexing anything.
+      - name: Choose a submit mode
+        id: submit
+        env:
+          MWMBL_API_KEY: ${{ secrets.MWMBL_API_KEY }}
+        run: |
+          if [ -n "$MWMBL_API_KEY" ]; then
+            echo "mode=dry-run" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=off" >> "$GITHUB_OUTPUT"
+            echo "::notice::No MWMBL_API_KEY available (expected on pull requests from a fork) - skipping result submission."
+          fi
+
+      - name: Crawl one batch and index it
+        env:
+          MWMBL_API_KEY: ${{ secrets.MWMBL_API_KEY }}
+        run: |
+          docker run --rm --network host \
+            -e MWMBL_API_KEY="$MWMBL_API_KEY" \
+            -e MWMBL_CONTACT_INFO=ci@mwmbl.org \
+            -e CRAWL_SUBMIT_MODE=${{ steps.submit.outputs.mode }} \
+            -e CRAWL_BATCH_SIZE=10 \
+            -e CRAWL_ALLOWED_DOMAINS=mwmbl.org,en.wikipedia.org \
+            -e CRAWLER_WORKERS=1 \
+            -e REDIS_URL=redis://localhost:6379 \
+            -e PYTHONUNBUFFERED=1 \
+            mwmbl/crawler:smoke /venv/bin/mwmbl-crawl --once


### PR DESCRIPTION
## Why

Last of three. Nothing in CI builds or runs the crawler image, and two failures came out of that gap:

- **#380** — the image stopped building when Debian bullseye went end of life
- **#360** — the image built fine but the container crash-looped on an import that reached Django too early

Both were only noticed after they had landed on `main`, because `docker-publish.yml` triggers on `push: main` and never on a pull request.

## What

`.github/workflows/crawler-smoke.yml`: build `Dockerfile.crawler`, then actually run it against a redis service container.

The run is bounded by the options from #384 so it can go on every PR — one batch of at most ten URLs, from `mwmbl.org` and `en.wikipedia.org`, with `--once` so the crawler does a single crawl and indexing pass and exits with a status.

That last part is what makes the check meaningful rather than decorative. I measured this on the current image before writing any of it: it reported `status=running` for 90 seconds while *every* indexing pass failed with a 401. A liveness check would have gone green on a completely broken crawler.

**Submission depends on whether a key is available**, decided in a step rather than assumed:

| Where | Key | `CRAWL_SUBMIT_MODE` | Covers |
|---|---|---|---|
| PR from a fork | none | `off` | build, crawl, local index, remote sync |
| PR from a branch here, `main`, schedule | secret | `dry-run` | the above + authenticated submission, validated server-side, indexing nothing |

**The schedule is not decoration either.** The bullseye expiry broke the build with no commit to blame — it simply came around. No PR-triggered check can catch that class; only a scheduled run notices before someone's unrelated push does.

The standalone-import step in `ci.yml` stays. It's subsumed by this, but costs seconds rather than a Docker build, so it fails faster.

## Verification

Ran the exact container invocation locally against a port-published redis, host networking, as the workflow does it:

```
exit 0
Returning URLs: ['https://en.wikipedia.org/', 'http://en.wikipedia.org/wiki/Pork', 'https://mwmbl.org']
Processing batch of 3 URLs
Indexed, top terms to sync: [('com', 52), ('page', 51), ...]
no tracebacks
```

Failure paths were checked too: unreachable redis exits 1, an invalid `CRAWL_SUBMIT_MODE` exits 1 at import.

## Before merging

Needs **#380** (the image does not build on `main` today), **#381** (the `dry_run` parameter) and **#384** (the crawler options) merged first. Add `MWMBL_API_KEY` as a repository secret — a crawl-scoped key; without it every run silently falls back to `CRAWL_SUBMIT_MODE=off` and prints a notice.

## Optionally, later: covering fork PRs with a key

Fork PRs get no secrets, and an environment's required-reviewer gate does not change that — the rule applies to the `pull_request` event regardless. The combination that does work is `pull_request_target` plus an environment with required reviewers: the job waits in "waiting" until an approver clicks through, and only then are that environment's secrets released. Since 2025-12-08 `pull_request_target` always takes the workflow file from the default branch, so a fork cannot edit this workflow to exfiltrate the key.

I have deliberately **not** wired that up here. If the named environment does not already exist with protection rules configured, GitHub creates it unprotected on first use — and the job would then run fork-authored code with the key and no gate. That environment has to be created with required reviewers *first*, as a separate deliberate step.

## Unrelated bug spotted along the way

`mwmbl/crawl.py:222` reads `new_high_score = max_local_score < min_remote_score`, which submits results only when they score *worse* than the worst existing remote item — the inverse of the docstring at line 190. Higher is better in `score_result`. Not touched here, and the dry-run mode means CI is unaffected by it either way; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d5yFTgAmvwunErsJ29eC6