### PR TITLE
Set the run log paths where the runner context exists

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -171,14 +171,20 @@ jobs:
           - 5432:5432
 
     env:
-      # Outside the checkout, both of these. The review and finalise steps run git with an
-      # unrestricted Bash tool and are asked to commit; a file sitting untracked in the
-      # working tree is one `git add -A` away from being part of the pull request.
-      CLAUDE_RUN_LOG: ${{ runner.temp }}/claude-runs.jsonl
-      CLAUDE_SUMMARY_DIR: ${{ runner.temp }}/claude-summaries
       ISSUE_NUMBER: ${{ matrix.item.issue }}
 
     steps:
+      # Both of these live outside the checkout. The review and finalise steps run git with
+      # an unrestricted Bash tool and are asked to commit; a file sitting untracked in the
+      # working tree is one `git add -A` away from being part of the pull request.
+      #
+      # They are set here rather than in the job's `env` above because the `runner` context
+      # does not exist at job level: a `${{ runner.temp }}` there is not an empty string but
+      # a workflow that fails to validate, which is what broke every run from 2f0de72 on.
+      - name: Point the run log outside the checkout
+        run: |
+          echo "CLAUDE_RUN_LOG=$RUNNER_TEMP/claude-runs.jsonl" >>"$GITHUB_ENV"
+          echo "CLAUDE_SUMMARY_DIR=$RUNNER_TEMP/claude-summaries" >>"$GITHUB_ENV"
       # Full history: every step diffs the branch against main, and the step below
       # compares HEAD against the branch's own remote tip.
       #


### PR DESCRIPTION
Every run of the Claude issue automation since 2f0de72 failed before starting a single job — [run 34277767566](https://github.com/mwmbl/mwmbl/actions/runs/34277767566) and the two branch pushes before it all have zero jobs and only the "This run likely failed because of a workflow file issue" annotation.

The `work` job set two paths from `${{ runner.temp }}` in its job-level `env:`. That block only gets `github`, `needs`, `strategy`, `matrix`, `vars`, `secrets` and `inputs` — `runner` is not among them, so this is not an empty path at runtime but a workflow that fails validation outright.

It also explains why those runs are labelled `push` after 141ae84 removed the push trigger: with the file unparseable GitHub cannot evaluate `on:` at all, so it fails the push that changed the file regardless.

`$RUNNER_TEMP` is an ordinary environment variable inside a step, so both paths are now set from one first step via `$GITHUB_ENV`. `ISSUE_NUMBER: ${{ matrix.item.issue }}` stays in the job `env` (matrix is allowed there), and the three step-level `${{ runner.temp }}` uses are untouched — those were always valid.

I scanned every workflow in `.github/workflows/` for the same class of mistake (`runner`/`steps`/`job`/`env` contexts used in job-level `env`, `if`, `name`, `runs-on` or `concurrency`); nothing else hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSkXRdrL8WTu1fFnfX95cR