### PR TITLE
Retry the native build, which fails on a reset download

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -18,11 +18,18 @@ runs:
         cache-dependency-glob: "uv.lock"
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+    # Both of these build the Rust extension, and its xgboost_lib-sys dependency's build
+    # script downloads a prebuilt libxgboost.so from github.com every time it runs. That
+    # download is not retried and its failure is a panic, so a single reset connection
+    # ends the whole job before Claude has started - which is what killed run 34278357092
+    # ("Connection reset by peer" fetching libxgboost.so). Retrying the build is enough:
+    # the download is repeated from scratch each attempt, and everything cargo already
+    # compiled is still in target/, so a second attempt costs little.
     - name: Install dependencies
-      run: uv sync --group dev
+      run: .github/scripts/retry.sh uv sync --group dev
       shell: bash
     - name: Install project with maturin
-      run: uv run maturin develop
+      run: .github/scripts/retry.sh uv run maturin develop
       shell: bash
     - name: Create test directories and files
       run: mkdir -p /tmp/test_mwmbl_data

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Run a command, and run it again if it fails.
+#
+# For build steps whose failures are dominated by the network rather than by the code:
+# see the comment in .github/actions/setup-project/action.yml for the one that made this
+# necessary. A command that fails because the tree is broken fails every attempt, so the
+# only thing this costs in that case is the time of the extra attempts.
+
+set -euo pipefail
+
+attempts=${RETRY_ATTEMPTS:-3}
+delay=${RETRY_DELAY:-15}
+
+for attempt in $(seq 1 "$attempts"); do
+  status=0
+  "$@" || status=$?
+  if [[ $status -eq 0 ]]; then
+    exit 0
+  fi
+  if [[ $attempt -eq $attempts ]]; then
+    echo "::error::'$*' failed $attempts times; giving up."
+    exit "$status"
+  fi
+  echo "::warning::'$*' failed (attempt $attempt of $attempts, exit $status); retrying in ${delay}s."
+  sleep "$delay"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,19 @@ jobs:
 
       #----------------------------------------------
       # install dependencies
+      #
+      # Retried for the same reason as in .github/actions/setup-project: building the
+      # Rust extension downloads a prebuilt libxgboost.so, and a reset connection there
+      # panics the build script rather than being retried by it.
       #----------------------------------------------
       - name: Install dependencies
-        run: uv sync --group dev
+        run: .github/scripts/retry.sh uv sync --group dev
       #----------------------------------------------
       # build and install the project with maturin
       # (compiles the Rust extension and installs the package)
       #----------------------------------------------
       - name: Install project with maturin
-        run: uv run maturin develop
+        run: .github/scripts/retry.sh uv run maturin develop
       #----------------------------------------------
       #              run test suite
       #----------------------------------------------


### PR DESCRIPTION
Building the Rust extension pulls `xgboost_lib-sys`, whose build script downloads a prebuilt `libxgboost.so` from github.com on every build and `unwrap()`s the result rather than retrying it. One reset connection there panics the build and ends the whole job — which is what failed [run 34278357092](https://github.com/mwmbl/mwmbl/actions/runs/34278357092/job/102236909610#step:5:912), during `uv sync --group dev`, before the automation had done any work at all:

```
error: failed to run custom build command for `xgboost_lib-sys v3.0.4`
panicked at .../xgboost_lib-sys-3.0.4/build.rs:59:103:
called `Result::unwrap()` on an `Err` value: reqwest::Error { ...
  url: ".../rust-xgboost/raw/refs/tags/v3.0.1/xgboost-sys/lib//linux_amd64/libxgboost.so",
  ConnectionReset, message: "Connection reset by peer" }
```

CI passed on the same commit a minute earlier and no other recent failure looks like this, so it is a flake rather than a broken tree.

`.github/scripts/retry.sh` runs a command up to `RETRY_ATTEMPTS` (default 3) times, 15s apart, annotating each failed attempt. The two steps that build the extension go through it, both in the composite setup action the issue automation uses and in ci.yml's test job, which builds the same way — a flake there would otherwise turn CI red and spend three Opus steps on a network error via the `workflow_run` trigger.

A retry costs little: cargo keeps what it already compiled in `target/`, and only the download is repeated. A build failing because the tree is broken still fails every attempt and still exits with its own status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSkXRdrL8WTu1fFnfX95cR