### PR TITLE
Stop shipping a CUDA stack in the crawler image

### DIFF
--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -1,12 +1,6 @@
-FROM python:3.11.12-bookworm AS base
-
-ENV PYTHONFAULTHANDLER=1 \
-    PYTHONHASHSEED=random \
-    PYTHONUNBUFFERED=1
+FROM python:3.11.12-bookworm AS builder
 
 WORKDIR /app
-
-FROM base AS builder
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
@@ -42,7 +36,22 @@ RUN SODIR=/venv/lib/python3.11/site-packages/mwmbl_rank && \
     cp /app/mwmbl_rank/target/release/deps/libxgboost.so "$SODIR/" && \
     patchelf --set-rpath '$ORIGIN' "$SODIR"/mwmbl_rank.cpython-311-*.so
 
-FROM base AS final
+# The final stage ships to crawler volunteers, so it runs on the slim base: it needs
+# no compilers, git or headers, only the interpreter and the prebuilt /venv. That is
+# ~330MB less to download than the full python:3.11.12-bookworm image.
+FROM python:3.11.12-slim-bookworm AS final
+
+ENV PYTHONFAULTHANDLER=1 \
+    PYTHONHASHSEED=random \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# libgomp1 is the OpenMP runtime that the bundled libxgboost.so links against. The
+# full base image happens to carry it; the slim one does not.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libgomp1 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy only the required /venv directory from the builder image that contains mwmbl and its dependencies
 COPY --from=builder /venv /venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ dependencies = [
     "numpy==1.23.2",
     "objgraph>=3.6.1",
     "psutil>=6.0.0",
-    "xgboost>=2.1.0",
+    # xgboost's Linux wheels bundle a CUDA-enabled libxgboost.so and pull in
+    # nvidia-nccl-cu12, together ~600MB installed. Since 3.1.3 that applies to
+    # arm64 as well, which is what doubled the crawler image. Nothing here trains
+    # or predicts on a GPU - serving goes through the Rust extension's own
+    # libxgboost - so take the CPU-only build wherever it is published (Linux and
+    # Windows). The macOS wheel has no CUDA in it to begin with.
+    "xgboost-cpu>=2.1.0; sys_platform != 'darwin'",
+    "xgboost>=2.1.0; sys_platform == 'darwin'",
     "pydistinct>=0.6.4",
     "django-ninja-jwt>=5.3.3",
     "sentry-sdk>=2.13.0",
@@ -85,6 +92,13 @@ dev = [
     "ty>=0.0.78",
     "pre-commit>=4.6.2",
 ]
+
+[tool.uv]
+# pydistinct declares xgboost as a dependency but never imports it - its four modules
+# use numpy, scipy and statsmodels only. On Linux that stale requirement is enough to
+# drag the CUDA wheel and nvidia-nccl-cu12 back in, undoing the xgboost-cpu switch
+# above, so confine every xgboost request to macOS where the wheel is CPU-only anyway.
+override-dependencies = ["xgboost>=2.1.0; sys_platform == 'darwin'"]
 
 [tool.maturin]
 python-source = "."

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.11.*"
 
+[manifest]
+overrides = [{ name = "xgboost", marker = "sys_platform == 'darwin'", specifier = ">=2.1.0" }]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -837,7 +840,8 @@ dependencies = [
     { name = "tokenizers" },
     { name = "uvicorn" },
     { name = "wasmtime" },
-    { name = "xgboost" },
+    { name = "xgboost", marker = "sys_platform == 'darwin'" },
+    { name = "xgboost-cpu", marker = "sys_platform != 'darwin'" },
     { name = "zstandard" },
 ]
 
@@ -917,7 +921,8 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.16.0" },
     { name = "warcio", marker = "extra == 'indexer'", specifier = "==1.7.4" },
     { name = "wasmtime", specifier = ">=24.0.0" },
-    { name = "xgboost", specifier = ">=2.1.0" },
+    { name = "xgboost", marker = "sys_platform == 'darwin'", specifier = ">=2.1.0" },
+    { name = "xgboost-cpu", marker = "sys_platform != 'darwin'", specifier = ">=2.1.0" },
     { name = "zstandard", specifier = ">=0.16.0" },
 ]
 provides-extras = ["indexer"]
@@ -959,15 +964,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/4b/4ee1067b542fbff6acc64ca937e7920f40706921ed5e3ea53f46a1d15670/numpy-1.23.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac987b35df8c2a2eab495ee206658117e9ce867acf3ccb376a19e83070e69418", size = 17032409, upload-time = "2022-08-14T00:17:33.693Z" },
     { url = "https://files.pythonhosted.org/packages/49/c9/fa9cbbf6f9a1d870bf8e89d462dc46831728d02e6bcee477ed5bda6fced5/numpy-1.23.2-cp311-cp311-win32.whl", hash = "sha256:d98addfd3c8728ee8b2c49126f3c44c703e2b005d4a95998e2167af176a9e722", size = 12182428, upload-time = "2022-08-14T00:17:52.704Z" },
     { url = "https://files.pythonhosted.org/packages/f5/85/3b622959cc922874aee72fc5c9db87c3e3779c7404d0370faab80450a3f3/numpy-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ecb818231afe5f0f568c81f12ce50f2b828ff2b27487520d85eb44c71313b9e", size = 14630485, upload-time = "2022-08-14T00:18:15.379Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.29.7"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/cc/f48875411d1f176bce58e6343fd5d4131fc1db5420719ff25944bdc006c6/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:0cf032ee22b560447daf0456108a75e32bd74a4de6c6b64725637a359fa48cd8", size = 293563644, upload-time = "2026-03-03T05:34:46.166Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1e/9e366f36efc550f07d6737f199e3f6bffafdf28795d007f10a77dd274f5c/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:ecd0a012051abc20c1aa87328841efa8cade3ced65803046e38c2f03c0891fea", size = 293633942, upload-time = "2026-03-03T05:37:05.625Z" },
 ]
 
 [[package]]
@@ -1272,7 +1268,7 @@ dependencies = [
     { name = "numpy" },
     { name = "scipy" },
     { name = "statsmodels" },
-    { name = "xgboost" },
+    { name = "xgboost", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/db/3611006a3e72c2249a8fe66dfd2ef88bb9cb33b81bb195ed0fc1329fdd23/pydistinct-0.6.4.tar.gz", hash = "sha256:ccd66ce4cdeefc20debe9e40a529de1d51f7175247a3216148d64fd29d3fe693", size = 17096, upload-time = "2020-03-25T09:56:43.774Z" }
 wheels = [
@@ -1913,16 +1909,28 @@ version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
     { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
-    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
-    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "xgboost-cpu"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/89437af879315468860b0ef566647113102be898f28fc094b667166d6fe3/xgboost_cpu-3.2.0.tar.gz", hash = "sha256:27f1b1642815c23ee73065d5702ad24c1c1649d63e4e2f498dc7e6a961012281", size = 1264279, upload-time = "2026-02-10T10:34:51.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/3d/b996f80a52e6a4f7c5ed1851bfc1f4e8dae2dc7670ef8b0ca283b3006e3b/xgboost_cpu-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:896b9e2bc52ec0921edf92ddd1cebedf47032e94992b7aca0293524d380ce6e9", size = 5213428, upload-time = "2026-02-10T10:32:30.609Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1d/c05e982a2220e1a208f5ca8792265cefb43e860e8796bff3245cc94fc2ce/xgboost_cpu-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9c10b1653e1a689bf4094a328144cf3633c9be0e5217a76fbdc2fde6abcb2950", size = 5595924, upload-time = "2026-02-10T10:33:04.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/3981ecd0f11992203254bb5a94002a6b07ada12d0e660f01f6e742d15795/xgboost_cpu-3.2.0-py3-none-win_amd64.whl", hash = "sha256:bfe72e42f73d2c6870a1a8b75324d56ae86ddad9abd4dccefeb36f2c3196dd48", size = 2149094, upload-time = "2026-02-10T10:34:25.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0a/595eff7c5603f6ba49b7ce1501bafed8ce3039ed2dcaadd61748d1be9ecd/xgboost_cpu-3.2.0-py3-none-win_arm64.whl", hash = "sha256:78fc90c09d7a1a1603ebb3a1c341689096797160c35a996d6a096b03e20caab4", size = 2087619, upload-time = "2026-02-10T10:33:32.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A crawler volunteer reported the image roughly doubling, from ~600MB to over 1.1GB. It was not the Debian upgrade. Moving from bullseye to bookworm added 27MB. Two thirds of the image is a GPU toolchain nothing here uses.

## What actually grew

xgboost's Linux wheels bundle a CUDA-enabled `libxgboost.so` and depend on `nvidia-nccl-cu12`. Installed, that is 228MB and 384MB. Serving never touches either: ranking goes through the Rust extension, which links its own libxgboost, and the Python package is imported only by training and evaluation code. There is no `tree_method` or `device="cuda"` anywhere in the repo.

## When, and why arm64 took the hit

| Date | Change | arm64 wheels |
|---|---|---|
| mid-2025 | xgboost 2.1.4, no nccl on arm | 129 MB |
| 2026-01-10 | xgboost 3.1.3 ships a CUDA aarch64 wheel (5MB to 115MB) and drops `platform_machine != "aarch64"` from its nccl marker | still capped out |
| 2026-04-08 | 6b07d56 rewrites `xgboost = "^2.1.0"` as `xgboost>=2.1.0`, dropping the `<3.0.0` bound | 566 MB |

Both Dockerfiles run `uv pip install .`, which resolves against PyPI and ignores `uv.lock`, so the image tracks whatever xgboost is newest. Once the cap went, 3.x came in on the next push to main.

That +437MB on arm64 maps to the ~1.04GB arm64 image on Docker Hub today, and the row above it to the ~600MB the volunteer remembers. On amd64 the change was roughly neutral, because nccl had been there since the image was first published. Most volunteers run arm64.

## The changes

**Switch to `xgboost-cpu`** wherever it is published. Same version, same API, same import name, 18MB installed instead of 612MB. `pydistinct` declares xgboost but never imports it, and on Linux that stale requirement alone pulls the CUDA wheel back in, so a `[tool.uv]` override confines xgboost to macOS.

**Base the crawler's final stage on `slim-bookworm`.** That stage only copies a prebuilt venv, so the compilers, headers and version-control tools in the full image are dead weight, ~330MB of it. It needs `libgomp1`, the OpenMP runtime the bundled libxgboost links against, which the full base happened to carry.

| | Before | After |
|---|---|---|
| On disk | 2.15 GB | 800 MB |
| To pull | ~1.1 GB | under 300 MB |

The xgboost change helps the main image by the same amount.

## Verification

Built the image and ran the CI smoke crawl against it: exit 0 after crawling and indexing a batch, no tracebacks. Every native extension imports and the Rust pipeline still returns all 50 features. No `nvidia*` left in site-packages. The full suite passes on xgboost-cpu: 779 passed, 9 skipped.

arm64 is not verified locally, since there is no emulation on this machine. `libgomp1` and the `xgboost-cpu` aarch64 wheel both exist, and the publish workflow builds that platform.

## Follow-up, not in this PR

The root cause of the drift is that the Docker builds resolve fresh instead of installing from `uv.lock`. Worth fixing separately so a volunteer's image size cannot move on an upstream release again. Note that today's unpinned build would take nccl 2.31.2 at 342MB, larger still than the 2.29.7 in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fUG7ZCe18pe192FWUV5U6