### PR TITLE
Drive the issue automation off events instead of a cron

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -1,6 +1,6 @@
 name: Claude issue automation
 
-# Turns triaged issues into pull requests, hourly.
+# Turns triaged issues into pull requests, as soon as they are ready.
 #
 #   "ready to plan"  ->  a PR adding docs/plans/issue-<N>-<slug>.md and nothing else
 #   "ready to code"  ->  a PR implementing the issue (or a plan, if it is too big for one)
@@ -21,15 +21,26 @@ name: Claude issue automation
 # repository token, so nothing unreviewed should ever reach it.
 
 on:
-  schedule:
-    # Hourly, off the hour: runs at :00 queue behind everyone else's.
-    - cron: "17 * * * *"
+  # Both queues are pure functions of repository state, so the triggers are the events
+  # that can change that state: a triage label going on an issue, and anything landing
+  # on main (a merged plan, or a merged part that frees the issue for the next one).
+  issues:
+    types: [labeled]
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       issue:
         description: "Act on this issue number only (blank = every eligible issue)"
         required: false
         type: string
+  schedule:
+    # A safety net, not the cadence. GitHub dispatches schedule events off a shared,
+    # best-effort queue and drops them under load: every scheduled run this repository
+    # has had arrived between 40 minutes and 6 hours late, so an hourly cron fired
+    # exactly never. The triggers above are what keep the queue moving; this is only
+    # here to pick up work whose event was missed.
+    - cron: "17 * * * *"
 
 permissions:
   contents: write
@@ -45,6 +56,17 @@ env:
 jobs:
   select:
     runs-on: ubuntu-latest
+    # Only the two triage labels start work; every other label edit is noise.
+    if: >-
+      github.event_name != 'issues'
+      || github.event.label.name == 'ready to plan'
+      || github.event.label.name == 'ready to code'
+    # A run of merges should produce one selection rather than one per push. A superseded
+    # selection has not started any work yet, so cancelling it costs nothing; a targeted
+    # workflow_dispatch gets its own group so a push cannot cancel it.
+    concurrency:
+      group: claude-issue-select-${{ inputs.issue || 'all' }}
+      cancel-in-progress: true
     outputs:
       plan_matrix: ${{ steps.select.outputs.plan_matrix }}
       implement_matrix: ${{ steps.select.outputs.implement_matrix }}


### PR DESCRIPTION
The `Claude issue automation` workflow's hourly schedule has never fired. It is `active`, it is on the default branch, and manual `workflow_dispatch` runs work — but the API shows zero `schedule` events since it landed.

GitHub dispatches `schedule` events off a shared, best-effort queue and drops them under load, and this repository sits well behind that queue. The weekly Super Search smoke run (`0 6 * * 1`) tells the story:

| scheduled | started | late by |
|---|---|---|
| 06:00 | 11:34 | 5h34m |
| 06:00 | 12:40 | 6h40m |
| 06:00 | 06:52 | 52m |
| 06:00 | 07:27 | 1h27m |
| 06:00 | 09:39 | 3h39m |

An hourly slot is always still backed up when the next one comes round, so it never runs.

## What this does

Both queues are pure functions of repository state, so this triggers on the events that change that state rather than on a clock:

- `issues: types: [labeled]` — labelling an issue `ready to plan` / `ready to code` starts a run at once. The `select` job's `if` filters out every other label edit.
- `push: branches: [main]` — a merged plan, or a merged part that marks its `## PR <k>:` section `(Done)`, starts the next part immediately instead of waiting up to an hour.
- The cron stays as a safety net for work whose event was missed.
- `select` gets a `claude-issue-select-*` concurrency group with `cancel-in-progress: true`, so a run of merges produces one selection rather than one per push. A superseded `select` has started no Claude jobs yet, so cancelling it costs nothing, and the per-issue groups on `plan`/`implement` are untouched — nothing in flight can be cancelled. A targeted `workflow_dispatch` gets its own group so a push cannot cancel it.

`select-claude-work.sh` is unchanged: it already derives both queues from issue, pull request and plan state, and on an `issues` event the checkout lands on the default branch, so `docs/plans/` is read from `main` as before.

## Checks

- The two label strings match the repository's labels exactly.
- YAML parses; pre-commit's `check yaml` passes.
- The real test is the first label or merge after this lands — I can watch for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu64HFHuXyTuVhgLLBrrEj